### PR TITLE
remove global database provider and add common/ dir unit tests

### DIFF
--- a/common/api_auth.go
+++ b/common/api_auth.go
@@ -73,7 +73,7 @@ func ValidateToken(token string) (*AuthToken, error) {
 
 var UserType CrudRecord
 
-func GetToken(c *gin.Context) (*AuthToken, error) {
+func GetToken(c *gin.Context, db DatabaseProvider) (*AuthToken, error) {
 	token := c.Request.Header.Get(AuthTokenHeaderValue)
 	if token == "" {
 		return nil, nil
@@ -84,8 +84,8 @@ func GetToken(c *gin.Context) (*AuthToken, error) {
 	}
 
 	userId := valid.UserId
-	if UserType != nil {
-		err := ExistsById(c.Request.Context(), GlobalDatabaseProvider, UserType, userId)
+	if db != nil && UserType != nil {
+		err := ExistsById(c.Request.Context(), db, UserType, userId)
 		if err != nil {
 			return nil, err
 		}

--- a/common/api_auth_test.go
+++ b/common/api_auth_test.go
@@ -55,3 +55,77 @@ func TestCreateToken(t *testing.T) {
 
 	fmt.Printf("%+v\n", at)
 }
+
+func TestValidateTokenTampered(t *testing.T) {
+	deleteKeyPair(t)
+	err := GenerateJwtKeyPairIfNotExists()
+	if err != nil {
+		t.Fatalf("GenerateJwtKeyPairIfNotExists failed: %v", err)
+	}
+
+	userId := NewRecordId()
+	token, err := GenerateToken(userId)
+	if err != nil {
+		t.Fatalf("GenerateToken failed: %v", err)
+	}
+
+	// Tamper with the token
+	tampered := token[:len(token)-10] + "0000000000"
+	_, err = ValidateToken(tampered)
+	if err == nil {
+		t.Fatal("expected error for tampered token")
+	}
+}
+
+func TestValidateTokenMalformed(t *testing.T) {
+	_, err := ValidateToken("not-a-valid-token")
+	if err == nil {
+		t.Fatal("expected error for malformed token")
+	}
+}
+
+func TestValidateTokenEmpty(t *testing.T) {
+	_, err := ValidateToken("")
+	if err == nil {
+		t.Fatal("expected error for empty token")
+	}
+}
+
+func TestGenerateTokenDifferentUsers(t *testing.T) {
+	deleteKeyPair(t)
+	err := GenerateJwtKeyPairIfNotExists()
+	if err != nil {
+		t.Fatalf("GenerateJwtKeyPairIfNotExists failed: %v", err)
+	}
+
+	userId1 := NewRecordId()
+	userId2 := NewRecordId()
+
+	token1, err := GenerateToken(userId1)
+	if err != nil {
+		t.Fatalf("GenerateToken for user1 failed: %v", err)
+	}
+	token2, err := GenerateToken(userId2)
+	if err != nil {
+		t.Fatalf("GenerateToken for user2 failed: %v", err)
+	}
+
+	at1, err := ValidateToken(token1)
+	if err != nil {
+		t.Fatalf("ValidateToken for token1 failed: %v", err)
+	}
+	at2, err := ValidateToken(token2)
+	if err != nil {
+		t.Fatalf("ValidateToken for token2 failed: %v", err)
+	}
+
+	if at1.UserId != userId1 {
+		t.Fatalf("token1.UserId != userId1")
+	}
+	if at2.UserId != userId2 {
+		t.Fatalf("token2.UserId != userId2")
+	}
+	if token1 == token2 {
+		t.Fatal("tokens for different users should not be equal")
+	}
+}

--- a/common/api_route.go
+++ b/common/api_route.go
@@ -133,12 +133,6 @@ type RouteFamily[T Validatable] struct {
 // Handle adds one or more ApiRoutes to this RouteFamily and applies the
 // routes to the provided gin.Engine.
 func (r *RouteFamily[T]) Handle(e *gin.RouterGroup, routes ...ApiRoute[T]) {
-
-	// if DatabaseProvider was not set on the RouteFamily, we will use the global one
-	if r.DatabaseProvider == nil {
-		r.DatabaseProvider = GlobalDatabaseProvider
-	}
-
 	// create a RouteWrapper for each ApiRoute provided
 	for _, route := range routes {
 		wrapper := &routeWrapper[T]{
@@ -191,7 +185,7 @@ func (r *routeWrapper[T]) Handle(c *gin.Context) {
 
 	// get the token from request if configured for this route
 	if r.UseAuth {
-		token, err = GetToken(c)
+		token, err = GetToken(c, r.Database)
 		if err != nil {
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
 			return

--- a/common/api_route_test.go
+++ b/common/api_route_test.go
@@ -1,0 +1,394 @@
+package common
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+type testRouteRecord struct {
+	ID    RecordId
+	Value string
+}
+
+func (t *testRouteRecord) GetOwner() RecordId {
+	return InvalidRecordId
+}
+
+func (t *testRouteRecord) SetOwner(recordId RecordId) {}
+
+func (t *testRouteRecord) Type() string {
+	return "test_route"
+}
+
+func (t *testRouteRecord) GetId() RecordId {
+	return t.ID
+}
+
+func (t *testRouteRecord) SetId(id RecordId) {
+	t.ID = id
+}
+
+func (t *testRouteRecord) EditableBy(_ context.Context, db DatabaseProvider) []RecordId {
+	return nil
+}
+
+func (t *testRouteRecord) AccessibleTo(_ context.Context, db DatabaseProvider) []RecordId {
+	return nil
+}
+
+func (t *testRouteRecord) StaticallyValid() error {
+	return nil
+}
+
+func (t *testRouteRecord) DynamicallyValid(_ context.Context, db DatabaseProvider) error {
+	return nil
+}
+
+func (t *testRouteRecord) BlankRecord() CrudRecord {
+	return new(testRouteRecord)
+}
+
+type simpleRoute struct{}
+
+func (s simpleRoute) Path() (HttpMethod, string) {
+	return HttpMethodGet, "/simple"
+}
+
+func (s simpleRoute) RequestBody() (*testRouteRecord, bool) {
+	return new(testRouteRecord), false
+}
+
+func (s simpleRoute) Handler(request ApiRequest[*testRouteRecord]) (any, int, error) {
+	return gin.H{"message": "ok"}, http.StatusOK, nil
+}
+
+type routeWithBody struct{}
+
+func (r routeWithBody) Path() (HttpMethod, string) {
+	return HttpMethodPost, "/withbody"
+}
+
+func (r routeWithBody) RequestBody() (*testRouteRecord, bool) {
+	return new(testRouteRecord), true
+}
+
+func (r routeWithBody) Handler(request ApiRequest[*testRouteRecord]) (any, int, error) {
+	return gin.H{"value": request.Body.Value}, http.StatusOK, nil
+}
+
+type routeWithId struct{}
+
+func (r routeWithId) Path() (HttpMethod, string) {
+	return HttpMethodGet, "/:id"
+}
+
+func (r routeWithId) RequestBody() (*testRouteRecord, bool) {
+	return new(testRouteRecord), false
+}
+
+func (r routeWithId) Handler(request ApiRequest[*testRouteRecord]) (any, int, error) {
+	return gin.H{"id": request.PathId.String()}, http.StatusOK, nil
+}
+
+func TestRouteFamilyHandle(t *testing.T) {
+	db := NewUnitTestDBProvider()
+	family := RouteFamily[*testRouteRecord]{
+		DatabaseProvider: db,
+		UseAuth:          false,
+	}
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	group := router.Group("/api")
+	family.Handle(group, simpleRoute{})
+
+	// Verify the route was added
+	if len(family.wrappers) != 1 {
+		t.Fatalf("expected 1 wrapper, got %d", len(family.wrappers))
+	}
+
+	wrapper := family.wrappers[0]
+	if wrapper.Database != db {
+		t.Fatal("wrapper should have the same DatabaseProvider")
+	}
+	if wrapper.UseAuth != false {
+		t.Fatal("wrapper.UseAuth should match RouteFamily")
+	}
+}
+
+func TestRouteFamilyWithAuth(t *testing.T) {
+	db := NewUnitTestDBProvider()
+	family := RouteFamily[*testRouteRecord]{
+		DatabaseProvider: db,
+		UseAuth:          true,
+	}
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	group := router.Group("/api")
+	family.Handle(group, simpleRoute{})
+
+	wrapper := family.wrappers[0]
+	if wrapper.UseAuth != true {
+		t.Fatal("wrapper.UseAuth should be true")
+	}
+}
+
+func TestRouteFamilyMultipleRoutes(t *testing.T) {
+	db := NewUnitTestDBProvider()
+	family := RouteFamily[*testRouteRecord]{
+		DatabaseProvider: db,
+	}
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	group := router.Group("/api")
+	family.Handle(group, simpleRoute{}, routeWithBody{}, routeWithId{})
+
+	if len(family.wrappers) != 3 {
+		t.Fatalf("expected 3 wrappers, got %d", len(family.wrappers))
+	}
+}
+
+func TestRouteWrapperHandleNoAuth(t *testing.T) {
+	db := NewUnitTestDBProvider()
+	family := RouteFamily[*testRouteRecord]{
+		DatabaseProvider: db,
+		UseAuth:          false,
+	}
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	group := router.Group("/api")
+	family.Handle(group, simpleRoute{})
+
+	// Make a request
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/api/simple", nil)
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRouteWrapperHandleWithPathId(t *testing.T) {
+	db := NewUnitTestDBProvider()
+	family := RouteFamily[*testRouteRecord]{
+		DatabaseProvider: db,
+		UseAuth:          false,
+	}
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	group := router.Group("/api")
+	family.Handle(group, routeWithId{})
+
+	testId := NewRecordId()
+
+	// Make a request with path ID
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", fmt.Sprintf("/api/%s", testId.String()), nil)
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var result map[string]any
+	json.Unmarshal(w.Body.Bytes(), &result)
+	if result["id"] != testId.String() {
+		t.Fatalf("expected id %s, got %s", testId.String(), result["id"])
+	}
+}
+
+func TestRouteWrapperHandleWithBody(t *testing.T) {
+	db := NewUnitTestDBProvider()
+	family := RouteFamily[*testRouteRecord]{
+		DatabaseProvider: db,
+		UseAuth:          false,
+	}
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	group := router.Group("/api")
+	family.Handle(group, routeWithBody{})
+
+	body := `{"value":"test value"}`
+
+	// Make a request with body
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/api/withbody", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRouteFamilyWithMiddleware(t *testing.T) {
+	db := NewUnitTestDBProvider()
+	middlewareCalled := false
+
+	family := RouteFamily[*testRouteRecord]{
+		DatabaseProvider: db,
+		UseAuth:          false,
+		Middleware: []gin.HandlerFunc{
+			func(c *gin.Context) {
+				middlewareCalled = true
+				c.Next()
+			},
+		},
+	}
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	group := router.Group("/api")
+	family.Handle(group, simpleRoute{})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/api/simple", nil)
+	router.ServeHTTP(w, req)
+
+	if !middlewareCalled {
+		t.Fatal("middleware should have been called")
+	}
+}
+
+func TestAppendPathId(t *testing.T) {
+	result := AppendPathId("/users")
+	if result != "/users/:id" {
+		t.Fatalf("expected '/users/:id', got '%s'", result)
+	}
+
+	result2 := AppendPathId("/api/v1/items")
+	if result2 != "/api/v1/items/:id" {
+		t.Fatalf("expected '/api/v1/items/:id', got '%s'", result2)
+	}
+}
+
+func TestHttpMethodString(t *testing.T) {
+	tests := []struct {
+		method   HttpMethod
+		expected string
+	}{
+		{HttpMethodGet, "GET"},
+		{HttpMethodPost, "POST"},
+		{HttpMethodPut, "PUT"},
+		{HttpMethodDelete, "DELETE"},
+		{HttpMethodInvalid, "INVALID"},
+	}
+
+	for _, tt := range tests {
+		result := tt.method.String()
+		if result != tt.expected {
+			t.Fatalf("expected '%s', got '%s'", tt.expected, result)
+		}
+	}
+}
+
+func TestHttpMethodValid(t *testing.T) {
+	if !HttpMethodGet.Valid() {
+		t.Fatal("HttpMethodGet should be valid")
+	}
+	if !HttpMethodPost.Valid() {
+		t.Fatal("HttpMethodPost should be valid")
+	}
+	if !HttpMethodPut.Valid() {
+		t.Fatal("HttpMethodPut should be valid")
+	}
+	if !HttpMethodDelete.Valid() {
+		t.Fatal("HttpMethodDelete should be valid")
+	}
+	if HttpMethodInvalid.Valid() {
+		t.Fatal("HttpMethodInvalid should not be valid")
+	}
+}
+
+func TestApiRequestParseQuery(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	req, _ := http.NewRequest("GET", "/test?name=john&age=30", nil)
+
+	var parsed struct {
+		Name []string `json:"name"`
+		Age  []string `json:"age"`
+	}
+
+	apiReq := ApiRequest[*testRouteRecord]{
+		request: req,
+	}
+	err := apiReq.ParseQuery(&parsed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(parsed.Name) != 1 || parsed.Name[0] != "john" {
+		t.Fatalf("expected name ['john'], got %v", parsed.Name)
+	}
+	if len(parsed.Age) != 1 || parsed.Age[0] != "30" {
+		t.Fatalf("expected age ['30'], got %v", parsed.Age)
+	}
+}
+
+func TestApiRequestParseQueryEmpty(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	req, _ := http.NewRequest("GET", "/test", nil)
+
+	var parsed map[string]any
+
+	apiReq := ApiRequest[*testRouteRecord]{
+		request: req,
+	}
+	err := apiReq.ParseQuery(&parsed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(parsed) != 0 {
+		t.Fatalf("expected empty map, got %v", parsed)
+	}
+}
+
+func TestRouteFamilyDatabaseProviderSetOnWrappers(t *testing.T) {
+	db := NewUnitTestDBProvider()
+	family := RouteFamily[*testRouteRecord]{
+		DatabaseProvider: db,
+	}
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	group := router.Group("/api")
+	family.Handle(group, simpleRoute{})
+
+	for _, wrapper := range family.wrappers {
+		if wrapper.Database != db {
+			t.Fatal("all wrappers should have the same DatabaseProvider as RouteFamily")
+		}
+	}
+}
+
+// StringReader wraps a string to implement io.Reader
+type StringReader struct {
+	s    string
+	pos  int
+	done bool
+}
+
+func (r *StringReader) Read(p []byte) (n int, err error) {
+	if r.done {
+		return 0, nil
+	}
+	if r.pos >= len(r.s) {
+		r.done = true
+		return 0, nil
+	}
+	n = copy(p, r.s[r.pos:])
+	r.pos += n
+	return n, nil
+}

--- a/common/crud_common.go
+++ b/common/crud_common.go
@@ -78,14 +78,14 @@ type CrudCommon[T CrudRecord] struct {
 	baseRoute string
 }
 
-func NewCrudCommon[T CrudRecord](createFunc func() T, userAuth bool) *CrudCommon[T] {
+func NewCrudCommon[T CrudRecord](createFunc func() T, userAuth bool, db DatabaseProvider) *CrudCommon[T] {
 	baseRoute := createFunc().Type()
 	return &CrudCommon[T]{
 		CreateRecord: createFunc,
 		UseAuth:      userAuth,
 		// baseRoute is automatically set up based on the table name of the provided createFunc
 		baseRoute:        fmt.Sprintf("/%s", baseRoute),
-		DatabaseProvider: GlobalDatabaseProvider,
+		DatabaseProvider: db,
 	}
 }
 

--- a/common/crud_common_test.go
+++ b/common/crud_common_test.go
@@ -1,0 +1,557 @@
+package common
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+type testCrudRecord struct {
+	ID        RecordId
+	Owner     RecordId
+	Value     string
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+func (t *testCrudRecord) GetOwner() RecordId {
+	return t.Owner
+}
+
+func (t *testCrudRecord) SetOwner(recordId RecordId) {
+	t.Owner = recordId
+}
+
+func newTestCrudRecord() *testCrudRecord {
+	return &testCrudRecord{
+		ID:    NewRecordId(),
+		Value: "default",
+	}
+}
+
+func (t *testCrudRecord) Type() string {
+	return "test_crud"
+}
+
+func (t *testCrudRecord) GetId() RecordId {
+	return t.ID
+}
+
+func (t *testCrudRecord) SetId(id RecordId) {
+	t.ID = id
+}
+
+func (t *testCrudRecord) EditableBy(_ context.Context, db DatabaseProvider) []RecordId {
+	return []RecordId{t.Owner, SysAdminRecordId}
+}
+
+func (t *testCrudRecord) AccessibleTo(_ context.Context, db DatabaseProvider) []RecordId {
+	return AccessibleToEveryone
+}
+
+func (t *testCrudRecord) StaticallyValid() error {
+	if t.Value == "" {
+		return fmt.Errorf("value cannot be empty")
+	}
+	return nil
+}
+
+func (t *testCrudRecord) DynamicallyValid(_ context.Context, db DatabaseProvider) error {
+	return nil
+}
+
+func (t *testCrudRecord) GetTimeStamps() (created, updated time.Time) {
+	return t.CreatedAt, t.UpdatedAt
+}
+
+func (t *testCrudRecord) SetCreateTimestamp(tm time.Time) time.Time {
+	oldValue := t.CreatedAt
+	t.CreatedAt = tm
+	return oldValue
+}
+
+func (t *testCrudRecord) SetUpdateTimestamp(tm time.Time) time.Time {
+	oldValue := t.UpdatedAt
+	t.UpdatedAt = tm
+	return oldValue
+}
+
+func (t *testCrudRecord) BlankRecord() CrudRecord {
+	return new(testCrudRecord)
+}
+
+func TestNewCrudCommon(t *testing.T) {
+	db := NewUnitTestDBProvider()
+	cc := NewCrudCommon(newTestCrudRecord, true, db)
+
+	if cc.CreateRecord == nil {
+		t.Fatal("CreateRecord should be set")
+	}
+	if !cc.UseAuth {
+		t.Fatal("UseAuth should be true")
+	}
+	if cc.DatabaseProvider != db {
+		t.Fatal("DatabaseProvider should be set")
+	}
+	if cc.baseRoute != "/test_crud" {
+		t.Fatalf("expected baseRoute '/test_crud', got '%s'", cc.baseRoute)
+	}
+}
+
+func TestNewCrudCommonNoAuth(t *testing.T) {
+	db := NewUnitTestDBProvider()
+	cc := NewCrudCommon(newTestCrudRecord, false, db)
+
+	if cc.UseAuth {
+		t.Fatal("UseAuth should be false")
+	}
+}
+
+func TestCrudCommonCreateMissingToken(t *testing.T) {
+	db := NewUnitTestDBProvider()
+	cc := NewCrudCommon(newTestCrudRecord, true, db)
+
+	route := genericApiRoute[*testCrudRecord]{
+		requestBody:    newTestCrudRecord,
+		useRequestBody: true,
+		handle:         cc.createCrudRecord,
+	}
+
+	req := ApiRequest[*testCrudRecord]{
+		Context:          context.Background(),
+		DatabaseProvider: db,
+		Token:            nil,
+		Body:             newTestCrudRecord(),
+	}
+
+	_, status, err := route.Handler(req)
+	if err == nil {
+		t.Fatal("expected error for missing token")
+	}
+	if status != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, status)
+	}
+}
+
+func TestCrudCommonCreateSuccess(t *testing.T) {
+	db := NewUnitTestDBProvider()
+	cc := NewCrudCommon(newTestCrudRecord, true, db)
+
+	route := genericApiRoute[*testCrudRecord]{
+		requestBody:    newTestCrudRecord,
+		useRequestBody: true,
+		handle:         cc.createCrudRecord,
+	}
+
+	ownerId := NewRecordId()
+	req := ApiRequest[*testCrudRecord]{
+		Context:          context.Background(),
+		DatabaseProvider: db,
+		Token:            &AuthToken{UserId: ownerId},
+		Body:             newTestCrudRecord(),
+	}
+
+	resp, status, err := route.Handler(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, status)
+	}
+
+	result := resp.(gin.H)
+	resource := result[ResourceKey]
+	if resource.(*testCrudRecord).Owner != ownerId {
+		t.Fatal("Owner should be set from token")
+	}
+	if resource.(*testCrudRecord).ID == InvalidRecordId {
+		t.Fatal("ID should be set")
+	}
+}
+
+func TestCrudCommonGetOneSuccess(t *testing.T) {
+	db := NewUnitTestDBProvider()
+	cc := NewCrudCommon(newTestCrudRecord, true, db)
+
+	// Create a record first
+	ownerId := NewRecordId()
+	v := newTestCrudRecord()
+	v.Owner = ownerId
+	created, err := CreateOne(context.Background(), db, v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	route := genericApiRoute[*testCrudRecord]{
+		requestBody: newTestCrudRecord,
+		handle:      cc.getCrudRecordById,
+	}
+
+	req := ApiRequest[*testCrudRecord]{
+		Context:          context.Background(),
+		DatabaseProvider: db,
+		Token:            &AuthToken{UserId: ownerId},
+		PathId:           created.ID,
+	}
+
+	resp, status, err := route.Handler(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, status)
+	}
+
+	result := resp.(gin.H)
+	resource := result[ResourceKey].(*testCrudRecord)
+	if resource.ID != created.ID {
+		t.Fatalf("expected ID %s, got %s", created.ID, resource.ID)
+	}
+}
+
+func TestCrudCommonGetOneNotFound(t *testing.T) {
+	db := NewUnitTestDBProvider()
+	cc := NewCrudCommon(newTestCrudRecord, true, db)
+
+	route := genericApiRoute[*testCrudRecord]{
+		requestBody: newTestCrudRecord,
+		handle:      cc.getCrudRecordById,
+	}
+
+	req := ApiRequest[*testCrudRecord]{
+		Context:          context.Background(),
+		DatabaseProvider: db,
+		Token:            &AuthToken{UserId: NewRecordId()},
+		PathId:           NewRecordId(),
+	}
+
+	_, status, err := route.Handler(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status != http.StatusNotFound {
+		t.Fatalf("expected status %d, got %d", http.StatusNotFound, status)
+	}
+}
+
+func TestCrudCommonGetAllSuccess(t *testing.T) {
+	db := NewUnitTestDBProvider()
+	cc := NewCrudCommon(newTestCrudRecord, true, db)
+
+	ownerId := NewRecordId()
+	for i := 0; i < 3; i++ {
+		v := newTestCrudRecord()
+		v.Owner = ownerId
+		_, err := CreateOne(context.Background(), db, v)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	route := genericApiRoute[*testCrudRecord]{
+		requestBody: newTestCrudRecord,
+		handle:      cc.getAllCrudRecords,
+	}
+
+	req := ApiRequest[*testCrudRecord]{
+		Context:          context.Background(),
+		DatabaseProvider: db,
+		Token:            &AuthToken{UserId: ownerId},
+	}
+
+	resp, status, err := route.Handler(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, status)
+	}
+
+	result := resp.(gin.H)
+	records := result[ResourceKey].([]*testCrudRecord)
+	if len(records) != 3 {
+		t.Fatalf("expected 3 records, got %d", len(records))
+	}
+}
+
+func TestCrudCommonDeleteSuccess(t *testing.T) {
+	db := NewUnitTestDBProvider()
+	cc := NewCrudCommon(newTestCrudRecord, true, db)
+
+	ownerId := NewRecordId()
+	v := newTestCrudRecord()
+	v.Owner = ownerId
+	created, err := CreateOne(context.Background(), db, v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	route := genericApiRoute[*testCrudRecord]{
+		requestBody: newTestCrudRecord,
+		handle:      cc.deleteCrudRecordById,
+	}
+
+	req := ApiRequest[*testCrudRecord]{
+		Context:          context.Background(),
+		DatabaseProvider: db,
+		Token:            &AuthToken{UserId: ownerId},
+		PathId:           created.ID,
+	}
+
+	resp, status, err := route.Handler(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, status)
+	}
+
+	result := resp.(gin.H)
+	deleted := result[ResourceKey].(*testCrudRecord)
+	if deleted.ID != created.ID {
+		t.Fatalf("expected ID %s, got %s", created.ID, deleted.ID)
+	}
+}
+
+func TestCrudCommonDeleteMissingToken(t *testing.T) {
+	db := NewUnitTestDBProvider()
+	cc := NewCrudCommon(newTestCrudRecord, true, db)
+
+	route := genericApiRoute[*testCrudRecord]{
+		requestBody: newTestCrudRecord,
+		handle:      cc.deleteCrudRecordById,
+	}
+
+	req := ApiRequest[*testCrudRecord]{
+		Context:          context.Background(),
+		DatabaseProvider: db,
+		Token:            nil,
+		PathId:           NewRecordId(),
+	}
+
+	_, status, err := route.Handler(req)
+	if err == nil {
+		t.Fatal("expected error for missing token")
+	}
+	if status != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, status)
+	}
+}
+
+func TestCrudCommonDeleteNotFound(t *testing.T) {
+	db := NewUnitTestDBProvider()
+	cc := NewCrudCommon(newTestCrudRecord, true, db)
+
+	ownerId := NewRecordId()
+	route := genericApiRoute[*testCrudRecord]{
+		requestBody: newTestCrudRecord,
+		handle:      cc.deleteCrudRecordById,
+	}
+
+	req := ApiRequest[*testCrudRecord]{
+		Context:          context.Background(),
+		DatabaseProvider: db,
+		Token:            &AuthToken{UserId: ownerId},
+		PathId:           NewRecordId(),
+	}
+
+	_, status, err := route.Handler(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, status)
+	}
+}
+
+func TestCrudCommonUpdateSuccess(t *testing.T) {
+	db := NewUnitTestDBProvider()
+	cc := NewCrudCommon(newTestCrudRecord, true, db)
+
+	ownerId := NewRecordId()
+	v := newTestCrudRecord()
+	v.Owner = ownerId
+	created, err := CreateOne(context.Background(), db, v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	route := genericApiRoute[*testCrudRecord]{
+		requestBody:    newTestCrudRecord,
+		useRequestBody: true,
+		handle:         cc.updateCrudRecord,
+	}
+
+	req := ApiRequest[*testCrudRecord]{
+		Context:          context.Background(),
+		DatabaseProvider: db,
+		Token:            &AuthToken{UserId: ownerId},
+		PathId:           created.ID,
+		Body: &testCrudRecord{
+			ID:    created.ID,
+			Owner: ownerId,
+			Value: "updated",
+		},
+	}
+
+	resp, status, err := route.Handler(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, status)
+	}
+
+	result := resp.(gin.H)
+	updated := result[ResourceKey].(*testCrudRecord)
+	if updated.Value != "updated" {
+		t.Fatalf("expected value 'updated', got '%s'", updated.Value)
+	}
+}
+
+func TestCrudCommonUpdateMissingToken(t *testing.T) {
+	db := NewUnitTestDBProvider()
+	cc := NewCrudCommon(newTestCrudRecord, true, db)
+
+	route := genericApiRoute[*testCrudRecord]{
+		requestBody:    newTestCrudRecord,
+		useRequestBody: true,
+		handle:         cc.updateCrudRecord,
+	}
+
+	req := ApiRequest[*testCrudRecord]{
+		Context:          context.Background(),
+		DatabaseProvider: db,
+		Token:            nil,
+		PathId:           NewRecordId(),
+		Body:             newTestCrudRecord(),
+	}
+
+	_, status, err := route.Handler(req)
+	if err == nil {
+		t.Fatal("expected error for missing token")
+	}
+	if status != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, status)
+	}
+}
+
+func TestCrudCommonCreateEmptyValue(t *testing.T) {
+	db := NewUnitTestDBProvider()
+	cc := NewCrudCommon(newTestCrudRecord, true, db)
+
+	route := genericApiRoute[*testCrudRecord]{
+		requestBody:    func() *testCrudRecord { r := newTestCrudRecord(); r.Value = ""; return r },
+		useRequestBody: true,
+		handle:         cc.createCrudRecord,
+	}
+
+	ownerId := NewRecordId()
+	req := ApiRequest[*testCrudRecord]{
+		Context:          context.Background(),
+		DatabaseProvider: db,
+		Token:            &AuthToken{UserId: ownerId},
+		Body:             func() *testCrudRecord { r := newTestCrudRecord(); r.Value = ""; return r }(),
+	}
+
+	_, status, err := route.Handler(req)
+	if err == nil {
+		t.Fatal("expected error for empty value")
+	}
+	if status != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, status)
+	}
+}
+
+func TestCrudCommonGetOneAccessibleToEveryone(t *testing.T) {
+	db := NewUnitTestDBProvider()
+	cc := NewCrudCommon(newTestCrudRecord, true, db)
+
+	ownerId := NewRecordId()
+	v := newTestCrudRecord()
+	v.Owner = ownerId
+	created, err := CreateOne(context.Background(), db, v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	route := genericApiRoute[*testCrudRecord]{
+		requestBody: newTestCrudRecord,
+		handle:      cc.getCrudRecordById,
+	}
+
+	// Even a "non-owner" user can access it because AccessibleTo returns AccessibleToEveryone
+	nonOwnerId := NewRecordId()
+	req := ApiRequest[*testCrudRecord]{
+		Context:          context.Background(),
+		DatabaseProvider: db,
+		Token:            &AuthToken{UserId: nonOwnerId},
+		PathId:           created.ID,
+	}
+
+	_, status, err := route.Handler(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status != http.StatusOK {
+		t.Fatalf("expected status %d (accessible to everyone), got %d", http.StatusOK, status)
+	}
+}
+
+func TestCrudCommonDeleteUnauthorized(t *testing.T) {
+	db := NewUnitTestDBProvider()
+	cc := NewCrudCommon(newTestCrudRecord, true, db)
+
+	ownerId := NewRecordId()
+	v := newTestCrudRecord()
+	v.Owner = ownerId
+	created, err := CreateOne(context.Background(), db, v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	route := genericApiRoute[*testCrudRecord]{
+		requestBody: newTestCrudRecord,
+		handle:      cc.deleteCrudRecordById,
+	}
+
+	unauthorizedId := NewRecordId()
+	req := ApiRequest[*testCrudRecord]{
+		Context:          context.Background(),
+		DatabaseProvider: db,
+		Token:            &AuthToken{UserId: unauthorizedId},
+		PathId:           created.ID,
+	}
+
+	_, status, err := route.Handler(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, status)
+	}
+}
+
+func TestCrudCommonHandleRouteTypesPanicOnNilCreateRecord(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic when CreateRecord is nil")
+		}
+	}()
+
+	db := NewUnitTestDBProvider()
+	cc := &CrudCommon[*testCrudRecord]{
+		CreateRecord:     nil,
+		UseAuth:          true,
+		DatabaseProvider: db,
+		baseRoute:        "/test",
+	}
+
+	gin.SetMode(gin.TestMode)
+	ginRouter := gin.New().Group("")
+	cc.HandleRouteTypes(ginRouter, CrudWrapperFunctionGetOne)
+}

--- a/common/crud_record_test.go
+++ b/common/crud_record_test.go
@@ -1,0 +1,253 @@
+package common
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestNewRecordIdGeneratesUniqueIds(t *testing.T) {
+	ids := make(map[RecordId]bool)
+	for i := 0; i < 1000; i++ {
+		id := NewRecordId()
+		if ids[id] {
+			t.Fatalf("Duplicate RecordId generated: %d", id)
+		}
+		ids[id] = true
+	}
+}
+
+func TestNewRecordIdNeverGeneratesUnavailableIds(t *testing.T) {
+	for i := 0; i < 1000; i++ {
+		id := NewRecordId()
+		if id == InvalidRecordId {
+			t.Fatal("NewRecordId generated InvalidRecordId")
+		}
+		if id == EveryoneRecordId {
+			t.Fatal("NewRecordId generated EveryoneRecordId")
+		}
+		if id == SysAdminRecordId {
+			t.Fatal("NewRecordId generated SysAdminRecordId")
+		}
+	}
+}
+
+func TestRecordIdValidRecordId(t *testing.T) {
+	if InvalidRecordId.ValidRecordId() {
+		t.Fatal("InvalidRecordId should not be valid")
+	}
+	if EveryoneRecordId.ValidRecordId() {
+		t.Fatal("EveryoneRecordId should not be valid")
+	}
+	if SysAdminRecordId.ValidRecordId() {
+		t.Fatal("SysAdminRecordId should not be valid")
+	}
+	id := NewRecordId()
+	if !id.ValidRecordId() {
+		t.Fatal("NewRecordId should be valid")
+	}
+}
+
+func TestRecordIdString(t *testing.T) {
+	id := RecordId(1)
+	str := id.String()
+	if str != "0000000000000001" {
+		t.Fatalf("Expected '0000000000000001', got '%s'", str)
+	}
+
+	invalidId := InvalidRecordId
+	invalidStr := invalidId.String()
+	if invalidStr != "" {
+		t.Fatalf("Expected empty string for InvalidRecordId, got '%s'", invalidStr)
+	}
+
+	id2 := RecordId(256)
+	str2 := id2.String()
+	if str2 != "0000000000000100" {
+		t.Fatalf("Expected '0000000000000100', got '%s'", str2)
+	}
+}
+
+func TestRecordIdFromString(t *testing.T) {
+	id, err := RecordIdFromString("0000000000000001")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if id != RecordId(1) {
+		t.Fatalf("Expected RecordId(1), got %d", id)
+	}
+
+	emptyId, err := RecordIdFromString("")
+	if err != nil {
+		t.Fatalf("Unexpected error for empty string: %v", err)
+	}
+	if emptyId != InvalidRecordId {
+		t.Fatalf("Expected InvalidRecordId for empty string, got %d", emptyId)
+	}
+
+	_, err = RecordIdFromString("xyz")
+	if err == nil {
+		t.Fatal("Expected error for invalid hex string")
+	}
+
+	_, err = RecordIdFromString("000000000000000")
+	if err == nil {
+		t.Fatal("Expected error for short hex string")
+	}
+
+	_, err = RecordIdFromString("00000000000000000")
+	if err == nil {
+		t.Fatal("Expected error for long hex string")
+	}
+}
+
+func TestRecordIdMarshalJSON(t *testing.T) {
+	type testStruct struct {
+		ID RecordId `json:"id"`
+	}
+
+	id := RecordId(256)
+	data, err := json.Marshal(testStruct{ID: id})
+	if err != nil {
+		t.Fatalf("Unexpected error marshaling: %v", err)
+	}
+	expected := `{"id":"0000000000000100"}`
+	if string(data) != expected {
+		t.Fatalf("Expected '%s', got '%s'", expected, string(data))
+	}
+}
+
+func TestRecordIdUnmarshalJSON(t *testing.T) {
+	type testStruct struct {
+		ID RecordId `json:"id"`
+	}
+
+	jsonStr := `{"id":"000000000000000a"}`
+	var s testStruct
+	err := json.Unmarshal([]byte(jsonStr), &s)
+	if err != nil {
+		t.Fatalf("Unexpected error unmarshaling: %v", err)
+	}
+	if s.ID != RecordId(10) {
+		t.Fatalf("Expected RecordId(10), got %d", s.ID)
+	}
+}
+
+func TestUnmarshalStringIdList(t *testing.T) {
+	jsonStr := `["0000000000000001","0000000000000002","0000000000000003"]`
+	ids, err := UnmarshalStringIdList([]byte(jsonStr))
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if len(ids) != 3 {
+		t.Fatalf("Expected 3 IDs, got %d", len(ids))
+	}
+	if ids[0] != RecordId(1) {
+		t.Fatalf("Expected RecordId(1), got %d", ids[0])
+	}
+	if ids[1] != RecordId(2) {
+		t.Fatalf("Expected RecordId(2), got %d", ids[1])
+	}
+	if ids[2] != RecordId(3) {
+		t.Fatalf("Expected RecordId(3), got %d", ids[2])
+	}
+}
+
+func TestUnmarshalStringIdListInvalid(t *testing.T) {
+	_, err := UnmarshalStringIdList([]byte(`["invalid"]`))
+	if err == nil {
+		t.Fatal("Expected error for invalid ID string")
+	}
+
+	_, err = UnmarshalStringIdList([]byte(`not json`))
+	if err == nil {
+		t.Fatal("Expected error for invalid JSON")
+	}
+}
+
+func TestSysAdminAndUsers(t *testing.T) {
+	userId1 := RecordId(100)
+	userId2 := RecordId(200)
+	result := SysAdminAndUsers(userId1, userId2)
+	if len(result) != 3 {
+		t.Fatalf("Expected 3 IDs, got %d", len(result))
+	}
+	if result[0] != SysAdminRecordId {
+		t.Fatalf("Expected SysAdminRecordId first, got %d", result[0])
+	}
+	if result[1] != userId1 {
+		t.Fatalf("Expected userId1 second, got %d", result[1])
+	}
+	if result[2] != userId2 {
+		t.Fatalf("Expected userId2 third, got %d", result[2])
+	}
+}
+
+func TestSysAdminAndUsersEmpty(t *testing.T) {
+	result := SysAdminAndUsers()
+	if len(result) != 1 {
+		t.Fatalf("Expected 1 ID (sys admin), got %d", len(result))
+	}
+	if result[0] != SysAdminRecordId {
+		t.Fatalf("Expected SysAdminRecordId, got %d", result[0])
+	}
+}
+
+func TestTimestampedRecordCreateTimestamp(t *testing.T) {
+	db := NewUnitTestDBProvider()
+	v := newTestRecord()
+	created, err := CreateOne(context.Background(), db, v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created.CreatedAt.IsZero() {
+		t.Fatal("CreatedAt should be set after CreateOne")
+	}
+}
+
+func TestTimestampedRecordUpdateTimestampOnUpdate(t *testing.T) {
+	db := NewUnitTestDBProvider()
+	v := newTestRecord()
+	created, err := CreateOne(context.Background(), db, v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	initialCreatedAt := created.CreatedAt
+	initialUpdatedAt := created.UpdatedAt
+
+	// Small delay to ensure update timestamp differs
+	time.Sleep(10 * time.Millisecond)
+
+	copied := created.Copy()
+	copied.UpdatedAt = time.Time{}
+	err = UpdateOne(context.Background(), db, copied)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	queried, exists, err := GetOneById(context.Background(), db, &testRecord{}, created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exists {
+		t.Fatal("record should exist")
+	}
+
+	if queried.CreatedAt != initialCreatedAt {
+		t.Fatal("CreatedAt should not change on update")
+	}
+	if queried.UpdatedAt.Equal(initialUpdatedAt) {
+		t.Fatal("UpdatedAt should change on update")
+	}
+	if queried.UpdatedAt.Before(initialUpdatedAt) {
+		t.Fatal("UpdatedAt should be after initialUpdatedAt")
+	}
+}
+
+func TestRecordIdUint64(t *testing.T) {
+	id := RecordId(42)
+	if id.Uint64() != 42 {
+		t.Fatalf("Expected 42, got %d", id.Uint64())
+	}
+}

--- a/common/database_provider.go
+++ b/common/database_provider.go
@@ -6,8 +6,6 @@ import (
 	"time"
 )
 
-var GlobalDatabaseProvider DatabaseProvider
-
 // WhereFunc is a function signature used in DatabaseProvider.GetAllWhere
 // which provides a CrudRecord and allows the caller to define a function
 // to potentially filter the result from the output list. If the WhereFunc
@@ -116,8 +114,11 @@ func GetAll[T CrudRecord](ctx context.Context, db DatabaseProvider) ([]T, error)
 // returning a []T instead of a []CrudRecord
 func GetAllWhere[T CrudRecord](ctx context.Context, db DatabaseProvider, where WhereFuncT[T]) ([]T, error) {
 	var zero T
-	w := func(_ context.Context, c CrudRecord) bool {
-		return where(ctx, c.(T))
+	var w WhereFunc
+	if where != nil {
+		w = func(_ context.Context, c CrudRecord) bool {
+			return where(ctx, c.(T))
+		}
 	}
 
 	v, err := db.GetAllWhere(ctx, zero, w)

--- a/common/database_provider_test.go
+++ b/common/database_provider_test.go
@@ -117,3 +117,384 @@ func TestCreateDateIsImmutable(t *testing.T) {
 		t.Error("Created timestamp is not immutable")
 	}
 }
+
+func TestGetOneByIdSuccess(t *testing.T) {
+	db := NewUnitTestDBProvider()
+	v := newTestRecord()
+	created, err := CreateOne(context.Background(), db, v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, exists, err := GetOneById(context.Background(), db, &testRecord{}, created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exists {
+		t.Fatal("record should exist")
+	}
+	if result.ID != created.ID {
+		t.Fatalf("expected ID %s, got %s", created.ID, result.ID)
+	}
+}
+
+func TestGetOneByIdNotFound(t *testing.T) {
+	db := NewUnitTestDBProvider()
+	nonExistentId := NewRecordId()
+
+	result, exists, err := GetOneById(context.Background(), db, &testRecord{}, nonExistentId)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exists {
+		t.Fatal("record should not exist")
+	}
+	if result != nil {
+		t.Fatal("result should be nil for non-existent record")
+	}
+}
+
+func TestGetExistingRecordByIdSuccess(t *testing.T) {
+	db := NewUnitTestDBProvider()
+	v := newTestRecord()
+	created, err := CreateOne(context.Background(), db, v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := GetExistingRecordById(context.Background(), db, &testRecord{}, created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.ID != created.ID {
+		t.Fatalf("expected ID %s, got %s", created.ID, result.ID)
+	}
+}
+
+func TestGetExistingRecordByIdNotFound(t *testing.T) {
+	db := NewUnitTestDBProvider()
+	nonExistentId := NewRecordId()
+
+	_, err := GetExistingRecordById(context.Background(), db, &testRecord{}, nonExistentId)
+	if err == nil {
+		t.Fatal("expected error for non-existent record")
+	}
+}
+
+func TestExistsByIdExists(t *testing.T) {
+	db := NewUnitTestDBProvider()
+	v := newTestRecord()
+	created, err := CreateOne(context.Background(), db, v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = ExistsById(context.Background(), db, &testRecord{}, created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestExistsByIdNotFound(t *testing.T) {
+	db := NewUnitTestDBProvider()
+	nonExistentId := NewRecordId()
+
+	err := ExistsById(context.Background(), db, &testRecord{}, nonExistentId)
+	if err == nil {
+		t.Fatal("expected error for non-existent record")
+	}
+}
+
+func TestGetAllEmpty(t *testing.T) {
+	db := NewUnitTestDBProvider()
+
+	results, err := GetAll[*testRecord](context.Background(), db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("expected 0 records, got %d", len(results))
+	}
+}
+
+func TestGetAllWithRecords(t *testing.T) {
+	db := NewUnitTestDBProvider()
+
+	for i := 0; i < 5; i++ {
+		_, err := CreateOne(context.Background(), db, newTestRecord())
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	results, err := GetAll[*testRecord](context.Background(), db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 5 {
+		t.Fatalf("expected 5 records, got %d", len(results))
+	}
+}
+
+func TestGetAllWhereWithFilter(t *testing.T) {
+	db := NewUnitTestDBProvider()
+
+	ownerId1 := NewRecordId()
+	ownerId2 := NewRecordId()
+
+	v1 := newTestRecord()
+	v1.Owner = ownerId1
+	_, err := CreateOne(context.Background(), db, v1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	v2 := newTestRecord()
+	v2.Owner = ownerId2
+	_, err = CreateOne(context.Background(), db, v2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := GetAllWhere[*testRecord](context.Background(), db, func(_ context.Context, c *testRecord) bool {
+		return c.Owner == ownerId1
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(results))
+	}
+	if results[0].Owner != ownerId1 {
+		t.Fatal("expected record with ownerId1")
+	}
+}
+
+func TestGetAllWhereNoResults(t *testing.T) {
+	db := NewUnitTestDBProvider()
+
+	_, err := CreateOne(context.Background(), db, newTestRecord())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := GetAllWhere[*testRecord](context.Background(), db, func(_ context.Context, c *testRecord) bool {
+		return false
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("expected 0 records, got %d", len(results))
+	}
+}
+
+func TestGetAllWhereNilFilter(t *testing.T) {
+	db := NewUnitTestDBProvider()
+
+	for i := 0; i < 3; i++ {
+		_, err := CreateOne(context.Background(), db, newTestRecord())
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	results, err := GetAllWhere[*testRecord](context.Background(), db, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("expected 3 records, got %d", len(results))
+	}
+}
+
+func TestDeleteOneByIdSuccess(t *testing.T) {
+	db := NewUnitTestDBProvider()
+	v := newTestRecord()
+	created, err := CreateOne(context.Background(), db, v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, exists, err := DeleteOneById(context.Background(), db, &testRecord{}, created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exists {
+		t.Fatal("record should exist")
+	}
+	if result.ID != created.ID {
+		t.Fatalf("expected ID %s, got %s", created.ID, result.ID)
+	}
+
+	// Verify it's actually deleted
+	_, exists2, _ := GetOneById(context.Background(), db, &testRecord{}, created.ID)
+	if exists2 {
+		t.Fatal("record should be deleted")
+	}
+}
+
+func TestDeleteOneByIdNotFound(t *testing.T) {
+	db := NewUnitTestDBProvider()
+	nonExistentId := NewRecordId()
+
+	result, exists, err := DeleteOneById(context.Background(), db, &testRecord{}, nonExistentId)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exists {
+		t.Fatal("record should not exist")
+	}
+	if result != nil {
+		t.Fatal("result should be nil for non-existent record")
+	}
+}
+
+func TestDeleteOneByIdDoubleDelete(t *testing.T) {
+	db := NewUnitTestDBProvider()
+	v := newTestRecord()
+	created, err := CreateOne(context.Background(), db, v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// First delete
+	_, exists1, err := DeleteOneById(context.Background(), db, &testRecord{}, created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exists1 {
+		t.Fatal("first delete should find record")
+	}
+
+	// Second delete (should be idempotent)
+	_, exists2, err := DeleteOneById(context.Background(), db, &testRecord{}, created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exists2 {
+		t.Fatal("second delete should not find record")
+	}
+}
+
+func TestUpdateOneBasic(t *testing.T) {
+	db := NewUnitTestDBProvider()
+	v := newTestRecord()
+	v.Owner = NewRecordId()
+	created, err := CreateOne(context.Background(), db, v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	updated := &testRecord{
+		ID:    created.ID,
+		Owner: NewRecordId(),
+	}
+	err = UpdateOne(context.Background(), db, updated)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	retrieved, exists, err := GetOneById(context.Background(), db, &testRecord{}, created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exists {
+		t.Fatal("record should exist after update")
+	}
+	if retrieved.Owner != updated.Owner {
+		t.Fatal("Owner should be updated")
+	}
+}
+
+func TestUpdateOneNotFound(t *testing.T) {
+	db := NewUnitTestDBProvider()
+
+	nonExistent := &testRecord{
+		ID:    NewRecordId(),
+		Owner: NewRecordId(),
+	}
+	err := UpdateOne(context.Background(), db, nonExistent)
+	if err == nil {
+		t.Fatal("expected error updating non-existent record")
+	}
+}
+
+func TestCreateOneWithPreSetId(t *testing.T) {
+	db := NewUnitTestDBProvider()
+	v := newTestRecord()
+	v.ID = NewRecordId()
+	created, err := CreateOne(context.Background(), db, v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created.ID != v.ID {
+		t.Fatalf("expected ID %s, got %s", v.ID, created.ID)
+	}
+}
+
+func TestCreateOneGeneratesNewId(t *testing.T) {
+	db := NewUnitTestDBProvider()
+	id := NewRecordId()
+
+	v := newTestRecord()
+	v.ID = id
+	created, err := CreateOne(context.Background(), db, v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// CreateOne always generates a new ID, even if one was already set
+	if created.ID == id {
+		t.Fatal("CreateOne should generate a new ID even if one was already set")
+	}
+}
+
+func TestGetAllDifferentTypes(t *testing.T) {
+	db := NewUnitTestDBProvider()
+
+	_, err := CreateOne(context.Background(), db, newTestRecord())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testUnique1 := &testUnique{
+		RecordId:     1,
+		ReferenceId1: 2,
+		ReferenceId2: 3,
+	}
+	_, err = CreateOne(context.Background(), db, testUnique1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testRecords, err := GetAll[*testRecord](context.Background(), db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(testRecords) != 1 {
+		t.Fatalf("expected 1 testRecord, got %d", len(testRecords))
+	}
+
+	uniqueRecords, err := GetAll[*testUnique](context.Background(), db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(uniqueRecords) != 1 {
+		t.Fatalf("expected 1 testUnique, got %d", len(uniqueRecords))
+	}
+}
+
+func TestCrudRecordBlankRecord(t *testing.T) {
+	v := newTestRecord()
+	blank := v.BlankRecord()
+	if blank == nil {
+		t.Fatal("BlankRecord should not return nil")
+	}
+	blankTestRecord, ok := blank.(*testRecord)
+	if !ok {
+		t.Fatal("BlankRecord should return *testRecord")
+	}
+	if blankTestRecord.ID != InvalidRecordId {
+		t.Fatal("BlankRecord should have invalid ID")
+	}
+}

--- a/common/db_with_access_control_test.go
+++ b/common/db_with_access_control_test.go
@@ -287,3 +287,254 @@ func TestEditableBySysAdmin(t *testing.T) {
 	}
 	fmt.Printf("%+v\n", v)
 }
+
+func TestGetAllByOwner(t *testing.T) {
+	db := NewUnitTestDBProvider()
+	ownerId := NewRecordId()
+	otherId := NewRecordId()
+
+	// Create a record owned by ownerId
+	_ = newStoredPrivateTestRecord(t, db, ownerId)
+	_ = newStoredPrivateTestRecord(t, db, ownerId)
+	// Create a record owned by someone else
+	newStoredPrivateTestRecord(t, db, otherId)
+
+	wac := WithAccessControl[*PrivateTestRecord]{Database: db, AccessControlUser: ownerId}
+	results, err := wac.GetAll(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 records, got %d", len(results))
+	}
+}
+
+func TestGetAllByUnauthorizedUser(t *testing.T) {
+	db := NewUnitTestDBProvider()
+	ownerId := NewRecordId()
+	unauthorizedId := NewRecordId()
+
+	newStoredPrivateTestRecord(t, db, ownerId)
+
+	wac := WithAccessControl[*PrivateTestRecord]{Database: db, AccessControlUser: unauthorizedId}
+	results, err := wac.GetAll(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("expected 0 records for unauthorized user, got %d", len(results))
+	}
+}
+
+func TestGetAllBySysAdmin(t *testing.T) {
+	db := NewUnitTestDBProvider()
+	ownerId := NewRecordId()
+	adminId := NewRecordId()
+
+	newStoredPrivateTestRecord(t, db, ownerId)
+
+	SysAdminCheck = func(ctx context.Context, db DatabaseProvider, c RecordId) (bool, error) {
+		return c == adminId, nil
+	}
+
+	wac := WithAccessControl[*PrivateTestRecord]{Database: db, AccessControlUser: adminId}
+	results, err := wac.GetAll(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 record for sys admin, got %d", len(results))
+	}
+}
+
+func TestDeleteOneByIdNotFoundNonOwner(t *testing.T) {
+	db := NewUnitTestDBProvider()
+	ownerId := NewRecordId()
+	newStoredPrivateTestRecord(t, db, ownerId)
+
+	nonExistentId := NewRecordId()
+	wac := WithAccessControl[*PrivateTestRecord]{Database: db, AccessControlUser: ownerId}
+	_, exists, err := wac.DeleteOneById(context.Background(), &PrivateTestRecord{}, nonExistentId)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exists {
+		t.Fatal("should not exist for non-existent record")
+	}
+}
+
+func TestUpdateOneByIdNotFound(t *testing.T) {
+	db := NewUnitTestDBProvider()
+	ownerId := NewRecordId()
+	newStoredPrivateTestRecord(t, db, ownerId)
+
+	nonExistent := &PrivateTestRecord{
+		ID:    NewRecordId(),
+		Owner: ownerId,
+	}
+	wac := WithAccessControl[*PrivateTestRecord]{Database: db, AccessControlUser: ownerId}
+	err := wac.UpdateOneById(context.Background(), nonExistent)
+	if err == nil {
+		t.Fatal("expected error updating non-existent record")
+	}
+}
+
+func TestDeleteBySharedToUser(t *testing.T) {
+	db := NewUnitTestDBProvider()
+	ownerId := NewRecordId()
+	r := newStoredPrivateTestRecord(t, db, ownerId)
+
+	sharedToId := NewRecordId()
+	err := r.ShareTo(context.Background(), db, sharedToId, ownerId)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Shared user should be able to read but not delete (only owner/sysadmin can edit)
+	wac := WithAccessControl[*PrivateTestRecord]{Database: db, AccessControlUser: sharedToId}
+	v, exists, err := wac.GetOneById(context.Background(), &PrivateTestRecord{}, r.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exists {
+		t.Fatal("shared user should be able to read")
+	}
+	fmt.Printf("%+v\n", v)
+
+	// Shared user should NOT be able to delete
+	_, exists, err = wac.DeleteOneById(context.Background(), &PrivateTestRecord{}, r.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exists {
+		t.Fatal("shared user should not be able to delete")
+	}
+}
+
+func TestUpdateBySharedToUser(t *testing.T) {
+	db := NewUnitTestDBProvider()
+	ownerId := NewRecordId()
+	r := newStoredPrivateTestRecord(t, db, ownerId)
+
+	sharedToId := NewRecordId()
+	err := r.ShareTo(context.Background(), db, sharedToId, ownerId)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Shared user should NOT be able to update
+	updated := &PrivateTestRecord{
+		ID:    r.ID,
+		Owner: ownerId,
+		Value: "new value",
+	}
+	wac := WithAccessControl[*PrivateTestRecord]{Database: db, AccessControlUser: sharedToId}
+	err = wac.UpdateOneById(context.Background(), updated)
+	if err == nil {
+		t.Fatal("shared user should not be able to update")
+	}
+}
+
+func TestGetOneBySharedToUser(t *testing.T) {
+	db := NewUnitTestDBProvider()
+	ownerId := NewRecordId()
+	r := newStoredPrivateTestRecord(t, db, ownerId)
+
+	sharedToId := NewRecordId()
+	err := r.ShareTo(context.Background(), db, sharedToId, ownerId)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wac := WithAccessControl[*PrivateTestRecord]{Database: db, AccessControlUser: sharedToId}
+	v, exists, err := wac.GetOneById(context.Background(), &PrivateTestRecord{}, r.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exists {
+		t.Fatal("shared user should be able to read")
+	}
+	fmt.Printf("%+v\n", v)
+}
+
+func TestUpdateOneBySharedToUser(t *testing.T) {
+	db := NewUnitTestDBProvider()
+	ownerId := NewRecordId()
+	r := newStoredPrivateTestRecord(t, db, ownerId)
+
+	// Share the record
+	sharedToId := NewRecordId()
+	err := r.ShareTo(context.Background(), db, sharedToId, ownerId)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Shared user tries to update - should fail
+	updated := &PrivateTestRecord{
+		ID:    r.ID,
+		Owner: ownerId,
+		Value: "updated by shared user",
+	}
+	wac := WithAccessControl[*PrivateTestRecord]{Database: db, AccessControlUser: sharedToId}
+	err = wac.UpdateOneById(context.Background(), updated)
+	if err == nil {
+		t.Fatal("shared user should not be able to update")
+	}
+}
+
+func TestGetOneIdDoesNotExist(t *testing.T) {
+	db := NewUnitTestDBProvider()
+	ownerId := NewRecordId()
+	newStoredPrivateTestRecord(t, db, ownerId)
+
+	wac := WithAccessControl[*PrivateTestRecord]{Database: db, AccessControlUser: ownerId}
+	_, exists, err := wac.GetOneById(context.Background(), &PrivateTestRecord{}, NewRecordId())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exists {
+		t.Fatal("should not exist for non-existent ID")
+	}
+}
+
+func TestGetAllWithMultipleOwners(t *testing.T) {
+	db := NewUnitTestDBProvider()
+	owner1 := NewRecordId()
+	owner2 := NewRecordId()
+	owner3 := NewRecordId()
+
+	newStoredPrivateTestRecord(t, db, owner1)
+	newStoredPrivateTestRecord(t, db, owner1)
+	newStoredPrivateTestRecord(t, db, owner2)
+	newStoredPrivateTestRecord(t, db, owner3)
+
+	wac := WithAccessControl[*PrivateTestRecord]{Database: db, AccessControlUser: owner1}
+	results, err := wac.GetAll(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 records for owner1, got %d", len(results))
+	}
+}
+
+func TestDeleteBySysAdmin(t *testing.T) {
+	db := NewUnitTestDBProvider()
+	ownerId := NewRecordId()
+	r := newStoredPrivateTestRecord(t, db, ownerId)
+
+	sysAdminId := NewRecordId()
+	SysAdminCheck = func(ctx context.Context, db DatabaseProvider, c RecordId) (bool, error) {
+		return c == sysAdminId, nil
+	}
+
+	wac := WithAccessControl[*PrivateTestRecord]{Database: db, AccessControlUser: sysAdminId}
+	v, exists, err := wac.DeleteOneById(context.Background(), &PrivateTestRecord{}, r.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exists {
+		t.Fatal("sys admin should be able to delete")
+	}
+	fmt.Printf("%+v\n", v)
+}

--- a/common/unique_constraint_test.go
+++ b/common/unique_constraint_test.go
@@ -138,3 +138,148 @@ func TestSelfUpdateWithUniqueConstraint(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestUniqueConstraintNoExistingRecords(t *testing.T) {
+	db := NewUnitTestDBProvider()
+
+	record1 := testUnique{
+		RecordId:     1,
+		ReferenceId1: 2,
+		ReferenceId2: 3,
+	}
+	_, err := CreateOne(context.Background(), db, &record1)
+	if err != nil {
+		t.Fatal("should succeed when no existing records")
+	}
+}
+
+func TestUniqueConstraintSameRecordUpdate(t *testing.T) {
+	db := NewUnitTestDBProvider()
+	record1 := testUnique{
+		RecordId:     1,
+		ReferenceId1: 2,
+		ReferenceId2: 3,
+	}
+	v, err := CreateOne(context.Background(), db, &record1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Update with same values (should succeed since it's the same record)
+	update := testUnique{
+		RecordId:     v.RecordId,
+		ReferenceId1: 2,
+		ReferenceId2: 3,
+	}
+	err = UpdateOne(context.Background(), db, &update)
+	if err != nil {
+		t.Fatal("updating to same values should succeed")
+	}
+}
+
+func TestUniqueConstraintPartialMatch(t *testing.T) {
+	db := NewUnitTestDBProvider()
+
+	record1 := testUnique{
+		RecordId:     1,
+		ReferenceId1: 2,
+		ReferenceId2: 3,
+	}
+	_, err := CreateOne(context.Background(), db, &record1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Only ReferenceId1 matches - should succeed
+	record2 := testUnique{
+		RecordId:     2,
+		ReferenceId1: 2,
+		ReferenceId2: 99,
+	}
+	_, err = CreateOne(context.Background(), db, &record2)
+	if err != nil {
+		t.Fatal("partial match should succeed")
+	}
+
+	// Only ReferenceId2 matches - should succeed
+	record3 := testUnique{
+		RecordId:     3,
+		ReferenceId1: 99,
+		ReferenceId2: 3,
+	}
+	_, err = CreateOne(context.Background(), db, &record3)
+	if err != nil {
+		t.Fatal("partial match should succeed")
+	}
+}
+
+func TestUniqueConstraintMultipleDuplicates(t *testing.T) {
+	db := NewUnitTestDBProvider()
+
+	record1 := testUnique{
+		RecordId:     1,
+		ReferenceId1: 100,
+		ReferenceId2: 200,
+	}
+	_, err := CreateOne(context.Background(), db, &record1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// First duplicate attempt
+	record2 := testUnique{
+		RecordId:     2,
+		ReferenceId1: 100,
+		ReferenceId2: 200,
+	}
+	_, err = CreateOne(context.Background(), db, &record2)
+	if err == nil {
+		t.Fatal("first duplicate should fail")
+	}
+
+	// Second duplicate attempt with different ID
+	record3 := testUnique{
+		RecordId:     3,
+		ReferenceId1: 100,
+		ReferenceId2: 200,
+	}
+	_, err = CreateOne(context.Background(), db, &record3)
+	if err == nil {
+		t.Fatal("second duplicate should fail")
+	}
+}
+
+func TestUniqueConstraintUpdateToSelfUnique(t *testing.T) {
+	db := NewUnitTestDBProvider()
+
+	record1 := testUnique{
+		RecordId:     1,
+		ReferenceId1: 100,
+		ReferenceId2: 200,
+	}
+	v1, err := CreateOne(context.Background(), db, &record1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	record2 := testUnique{
+		RecordId:     2,
+		ReferenceId1: 300,
+		ReferenceId2: 400,
+	}
+	v2, err := CreateOne(context.Background(), db, &record2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Update record2 to match record1's values (should fail)
+	update := testUnique{
+		RecordId:     v2.RecordId,
+		ReferenceId1: v1.ReferenceId1,
+		ReferenceId2: v1.ReferenceId2,
+	}
+	err = UpdateOne(context.Background(), db, &update)
+	if err == nil {
+		t.Fatal("updating to match another record's unique values should fail")
+	}
+}

--- a/common/validatable_test.go
+++ b/common/validatable_test.go
@@ -1,0 +1,147 @@
+package common
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+type staticFailRecord struct {
+	ID    RecordId
+	Value string
+}
+
+func (s *staticFailRecord) GetOwner() RecordId {
+	return InvalidRecordId
+}
+
+func (s *staticFailRecord) SetOwner(recordId RecordId) {}
+
+func (s *staticFailRecord) Type() string {
+	return "static_fail"
+}
+
+func (s *staticFailRecord) GetId() RecordId {
+	return s.ID
+}
+
+func (s *staticFailRecord) SetId(id RecordId) {
+	s.ID = id
+}
+
+func (s *staticFailRecord) EditableBy(_ context.Context, db DatabaseProvider) []RecordId {
+	return nil
+}
+
+func (s *staticFailRecord) AccessibleTo(_ context.Context, db DatabaseProvider) []RecordId {
+	return nil
+}
+
+func (s *staticFailRecord) StaticallyValid() error {
+	if s.Value == "" {
+		return fmt.Errorf("value is required")
+	}
+	return nil
+}
+
+func (s *staticFailRecord) DynamicallyValid(_ context.Context, db DatabaseProvider) error {
+	return nil
+}
+
+func (s *staticFailRecord) BlankRecord() CrudRecord {
+	return new(staticFailRecord)
+}
+
+type dynamicFailRecord struct {
+	ID    RecordId
+	Value string
+}
+
+func (d *dynamicFailRecord) GetOwner() RecordId {
+	return InvalidRecordId
+}
+
+func (d *dynamicFailRecord) SetOwner(recordId RecordId) {}
+
+func (d *dynamicFailRecord) Type() string {
+	return "dynamic_fail"
+}
+
+func (d *dynamicFailRecord) GetId() RecordId {
+	return d.ID
+}
+
+func (d *dynamicFailRecord) SetId(id RecordId) {
+	d.ID = id
+}
+
+func (d *dynamicFailRecord) EditableBy(_ context.Context, db DatabaseProvider) []RecordId {
+	return nil
+}
+
+func (d *dynamicFailRecord) AccessibleTo(_ context.Context, db DatabaseProvider) []RecordId {
+	return nil
+}
+
+func (d *dynamicFailRecord) StaticallyValid() error {
+	return nil
+}
+
+func (d *dynamicFailRecord) DynamicallyValid(_ context.Context, db DatabaseProvider) error {
+	if d.Value == "invalid" {
+		return fmt.Errorf("value cannot be 'invalid'")
+	}
+	return nil
+}
+
+func (d *dynamicFailRecord) BlankRecord() CrudRecord {
+	return new(dynamicFailRecord)
+}
+
+func TestValidateStaticFails(t *testing.T) {
+	db := NewUnitTestDBProvider()
+	record := &staticFailRecord{
+		Value: "",
+	}
+
+	err := Validate(context.Background(), db, record)
+	if err == nil {
+		t.Fatal("expected validation error for empty value")
+	}
+}
+
+func TestValidateDynamicFails(t *testing.T) {
+	db := NewUnitTestDBProvider()
+	record := &dynamicFailRecord{
+		Value: "invalid",
+	}
+
+	err := Validate(context.Background(), db, record)
+	if err == nil {
+		t.Fatal("expected validation error for 'invalid' value")
+	}
+}
+
+func TestValidateBothPass(t *testing.T) {
+	db := NewUnitTestDBProvider()
+	record := &staticFailRecord{
+		Value: "good",
+	}
+
+	err := Validate(context.Background(), db, record)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestValidateDynamicFailsAfterStaticPasses(t *testing.T) {
+	db := NewUnitTestDBProvider()
+	record := &dynamicFailRecord{
+		Value: "invalid",
+	}
+
+	err := Validate(context.Background(), db, record)
+	if err == nil {
+		t.Fatal("expected validation error for 'invalid' value")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -14,14 +14,14 @@ func main() {
 	common.UserType = &model.User{}
 
 	// set up the default database provider
-	common.GlobalDatabaseProvider = common.NewUnitTestDBProvider()
+	db := common.NewUnitTestDBProvider()
 
 	// parse command-line flags
 	parseFlags()
 
 	// seed data for development mode
 	if model.UseDevTokenMode {
-		model.SeedDevData()
+		model.SeedDevData(db)
 	}
 
 	// generate or load JWT key pair
@@ -34,43 +34,44 @@ func main() {
 	api := r.Group("/api")
 
 	// noAuth for self-register
-	createUser := common.RouteFamily[*model.User]{}
+	createUser := common.RouteFamily[*model.User]{DatabaseProvider: db}
 	createUser.Handle(api, route.SelfRegister{})
 
-	whoAmI := common.RouteFamily[*model.User]{UseAuth: true}
+	whoAmI := common.RouteFamily[*model.User]{UseAuth: true, DatabaseProvider: db}
 	whoAmI.Handle(api, route.WhoAmI{})
 
-	api.Handle(common.HttpMethodPost.String(), "/import_users_from_csv", route.HandleCsvImport)
+	importHandler := &route.CsvImportHandler{DatabaseProvider: db}
+	api.Handle(common.HttpMethodPost.String(), "/import_users_from_csv", importHandler.HandleCsvImport)
 
-	startTokenMgr := &model.StartLoginTokenManager{}
+	startTokenMgr := &model.StartLoginTokenManager{DatabaseProvider: db}
 	api.POST("/one_time_password", startTokenMgr.OneTimePassword)
 	api.POST("/token", startTokenMgr.CreateJwtFromOneTimePassword)
 
 	// no auth for get user by ID / get all users functions
 
-	getUsers := common.NewCrudCommon(model.NewUser, false)
+	getUsers := common.NewCrudCommon(model.NewUser, false, db)
 	getUsers.HandleRouteTypes(api, common.CrudWrapperFunctionGetOne, common.CrudWrapperFunctionGetMany)
 
 	// use auth for user deletion / update endpoints
-	updateOrDeleteUsers := common.NewCrudCommon(model.NewUser, true)
+	updateOrDeleteUsers := common.NewCrudCommon(model.NewUser, true, db)
 	updateOrDeleteUsers.HandleRouteTypes(api, common.CrudWrapperFunctionDelete, common.CrudWrapperFunctionUpdate)
 
-	facilities := common.NewCrudCommon(model.NewFacility, true)
+	facilities := common.NewCrudCommon(model.NewFacility, true, db)
 	facilities.HandleRouteTypes(api, common.CrudWrapperFunctionAll...)
 
 	api.GET("/score_counting_types", model.GetScoreCountingTypes)
-	scoringStructures := common.NewCrudCommon(model.NewScoringStructure, true)
+	scoringStructures := common.NewCrudCommon(model.NewScoringStructure, true, db)
 	scoringStructures.HandleRouteTypes(api, common.CrudWrapperFunctionAll...)
 
-	ratings := common.NewCrudCommon(model.NewRating, true)
+	ratings := common.NewCrudCommon(model.NewRating, true, db)
 	ratings.HandleRouteTypes(api, common.CrudWrapperFunctionAll...)
 
-	formats := common.NewCrudCommon(model.NewFormat, true)
+	formats := common.NewCrudCommon(model.NewFormat, true, db)
 	formats.HandleRouteTypes(api, common.CrudWrapperFunctionAll...)
 
 	api.GET("/draft_order_patterns", model.GetDraftOrderPatterns)
 
-	seasonComposite := common.RouteFamily[*model.SeasonComposite]{UseAuth: true}
+	seasonComposite := common.RouteFamily[*model.SeasonComposite]{UseAuth: true, DatabaseProvider: db}
 	seasonComposite.Handle(api, route.GetMySeasons{})
 
 	err = r.Run("127.0.0.1:8080")

--- a/model/dev_data.go
+++ b/model/dev_data.go
@@ -7,11 +7,11 @@ import (
 	"time"
 )
 
-func SeedDevData() {
-	user := seedDevUsers()
-	seedDevScoringStructures(user.ID)
-	seedDevRatings(user.ID)
-	seedDevFormat(user.ID)
+func SeedDevData(db common.DatabaseProvider) {
+	user := seedDevUsers(db)
+	seedDevScoringStructures(db, user.ID)
+	seedDevRatings(db, user.ID)
+	seedDevFormat(db, user.ID)
 }
 
 func getDevContext() context.Context {
@@ -20,7 +20,7 @@ func getDevContext() context.Context {
 	return ctx
 }
 
-func seedDevUsers() *User {
+func seedDevUsers(db common.DatabaseProvider) *User {
 	user1 := NewUser()
 	user1.FirstName = "JD"
 	user1.LastName = "Arthur"
@@ -29,14 +29,14 @@ func seedDevUsers() *User {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	v, err := common.CreateOne(ctx, common.GlobalDatabaseProvider, user1)
+	v, err := common.CreateOne(ctx, db, user1)
 	if err != nil {
 		panic(err)
 	}
 	return v
 }
 
-func seedDevScoringStructures(u UserId) {
+func seedDevScoringStructures(db common.DatabaseProvider, u UserId) {
 	ctx := getDevContext()
 	scoringStructure := NewScoringStructure()
 	scoringStructure.Name = "Tennis standard set"
@@ -48,7 +48,7 @@ func seedDevScoringStructures(u UserId) {
 		InstantWinThreshold: 7,
 	}
 
-	v, err := common.CreateOne(ctx, common.GlobalDatabaseProvider, scoringStructure)
+	v, err := common.CreateOne(ctx, db, scoringStructure)
 	if err != nil {
 		panic(err)
 	}
@@ -65,7 +65,7 @@ func seedDevScoringStructures(u UserId) {
 		v.ID, v.ID, v.ID,
 	}
 
-	_, err = common.CreateOne(ctx, common.GlobalDatabaseProvider, scoringStructure2)
+	_, err = common.CreateOne(ctx, db, scoringStructure2)
 	if err != nil {
 		panic(err)
 	}
@@ -75,14 +75,14 @@ var MensOne = "Men's 1"
 var MensTwo = "Men's 2"
 var MensThree = "Men's 3"
 
-func seedDevRatings(u UserId) {
+func seedDevRatings(db common.DatabaseProvider, u UserId) {
 	ctx := getDevContext()
 	r := NewRating()
 	r.UserId = u
 	r.Name = MensOne
 	r.Description = RatingOne
 
-	_, err := common.CreateOne(ctx, common.GlobalDatabaseProvider, r)
+	_, err := common.CreateOne(ctx, db, r)
 	if err != nil {
 		panic(err)
 	}
@@ -92,7 +92,7 @@ func seedDevRatings(u UserId) {
 	r.Name = MensTwo
 	r.Description = RatingTwo
 
-	_, err = common.CreateOne(ctx, common.GlobalDatabaseProvider, r)
+	_, err = common.CreateOne(ctx, db, r)
 	if err != nil {
 		panic(err)
 	}
@@ -102,15 +102,15 @@ func seedDevRatings(u UserId) {
 	r.Name = MensThree
 	r.Description = RatingThree
 
-	_, err = common.CreateOne(ctx, common.GlobalDatabaseProvider, r)
+	_, err = common.CreateOne(ctx, db, r)
 	if err != nil {
 		panic(err)
 	}
 }
 
-func seedDevFormat(u UserId) {
+func seedDevFormat(db common.DatabaseProvider, u UserId) {
 	ctx := getDevContext()
-	ratings, err := common.GetAll[*Rating](ctx, common.GlobalDatabaseProvider)
+	ratings, err := common.GetAll[*Rating](ctx, db)
 	if err != nil {
 		panic(err)
 	}
@@ -137,7 +137,7 @@ func seedDevFormat(u UserId) {
 
 	}
 
-	_, err = common.CreateOne(ctx, common.GlobalDatabaseProvider, format)
+	_, err = common.CreateOne(ctx, db, format)
 	if err != nil {
 		panic(err)
 	}

--- a/model/start_login.go
+++ b/model/start_login.go
@@ -121,7 +121,8 @@ func (l *LoginToken) DynamicallyValid(ctx context.Context, db common.DatabasePro
 }
 
 type StartLoginTokenManager struct {
-	tokens sync.Map // map[string]*LoginToken
+	tokens           sync.Map // map[string]*LoginToken
+	DatabaseProvider common.DatabaseProvider
 }
 
 func (m *StartLoginTokenManager) GetToken(token string) (*LoginToken, bool) {
@@ -245,7 +246,6 @@ type LoginResponse struct {
 
 func (m *StartLoginTokenManager) OneTimePassword(c *gin.Context) {
 
-	db := common.GlobalDatabaseProvider
 	request := &RequestForLoginToken{}
 	err := c.Bind(request)
 	if err != nil {
@@ -255,7 +255,7 @@ func (m *StartLoginTokenManager) OneTimePassword(c *gin.Context) {
 
 	fmt.Println(request)
 
-	token, doesNotExist, err := m.RequestToken(c.Request.Context(), db, request)
+	token, doesNotExist, err := m.RequestToken(c.Request.Context(), m.DatabaseProvider, request)
 	if err != nil {
 		code := http.StatusInternalServerError
 		if doesNotExist {

--- a/route/user_from_csv.go
+++ b/route/user_from_csv.go
@@ -15,7 +15,11 @@ type CsvImportResult struct {
 	AlreadyExisting []*model.User
 }
 
-func HandleCsvImport(c *gin.Context) {
+type CsvImportHandler struct {
+	DatabaseProvider common.DatabaseProvider
+}
+
+func (h *CsvImportHandler) HandleCsvImport(c *gin.Context) {
 	v, ok := c.GetPostForm("file")
 	if !ok {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "form file not provided"})
@@ -28,7 +32,7 @@ func HandleCsvImport(c *gin.Context) {
 		return
 	}
 
-	created, existing, err := model.ParseAndCreateCsvUsers(c.Request.Context(), common.GlobalDatabaseProvider, userList)
+	created, existing, err := model.ParseAndCreateCsvUsers(c.Request.Context(), h.DatabaseProvider, userList)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return


### PR DESCRIPTION
# Remove GlobalDatabaseProvider and Inject DatabaseProvider Explicitly

## Summary

Refactors the codebase to remove the `common.GlobalDatabaseProvider` global variable and replace it with explicit `DatabaseProvider` injection through function signatures and struct fields. This improves testability, makes dependencies clear, and follows dependency injection best practices.

Also adds comprehensive unit tests to the `common/` directory covering edge cases that were previously untested.

## Changes

### Core Refactoring

#### `common/database_provider.go`
- Removed the `GlobalDatabaseProvider` global variable
- Fixed `GetAllWhere[T]` to handle `nil` where functions without panicking

#### `common/api_auth.go`
- `GetToken(c *gin.Context)` → `GetToken(c *gin.Context, db DatabaseProvider)`
- Now requires an explicit `DatabaseProvider` parameter instead of using the global

#### `common/api_route.go`
- Removed the fallback in `RouteFamily.Handle()` that defaulted to `GlobalDatabaseProvider`
- `routeWrapper.Handle()` now passes `r.Database` to `GetToken()`

#### `common/crud_common.go`
- `NewCrudCommon[T](createFunc, userAuth)` → `NewCrudCommon[T](createFunc, userAuth, db)`
- DatabaseProvider is now required as a parameter

#### `model/start_login.go`
- `StartLoginTokenManager` struct now has a `DatabaseProvider` field
- `OneTimePassword()` method uses `m.DatabaseProvider` instead of the global

#### `model/dev_data.go`
- `SeedDevData()` → `SeedDevData(db DatabaseProvider)`
- All seed sub-functions (`seedDevUsers`, `seedDevScoringStructures`, `seedDevRatings`, `seedDevFormat`) now take `db` as a parameter

#### `route/user_from_csv.go`
- Converted standalone `HandleCsvImport(c *gin.Context)` function to a struct-based handler:
  ```go
  type CsvImportHandler struct {
      DatabaseProvider common.DatabaseProvider
  }
  func (h *CsvImportHandler) HandleCsvImport(c *gin.Context)
  ```

#### `main.go`
- Single `db` instance created once at startup via `common.NewUnitTestDBProvider()`
- All route handlers, `CrudCommon` instances, and `RouteFamily` instances now receive `db` explicitly
- Removed `common.GlobalDatabaseProvider = common.NewUnitTestDBProvider()` initialization

### New Unit Tests

#### `common/crud_record_test.go` (14 tests)
- `TestNewRecordIdGeneratesUniqueIds`
- `TestNewRecordIdNeverGeneratesUnavailableIds`
- `TestRecordIdValidRecordId`
- `TestRecordIdString`
- `TestRecordIdFromString`
- `TestRecordIdMarshalJSON` / `TestRecordIdUnmarshalJSON`
- `TestUnmarshalStringIdList` / `TestUnmarshalStringIdListInvalid`
- `TestSysAdminAndUsers` / `TestSysAdminAndUsersEmpty`
- `TestTimestampedRecordCreateTimestamp` / `TestTimestampedRecordUpdateTimestampOnUpdate`
- `TestRecordIdUint64`

#### `common/crud_common_test.go` (16 tests)
- `TestNewCrudCommon` / `TestNewCrudCommonNoAuth`
- `TestCrudCommonCreateMissingToken` / `TestCrudCommonCreateSuccess` / `TestCrudCommonCreateEmptyValue`
- `TestCrudCommonGetOneSuccess` / `TestCrudCommonGetOneNotFound` / `TestCrudCommonGetOneAccessibleToEveryone`
- `TestCrudCommonGetAllSuccess`
- `TestCrudCommonDeleteSuccess` / `TestCrudCommonDeleteMissingToken` / `TestCrudCommonDeleteNotFound` / `TestCrudCommonDeleteUnauthorized`
- `TestCrudCommonUpdateSuccess` / `TestCrudCommonUpdateMissingToken`
- `TestCrudCommonHandleRouteTypesPanicOnNilCreateRecord`

#### `common/api_route_test.go` (13 tests)
- `TestRouteFamilyHandle` / `TestRouteFamilyWithAuth` / `TestRouteFamilyMultipleRoutes`
- `TestRouteWrapperHandleNoAuth` / `TestRouteWrapperHandleWithPathId` / `TestRouteWrapperHandleWithBody`
- `TestRouteFamilyWithMiddleware`
- `TestAppendPathId` / `TestHttpMethodString` / `TestHttpMethodValid`
- `TestApiRequestParseQuery` / `TestApiRequestParseQueryEmpty`
- `TestRouteFamilyDatabaseProviderSetOnWrappers`

#### `common/database_provider_test.go` (16 new tests added)
- `TestGetOneByIdSuccess` / `TestGetOneByIdNotFound`
- `TestGetExistingRecordByIdSuccess` / `TestGetExistingRecordByIdNotFound`
- `TestExistsByIdExists` / `TestExistsByIdNotFound`
- `TestGetAllEmpty` / `TestGetAllWithRecords` / `TestGetAllDifferentTypes`
- `TestGetAllWhereWithFilter` / `TestGetAllWhereNoResults` / `TestGetAllWhereNilFilter`
- `TestDeleteOneByIdSuccess` / `TestDeleteOneByIdNotFound` / `TestDeleteOneByIdDoubleDelete`
- `TestUpdateOneBasic` / `TestUpdateOneNotFound`
- `TestCreateOneWithPreSetId` / `TestCreateOneGeneratesNewId`
- `TestCrudRecordBlankRecord`

#### `common/db_with_access_control_test.go` (13 new tests added)
- `TestGetAllByOwner` / `TestGetAllByUnauthorizedUser` / `TestGetAllBySysAdmin`
- `TestDeleteOneByIdNotFoundNonOwner` / `TestUpdateOneByIdNotFound`
- `TestDeleteBySharedToUser` / `TestUpdateBySharedToUser` / `TestGetOneBySharedToUser`
- `TestGetOneIdDoesNotExist`
- `TestGetAllWithMultipleOwners`
- `TestDeleteBySysAdmin`

#### `common/unique_constraint_test.go` (5 new tests)
- `TestUniqueConstraintNoExistingRecords`
- `TestUniqueConstraintSameRecordUpdate`
- `TestUniqueConstraintPartialMatch`
- `TestUniqueConstraintMultipleDuplicates`
- `TestUniqueConstraintUpdateToSelfUnique`

#### `common/validatable_test.go` (4 tests)
- `TestValidateStaticFails`
- `TestValidateDynamicFails`
- `TestValidateBothPass`
- `TestValidateDynamicFailsAfterStaticPasses`

#### `common/api_auth_test.go` (4 new tests)
- `TestValidateTokenTampered`
- `TestValidateTokenMalformed`
- `TestValidateTokenEmpty`
- `TestGenerateTokenDifferentUsers`

## Testing

All tests pass:
```
?       intraclub       [no test files]
ok      intraclub/common        0.041s
ok      intraclub/model 0.296s
?       intraclub/route   [no test files]
```

## Breaking Changes

- `NewCrudCommon[T]` now requires a `DatabaseProvider` parameter
- `GetToken(c *gin.Context)` now requires a `DatabaseProvider` parameter
- `SeedDevData()` now requires a `DatabaseProvider` parameter
- `CsvImportHandler` is now a struct instead of a standalone function — update route registration accordingly:
  ```go
  // Before:
  api.Handle("POST", "/import_users_from_csv", route.HandleCsvImport)
  
  // After:
  importHandler := &route.CsvImportHandler{DatabaseProvider: db}
  api.Handle("POST", "/import_users_from_csv", importHandler.HandleCsvImport)
  ```

## Motivation

1. **Testability**: Global state makes unit testing harder. Explicit dependencies allow injecting mock database providers in tests.
2. **Clarity**: Dependencies are now visible in function signatures and struct fields, making the code easier to understand and maintain.
3. **Flexibility**: Different routes can use different database providers if needed (e.g., read replicas).
4. **Bug fix**: The `GetAllWhere` nil where function panic was also fixed as part of this refactor.