### PR TITLE
refactor authorizable to use UserId references + add auth overview doc

### DIFF
--- a/api/api_auth.go
+++ b/api/api_auth.go
@@ -27,7 +27,7 @@ var JwtPublicKey *ecdsa.PublicKey
 var JwtPrivateKey *ecdsa.PrivateKey
 
 type AuthToken struct {
-	UserId database.RecordId
+	UserId database.UserId
 }
 
 func GenerateToken(userId database.RecordId) (string, error) {
@@ -70,7 +70,7 @@ func ValidateToken(token string) (*AuthToken, error) {
 	}
 
 	return &AuthToken{
-		UserId: userId,
+		UserId: database.UserId(userId),
 	}, nil
 }
 
@@ -88,7 +88,7 @@ func GetToken(c *gin.Context, db database.DatabaseProvider) (*AuthToken, error) 
 
 	userId := valid.UserId
 	if db != nil && UserType != nil {
-		err := database.ExistsById(c.Request.Context(), db, UserType, userId)
+		err := database.ExistsById(c.Request.Context(), db, UserType, userId.RecordId())
 		if err != nil {
 			return nil, err
 		}

--- a/api/api_auth_test.go
+++ b/api/api_auth_test.go
@@ -51,7 +51,7 @@ func TestCreateToken(t *testing.T) {
 		t.Fatalf("ValidateToken failed: %v", err)
 	}
 
-	if at.UserId != userId {
+	if at.UserId != database.UserId(userId) {
 		t.Fatalf("token2.Owner != userId")
 	}
 
@@ -121,10 +121,10 @@ func TestGenerateTokenDifferentUsers(t *testing.T) {
 		t.Fatalf("ValidateToken for token2 failed: %v", err)
 	}
 
-	if at1.UserId != userId1 {
+	if at1.UserId != database.UserId(userId1) {
 		t.Fatalf("token1.UserId != userId1")
 	}
-	if at2.UserId != userId2 {
+	if at2.UserId != database.UserId(userId2) {
 		t.Fatalf("token2.UserId != userId2")
 	}
 	if token1 == token2 {

--- a/api/api_route_test.go
+++ b/api/api_route_test.go
@@ -19,11 +19,11 @@ type testRouteRecord struct {
 	Value string
 }
 
-func (t *testRouteRecord) GetOwner() database.RecordId {
-	return database.InvalidRecordId
+func (t *testRouteRecord) GetOwner() database.UserId {
+	return database.InvalidUserId
 }
 
-func (t *testRouteRecord) SetOwner(recordId database.RecordId) {}
+func (t *testRouteRecord) SetOwner(userId database.UserId) {}
 
 func (t *testRouteRecord) Type() string {
 	return "test_route"
@@ -37,11 +37,11 @@ func (t *testRouteRecord) SetId(id database.RecordId) {
 	t.ID = id
 }
 
-func (t *testRouteRecord) EditableBy(_ context.Context, db database.DatabaseProvider) []database.RecordId {
+func (t *testRouteRecord) EditableBy(_ context.Context, db database.DatabaseProvider) []database.UserId {
 	return nil
 }
 
-func (t *testRouteRecord) AccessibleTo(_ context.Context, db database.DatabaseProvider) []database.RecordId {
+func (t *testRouteRecord) AccessibleTo(_ context.Context, db database.DatabaseProvider) []database.UserId {
 	return nil
 }
 

--- a/api/authorization.md
+++ b/api/authorization.md
@@ -1,0 +1,131 @@
+# Authorization model
+
+This document describes the authorization rules for user access and edit rights
+on object in the provisioning database. As a summary:
+- Each `CrudRecord` has an individual `UserId` as an owner and the _owner_ of a 
+  record has inherent ability to access, edit and delete their own records
+- Some higher-level grouping constructs such as `Team`s and `Season`s define the 
+  rules around access to particular record types such as `Availability` or `Lineup`
+- Some special roles such as `Commissioner`, `Captain` and `SysAdmin` allow an 
+  individual `User` elevated rights to perform specific modification actions
+
+## Database-level
+ - [x] The `Authorizable` interface is embedded into the `CrudRecord` type
+ - [x] This interface defines the `GetOwner` / `SetOwner` type, which is an individual
+   `UserId` corresponding to the `User` who created this record.
+ - [ ] This `UserId` is generally intended to be immutable, but the `SysAdmin` role may
+   have rights to change this field if need be
+    - e.g. to reassign ownership of a `Season` to a new `Commissioner` during season play
+    - However, even the `UserId` themselves that owns a record should not usually be able to do this
+ - [x] The `EditableBy` field on the `Authorizable` interface allows the business logic to
+   determine which `UserId` values can edit a `CrudRecord` at API-time
+    - For example, this can be used in API middleware to prevent updates to a `Season` by non-commissioners   
+ - [x] The `AccessibleTo` field on the `Authorizable` interface implements the corresponding logic for
+    access rights.
+    - E.g. some information like `Availability` is private from a viewing perspective to the `Team` that
+      it pertains to only.
+ - In general, the `GetOwner` / `SetOwner` logic is boilerplate in the database layer, but the logic
+   in `EditableBy` and `AccessibleTo` is defined on a record-by-record basis.
+    - This allows us to cleanly specify the business logic in-place w/ easy unit testing
+
+## Record-specific rules
+The types in the `model` directory implement all the specific `CrudRecord`s for the application
+
+### Common access logic
+- `captain_viewable`: a record that is `EditableBy` a `Season`'s `commissioner`, and viewable by the `Season`'s  `captain`s
+   - examples are `Draft` and `CommissionerProposal`  
+- `team_viewable`: a record that is viewable by members of a `Team` only
+   - examples are `Availability` and `Lineup`s
+- `user_modifiable_only`: a record that may only be modified by the record's owner
+   - these are typically root types, e.g.  `facility`, `format`, `rating`, etc. that higher level types like `Draft` are composed of
+
+### Base types
+- `availability`: a `User`'s availability for a given `Week` in a `Season` 
+   - `team_viewable` access rights
+- `blurb`: a weekly summary or other league communication from the `Commissioner` or designated reporter for a `Season`
+   - A `blurb` may only be created by a `Season`'s commissioner or designated `Reporter`(s)
+   - A `blurb` may only be edited after-the-fact by the same
+- `comment`: a `User`-supplied comment on a `blurb`
+    - A `comment` may only be created by a player participating in a `Season`
+    - A `comment` may be deleted (but not _edited_) by the `Commissioner` or `Reporter` on a season
+- `commissioner_proposal`: a mid-`Season` proposal from the commissioner to captains for a rule change
+    - `captain_viewable` access rules
+- `facility`: a physical location that a `Season` is played out of
+    - `user_modifiable_only` access rules
+    - Cannot be deleted after it is in use somewhere
+- `format`: a matchup format for a `Season` (e.g. the `rating`s and `line`s that are played)
+    - `user_modifiable_only` access rules
+    - Cannot be deleted (or modified) after it is in use somewhere
+- `individual_match`: the results of a single match during `Season` play
+    - this type is globally viewable without authorization
+    - Can only be edited by designees (e.g. the `Match` participants, `captain`s, `commissioner`, etc.)
+- `lineup`: a _planned_ set of players participating in a single `matchup` during `Season` play
+    - `team_viewable` access rules
+    - this type is copied into the globally-viewable `matchup` type before play begins
+- `matchup`: the _real_ players participating in a single `matchup` during `Season` play
+    - this type is globally viewable without authorization
+    - Can only be edited by captains and commissioners after creation (e.g. for substitutions)
+- `photo`: a photograph attached to a `blurb`
+    - `user_modifiable_only` access rules  
+- `playoff_structure`: a format for playoffs after the conclusion of the regular season portion of a `Season`
+    - `user_modifiable_only` access rules
+- `pre_draft_grade`: a `User` rating of another `User` for `Draft` pool calibration purposes
+    - `user_modifiable_only` access rules
+    - we might need to maintain a `draft_grader` assignment table to control who can create `pre_draft_grade`s for a `Draft`
+- `rating`: a description type defining the different levels present in a given `Format`
+    - `user_modifiable_only` access rules
+    - globally accessible without authorization
+    - cannot be deleted or modified after it's in-use
+- `reaction`: a `User`-supplied emoji reaction to a `blurb` or a `comment` on a blurb
+    - same rules as a `comment`
+- `rule_amendment`: a modification to some portion of a `ruleset`
+    - rule amendments can only be created by the owner of a `ruleset`
+    - amendments are viewable in the same way as `ruleset`s
+- `ruleset`: a set of league rules that is in-use for one or many `Season`s
+    - these are composed of `ruleset_section`s with the same rights
+    - `user_modifiable_only` access rules
+    - generally these would be created by the `commissioner` of a `Season`, but not necessarily so
+- `scoring_structure`: a scoring format for individual `match` play
+    - `user_modifiable_only` access rules
+    - can not be edited or deleted after creation
+- `skill_info`: a `User`-supplied rating of ones own skill (e.g. from playing on an ALTA team or USTA self-rating)
+    - `user_modifiable_only` access rights
+- `user`: an individual person who uses the application and participates in `Season`s
+    - `user_modifiable_only`
+    - this is a very important base type for almost all access rules
+- `week` a date-and-time where a week of play occurs during a `Season`
+    - this is used as a reference type for `Season` `Matchup`s and individual `Lineup` and `Availability` records
+    - only editable by the commissioner
+
+### Meta / grouping types
+- `draft`: a type corresponding to the actual draft event for a `Season`
+    - `captain_viewable` access rules
+- `schedule`: a list of `Matchup`s during a `Season`
+    - editable only by `commissioner`, and likely not so after `Season` begins
+    - viewable by all
+- `season`: a complete season of play, the highest level grouping type in the application
+    - editable only by the `commissioner`
+    - this is created automatically when finalizing the `draft`
+- `team`: an individual team competing in a given `Season`
+    - members, roles and rating are publicly viewable
+    - only editable by the commissioner
+    - `co_captain`s can be managed by the `captain` of a `team
+    - this grouping controls the `team_viewable` access-and-edit logic
+
+
+### Join-table types
+Join table types assign from one table to another and generally have their own boilerplate logic.
+
+These types are not typically exposed as a raw `CrudRecord` type in the API but are rather viewed
+and edited by business logic on another type. For example, the `TeamAssignment` type manages the 
+`User`s who are members (and `captain`s / `co_captain`s) of a particular `Team`.
+
+- `draft_captain`: an assignment of a `captain` to a `Team` inside a single `Draft` w/ draft position
+- `draft_available_plater`: an assignment of a `User` as a draftable player in a `Draft` pool
+- `draft_pick`: a selected player at a particular position in a `Draft`
+- `season_commissioner`: the owner / administrator of a particular `Season`
+- `season_late_add`: a late-added participant into a `season`
+- `player`: a `User` who is participating as a player in a `season`
+- `season_captain`: a `User` who is acting as a captain in a `draft` and subsequent `season`
+- `team_match`: a home-and-away assignment of `Lineup`s in a given `Week` in a `Season`
+- `weekly_matchup`: an assignment of which teams play who during a `Week` in a `Season`

--- a/api/crud_common.go
+++ b/api/crud_common.go
@@ -231,8 +231,8 @@ func (c *CrudCommon[T]) HandleRouteTypes(e *gin.RouterGroup, crudRouteTypes ...C
 	f.Handle(e, routes...)
 }
 
-func getTokenUserIdIfExists[T database.CrudRecord](req ApiRequest[T]) database.RecordId {
-	userId := database.InvalidRecordId
+func getTokenUserIdIfExists[T database.CrudRecord](req ApiRequest[T]) database.UserId {
+	userId := database.InvalidUserId
 	if req.Token != nil {
 		userId = req.Token.UserId
 	}

--- a/api/crud_common_test.go
+++ b/api/crud_common_test.go
@@ -14,18 +14,18 @@ import (
 
 type testCrudRecord struct {
 	ID        database.RecordId
-	Owner     database.RecordId
+	Owner     database.UserId
 	Value     string
 	CreatedAt time.Time
 	UpdatedAt time.Time
 }
 
-func (t *testCrudRecord) GetOwner() database.RecordId {
+func (t *testCrudRecord) GetOwner() database.UserId {
 	return t.Owner
 }
 
-func (t *testCrudRecord) SetOwner(recordId database.RecordId) {
-	t.Owner = recordId
+func (t *testCrudRecord) SetOwner(userId database.UserId) {
+	t.Owner = userId
 }
 
 func newTestCrudRecord() *testCrudRecord {
@@ -47,11 +47,11 @@ func (t *testCrudRecord) SetId(id database.RecordId) {
 	t.ID = id
 }
 
-func (t *testCrudRecord) EditableBy(_ context.Context, db database.DatabaseProvider) []database.RecordId {
-	return []database.RecordId{t.Owner, database.SysAdminRecordId}
+func (t *testCrudRecord) EditableBy(_ context.Context, db database.DatabaseProvider) []database.UserId {
+	return []database.UserId{t.Owner, database.SysAdminUserId}
 }
 
-func (t *testCrudRecord) AccessibleTo(_ context.Context, db database.DatabaseProvider) []database.RecordId {
+func (t *testCrudRecord) AccessibleTo(_ context.Context, db database.DatabaseProvider) []database.UserId {
 	return database.AccessibleToEveryone
 }
 
@@ -153,7 +153,7 @@ func TestCrudCommonCreateSuccess(t *testing.T) {
 	req := ApiRequest[*testCrudRecord]{
 		Context:          context.Background(),
 		DatabaseProvider: db,
-		Token:            &AuthToken{UserId: ownerId},
+		Token:            &AuthToken{UserId: database.UserId(ownerId)},
 		Body:             newTestCrudRecord(),
 	}
 
@@ -167,7 +167,7 @@ func TestCrudCommonCreateSuccess(t *testing.T) {
 
 	result := resp.(gin.H)
 	resource := result[ResourceKey]
-	if resource.(*testCrudRecord).Owner != ownerId {
+	if resource.(*testCrudRecord).Owner != database.UserId(ownerId) {
 		t.Fatal("Owner should be set from token")
 	}
 	if resource.(*testCrudRecord).ID == database.InvalidRecordId {
@@ -182,7 +182,7 @@ func TestCrudCommonGetOneSuccess(t *testing.T) {
 	// Create a record first
 	ownerId := database.NewRecordId()
 	v := newTestCrudRecord()
-	v.Owner = ownerId
+	v.Owner = database.UserId(ownerId)
 	created, err := database.CreateOne(context.Background(), db, v)
 	if err != nil {
 		t.Fatal(err)
@@ -196,7 +196,7 @@ func TestCrudCommonGetOneSuccess(t *testing.T) {
 	req := ApiRequest[*testCrudRecord]{
 		Context:          context.Background(),
 		DatabaseProvider: db,
-		Token:            &AuthToken{UserId: ownerId},
+		Token:            &AuthToken{UserId: database.UserId(ownerId)},
 		PathId:           created.ID,
 	}
 
@@ -227,7 +227,7 @@ func TestCrudCommonGetOneNotFound(t *testing.T) {
 	req := ApiRequest[*testCrudRecord]{
 		Context:          context.Background(),
 		DatabaseProvider: db,
-		Token:            &AuthToken{UserId: database.NewRecordId()},
+		Token:            &AuthToken{UserId: database.InvalidUserId},
 		PathId:           database.NewRecordId(),
 	}
 
@@ -247,7 +247,7 @@ func TestCrudCommonGetAllSuccess(t *testing.T) {
 	ownerId := database.NewRecordId()
 	for i := 0; i < 3; i++ {
 		v := newTestCrudRecord()
-		v.Owner = ownerId
+		v.Owner = database.UserId(ownerId)
 		_, err := database.CreateOne(context.Background(), db, v)
 		if err != nil {
 			t.Fatal(err)
@@ -262,7 +262,7 @@ func TestCrudCommonGetAllSuccess(t *testing.T) {
 	req := ApiRequest[*testCrudRecord]{
 		Context:          context.Background(),
 		DatabaseProvider: db,
-		Token:            &AuthToken{UserId: ownerId},
+		Token:            &AuthToken{UserId: database.UserId(ownerId)},
 	}
 
 	resp, status, err := route.Handler(req)
@@ -286,7 +286,7 @@ func TestCrudCommonDeleteSuccess(t *testing.T) {
 
 	ownerId := database.NewRecordId()
 	v := newTestCrudRecord()
-	v.Owner = ownerId
+	v.Owner = database.UserId(ownerId)
 	created, err := database.CreateOne(context.Background(), db, v)
 	if err != nil {
 		t.Fatal(err)
@@ -300,7 +300,7 @@ func TestCrudCommonDeleteSuccess(t *testing.T) {
 	req := ApiRequest[*testCrudRecord]{
 		Context:          context.Background(),
 		DatabaseProvider: db,
-		Token:            &AuthToken{UserId: ownerId},
+		Token:            &AuthToken{UserId: database.UserId(ownerId)},
 		PathId:           created.ID,
 	}
 
@@ -357,7 +357,7 @@ func TestCrudCommonDeleteNotFound(t *testing.T) {
 	req := ApiRequest[*testCrudRecord]{
 		Context:          context.Background(),
 		DatabaseProvider: db,
-		Token:            &AuthToken{UserId: ownerId},
+		Token:            &AuthToken{UserId: database.UserId(ownerId)},
 		PathId:           database.NewRecordId(),
 	}
 
@@ -376,7 +376,7 @@ func TestCrudCommonUpdateSuccess(t *testing.T) {
 
 	ownerId := database.NewRecordId()
 	v := newTestCrudRecord()
-	v.Owner = ownerId
+	v.Owner = database.UserId(ownerId)
 	created, err := database.CreateOne(context.Background(), db, v)
 	if err != nil {
 		t.Fatal(err)
@@ -391,11 +391,11 @@ func TestCrudCommonUpdateSuccess(t *testing.T) {
 	req := ApiRequest[*testCrudRecord]{
 		Context:          context.Background(),
 		DatabaseProvider: db,
-		Token:            &AuthToken{UserId: ownerId},
+		Token:            &AuthToken{UserId: database.UserId(ownerId)},
 		PathId:           created.ID,
 		Body: &testCrudRecord{
 			ID:    created.ID,
-			Owner: ownerId,
+			Owner: database.UserId(ownerId),
 			Value: "updated",
 		},
 	}
@@ -456,7 +456,7 @@ func TestCrudCommonCreateEmptyValue(t *testing.T) {
 	req := ApiRequest[*testCrudRecord]{
 		Context:          context.Background(),
 		DatabaseProvider: db,
-		Token:            &AuthToken{UserId: ownerId},
+		Token:            &AuthToken{UserId: database.UserId(ownerId)},
 		Body:             func() *testCrudRecord { r := newTestCrudRecord(); r.Value = ""; return r }(),
 	}
 
@@ -475,7 +475,7 @@ func TestCrudCommonGetOneAccessibleToEveryone(t *testing.T) {
 
 	ownerId := database.NewRecordId()
 	v := newTestCrudRecord()
-	v.Owner = ownerId
+	v.Owner = database.UserId(ownerId)
 	created, err := database.CreateOne(context.Background(), db, v)
 	if err != nil {
 		t.Fatal(err)
@@ -491,7 +491,7 @@ func TestCrudCommonGetOneAccessibleToEveryone(t *testing.T) {
 	req := ApiRequest[*testCrudRecord]{
 		Context:          context.Background(),
 		DatabaseProvider: db,
-		Token:            &AuthToken{UserId: nonOwnerId},
+		Token:            &AuthToken{UserId: database.UserId(nonOwnerId)},
 		PathId:           created.ID,
 	}
 
@@ -510,7 +510,7 @@ func TestCrudCommonDeleteUnauthorized(t *testing.T) {
 
 	ownerId := database.NewRecordId()
 	v := newTestCrudRecord()
-	v.Owner = ownerId
+	v.Owner = database.UserId(ownerId)
 	created, err := database.CreateOne(context.Background(), db, v)
 	if err != nil {
 		t.Fatal(err)
@@ -525,7 +525,7 @@ func TestCrudCommonDeleteUnauthorized(t *testing.T) {
 	req := ApiRequest[*testCrudRecord]{
 		Context:          context.Background(),
 		DatabaseProvider: db,
-		Token:            &AuthToken{UserId: unauthorizedId},
+		Token:            &AuthToken{UserId: database.UserId(unauthorizedId)},
 		PathId:           created.ID,
 	}
 

--- a/database/crud_record.go
+++ b/database/crud_record.go
@@ -92,35 +92,63 @@ func UnmarshalStringIdList(bytes []byte) ([]RecordId, error) {
 	return l2, nil
 }
 
+// UserId is a first-class type representing a user identifier in the system.
+// It is used throughout the authorization and access control subsystems.
+type UserId RecordId
+
+func (id UserId) RecordId() RecordId {
+	return RecordId(id)
+}
+
+func (id UserId) String() string {
+	return RecordId(id).String()
+}
+
+func (id UserId) MarshalJSON() ([]byte, error) {
+	return RecordId(id).MarshalJSON()
+}
+
+func (id *UserId) UnmarshalJSON(bytes []byte) error {
+	v, err := RecordIdFromString(strings.Trim(string(bytes), "\""))
+	if err != nil {
+		return err
+	}
+	*id = UserId(v)
+	return nil
+}
+
 // InvalidRecordId is a special record ID that indicates a value hasn't been set
 var InvalidRecordId = RecordId(0)
 
-// EveryoneRecordId indicates that a CrudRecord is accessible by everyone
-var EveryoneRecordId = RecordId(1)
-var AccessibleToEveryone = []RecordId{EveryoneRecordId}
+// InvalidUserId is a special user ID that indicates a value hasn't been set
+var InvalidUserId = UserId(0)
 
-// SysAdminRecordId indicated that a CrudRecord is accessible / editable by users
-// the model.SystemAdministrator role applied to their model.User record
-var SysAdminRecordId = RecordId(2)
+// EveryoneUserId indicates that a CrudRecord is accessible by everyone
+var EveryoneUserId = UserId(1)
+var AccessibleToEveryone = []UserId{EveryoneUserId}
 
-func SysAdminAndUsers(users ...RecordId) []RecordId {
-	recordIds := make([]RecordId, 0, 1+len(users))
-	recordIds = append(recordIds, SysAdminRecordId)
-	recordIds = append(recordIds, users...)
-	return recordIds
+// SysAdminUserId indicates that a CrudRecord is accessible / editable by users
+// with the SystemAdministrator role applied to their User record
+var SysAdminUserId = UserId(2)
+
+func SysAdminAndUsers(users ...UserId) []UserId {
+	userIds := make([]UserId, 0, 1+len(users))
+	userIds = append(userIds, SysAdminUserId)
+	userIds = append(userIds, users...)
+	return userIds
 }
 
 // unavailableRecordIds is a list of RecordId values that cannot be set
 // in NewRecordId because they have a special meaning in the auth/access logic
 var unavailableRecordIds = []RecordId{
-	InvalidRecordId, EveryoneRecordId, SysAdminRecordId,
+	InvalidRecordId, RecordId(EveryoneUserId), RecordId(SysAdminUserId),
 }
 
 type Authorizable interface {
-	EditableBy(ctx context.Context, db DatabaseProvider) []RecordId
-	AccessibleTo(ctx context.Context, db DatabaseProvider) []RecordId
-	SetOwner(recordId RecordId)
-	GetOwner() RecordId
+	EditableBy(ctx context.Context, db DatabaseProvider) []UserId
+	AccessibleTo(ctx context.Context, db DatabaseProvider) []UserId
+	SetOwner(userId UserId)
+	GetOwner() UserId
 }
 
 type CrudRecord interface {
@@ -142,7 +170,7 @@ type PreUpdate interface {
 
 type CanOnlyDelete interface {
 	CrudRecord
-	CanOnlyDelete(ctx context.Context, db DatabaseProvider, userId RecordId) bool
+	CanOnlyDelete(ctx context.Context, db DatabaseProvider, userId UserId) bool
 }
 
 type PostUpdate interface {

--- a/database/crud_record_test.go
+++ b/database/crud_record_test.go
@@ -24,11 +24,11 @@ func TestNewRecordIdNeverGeneratesUnavailableIds(t *testing.T) {
 		if id == InvalidRecordId {
 			t.Fatal("NewRecordId generated InvalidRecordId")
 		}
-		if id == EveryoneRecordId {
-			t.Fatal("NewRecordId generated EveryoneRecordId")
+		if id == RecordId(EveryoneUserId) {
+			t.Fatal("NewRecordId generated EveryoneUserId")
 		}
-		if id == SysAdminRecordId {
-			t.Fatal("NewRecordId generated SysAdminRecordId")
+		if id == RecordId(SysAdminUserId) {
+			t.Fatal("NewRecordId generated SysAdminUserId")
 		}
 	}
 }
@@ -37,11 +37,11 @@ func TestRecordIdValidRecordId(t *testing.T) {
 	if InvalidRecordId.ValidRecordId() {
 		t.Fatal("InvalidRecordId should not be valid")
 	}
-	if EveryoneRecordId.ValidRecordId() {
-		t.Fatal("EveryoneRecordId should not be valid")
+	if RecordId(EveryoneUserId).ValidRecordId() {
+		t.Fatal("EveryoneUserId should not be valid as RecordId")
 	}
-	if SysAdminRecordId.ValidRecordId() {
-		t.Fatal("SysAdminRecordId should not be valid")
+	if RecordId(SysAdminUserId).ValidRecordId() {
+		t.Fatal("SysAdminUserId should not be valid as RecordId")
 	}
 	id := NewRecordId()
 	if !id.ValidRecordId() {
@@ -167,14 +167,14 @@ func TestUnmarshalStringIdListInvalid(t *testing.T) {
 }
 
 func TestSysAdminAndUsers(t *testing.T) {
-	userId1 := RecordId(100)
-	userId2 := RecordId(200)
+	userId1 := UserId(100)
+	userId2 := UserId(200)
 	result := SysAdminAndUsers(userId1, userId2)
 	if len(result) != 3 {
 		t.Fatalf("Expected 3 IDs, got %d", len(result))
 	}
-	if result[0] != SysAdminRecordId {
-		t.Fatalf("Expected SysAdminRecordId first, got %d", result[0])
+	if result[0] != SysAdminUserId {
+		t.Fatalf("Expected SysAdminUserId first, got %d", result[0])
 	}
 	if result[1] != userId1 {
 		t.Fatalf("Expected userId1 second, got %d", result[1])
@@ -189,8 +189,8 @@ func TestSysAdminAndUsersEmpty(t *testing.T) {
 	if len(result) != 1 {
 		t.Fatalf("Expected 1 ID (sys admin), got %d", len(result))
 	}
-	if result[0] != SysAdminRecordId {
-		t.Fatalf("Expected SysAdminRecordId, got %d", result[0])
+	if result[0] != SysAdminUserId {
+		t.Fatalf("Expected SysAdminUserId, got %d", result[0])
 	}
 }
 

--- a/database/database_provider_test.go
+++ b/database/database_provider_test.go
@@ -9,12 +9,12 @@ import (
 
 type testRecord struct {
 	ID        RecordId
-	Owner     RecordId
+	Owner     UserId
 	CreatedAt time.Time
 	UpdatedAt time.Time
 }
 
-func (t *testRecord) GetOwner() RecordId {
+func (t *testRecord) GetOwner() UserId {
 	return t.Owner
 }
 
@@ -45,16 +45,16 @@ func (t *testRecord) SetId(id RecordId) {
 	t.ID = id
 }
 
-func (t *testRecord) EditableBy(_ context.Context, db DatabaseProvider) []RecordId {
-	return []RecordId{t.Owner}
+func (t *testRecord) EditableBy(_ context.Context, db DatabaseProvider) []UserId {
+	return []UserId{t.Owner}
 }
 
-func (t *testRecord) AccessibleTo(_ context.Context, db DatabaseProvider) []RecordId {
+func (t *testRecord) AccessibleTo(_ context.Context, db DatabaseProvider) []UserId {
 	return AccessibleToEveryone
 }
 
-func (t *testRecord) SetOwner(recordId RecordId) {
-	t.Owner = recordId
+func (t *testRecord) SetOwner(userId UserId) {
+	t.Owner = userId
 }
 
 func (t *testRecord) StaticallyValid() error {
@@ -239,8 +239,8 @@ func TestGetAllWithRecords(t *testing.T) {
 func TestGetAllWhereWithFilter(t *testing.T) {
 	db := NewUnitTestDBProvider()
 
-	ownerId1 := NewRecordId()
-	ownerId2 := NewRecordId()
+	ownerId1 := UserId(NewRecordId())
+	ownerId2 := UserId(NewRecordId())
 
 	v1 := newTestRecord()
 	v1.Owner = ownerId1
@@ -380,7 +380,7 @@ func TestDeleteOneByIdDoubleDelete(t *testing.T) {
 func TestUpdateOneBasic(t *testing.T) {
 	db := NewUnitTestDBProvider()
 	v := newTestRecord()
-	v.Owner = NewRecordId()
+	v.Owner = UserId(NewRecordId())
 	created, err := CreateOne(context.Background(), db, v)
 	if err != nil {
 		t.Fatal(err)
@@ -388,7 +388,7 @@ func TestUpdateOneBasic(t *testing.T) {
 
 	updated := &testRecord{
 		ID:    created.ID,
-		Owner: NewRecordId(),
+		Owner: UserId(NewRecordId()),
 	}
 	err = UpdateOne(context.Background(), db, updated)
 	if err != nil {
@@ -412,7 +412,7 @@ func TestUpdateOneNotFound(t *testing.T) {
 
 	nonExistent := &testRecord{
 		ID:    NewRecordId(),
-		Owner: NewRecordId(),
+		Owner: UserId(NewRecordId()),
 	}
 	err := UpdateOne(context.Background(), db, nonExistent)
 	if err == nil {

--- a/database/db_with_access_control.go
+++ b/database/db_with_access_control.go
@@ -7,17 +7,17 @@ import (
 
 type WithAccessControl[T CrudRecord] struct {
 	Database          DatabaseProvider
-	AccessControlUser RecordId
+	AccessControlUser UserId
 }
 
-func NewWithAccessControl[T CrudRecord](ctx context.Context, db DatabaseProvider, accessControlUser RecordId) *WithAccessControl[T] {
+func NewWithAccessControl[T CrudRecord](ctx context.Context, db DatabaseProvider, accessControlUser UserId) *WithAccessControl[T] {
 	return &WithAccessControl[T]{
 		Database:          db,
 		AccessControlUser: accessControlUser,
 	}
 }
 
-var SysAdminCheck func(ctx context.Context, db DatabaseProvider, c RecordId) (bool, error)
+var SysAdminCheck func(ctx context.Context, db DatabaseProvider, userId UserId) (bool, error)
 
 func (w *WithAccessControl[T]) CanUserAccess(record T) bool {
 	list := record.AccessibleTo(context.Background(), w.Database)
@@ -27,7 +27,7 @@ func (w *WithAccessControl[T]) CanUserAccess(record T) bool {
 	}
 
 	for _, userId := range list {
-		if userId == w.AccessControlUser || userId == EveryoneRecordId {
+		if userId == w.AccessControlUser || userId == EveryoneUserId {
 			return true
 		}
 	}
@@ -59,13 +59,13 @@ func (w *WithAccessControl[T]) CanUserEdit(record T) bool {
 			}
 		}
 
-		if userId == SysAdminRecordId {
+		if userId == SysAdminUserId {
 			isSysAdminEditable = true
 		}
 	}
 
 	if isSysAdminEditable && SysAdminCheck != nil {
-		if editIsConstrained && cod.CanOnlyDelete(context.Background(), w.Database, SysAdminRecordId) {
+		if editIsConstrained && cod.CanOnlyDelete(context.Background(), w.Database, SysAdminUserId) {
 			return false
 		}
 		isSysAdmin, err := SysAdminCheck(context.Background(), w.Database, w.AccessControlUser)
@@ -131,7 +131,7 @@ func (w *WithAccessControl[T]) UpdateOneById(ctx context.Context, record T) (err
 
 	// make sure the owner is set on the record after we have validated that
 	// this user can edit
-	if record.GetOwner() == InvalidRecordId {
+	if record.GetOwner() == InvalidUserId {
 		record.SetOwner(t.GetOwner())
 	}
 

--- a/database/db_with_access_control_test.go
+++ b/database/db_with_access_control_test.go
@@ -8,17 +8,17 @@ import (
 
 type PrivateTestRecord struct {
 	ID       RecordId
-	Owner    RecordId
-	SharedTo []RecordId
+	Owner    UserId
+	SharedTo []UserId
 	Value    string
 }
 
-func (p *PrivateTestRecord) GetOwner() RecordId {
+func (p *PrivateTestRecord) GetOwner() UserId {
 	return p.Owner
 }
 
-func (p *PrivateTestRecord) SetOwner(recordId RecordId) {
-	p.Owner = recordId
+func (p *PrivateTestRecord) SetOwner(userId UserId) {
+	p.Owner = userId
 }
 
 func NewPrivateTestRecord() *PrivateTestRecord {
@@ -37,12 +37,12 @@ func (p *PrivateTestRecord) SetId(id RecordId) {
 	p.ID = id
 }
 
-func (p *PrivateTestRecord) EditableBy(_ context.Context, db DatabaseProvider) []RecordId {
-	return []RecordId{p.Owner, SysAdminRecordId}
+func (p *PrivateTestRecord) EditableBy(_ context.Context, db DatabaseProvider) []UserId {
+	return []UserId{p.Owner, SysAdminUserId}
 }
 
-func (p *PrivateTestRecord) AccessibleTo(_ context.Context, db DatabaseProvider) []RecordId {
-	v := make([]RecordId, 0, 1+len(p.SharedTo))
+func (p *PrivateTestRecord) AccessibleTo(_ context.Context, db DatabaseProvider) []UserId {
+	v := make([]UserId, 0, 1+len(p.SharedTo))
 	v = append(v, p.Owner)
 	v = append(v, p.SharedTo...)
 	return v
@@ -60,7 +60,7 @@ func (p *PrivateTestRecord) BlankRecord() CrudRecord {
 	return new(PrivateTestRecord)
 }
 
-func (p *PrivateTestRecord) ShareTo(ctx context.Context, db DatabaseProvider, shareToUserId, updateUserId RecordId) error {
+func (p *PrivateTestRecord) ShareTo(ctx context.Context, db DatabaseProvider, shareToUserId, updateUserId UserId) error {
 	for _, s := range p.SharedTo {
 		if shareToUserId == s {
 			return nil
@@ -72,7 +72,7 @@ func (p *PrivateTestRecord) ShareTo(ctx context.Context, db DatabaseProvider, sh
 	return wac.UpdateOneById(ctx, p)
 }
 
-func newStoredPrivateTestRecord(t *testing.T, db DatabaseProvider, owner RecordId) *PrivateTestRecord {
+func newStoredPrivateTestRecord(t *testing.T, db DatabaseProvider, owner UserId) *PrivateTestRecord {
 	r := NewPrivateTestRecord()
 	r.Owner = owner
 	v, err := CreateOne(context.Background(), db, r)
@@ -84,7 +84,7 @@ func newStoredPrivateTestRecord(t *testing.T, db DatabaseProvider, owner RecordI
 
 func TestGetOneViaOwner(t *testing.T) {
 	db := NewUnitTestDBProvider()
-	userId := NewRecordId()
+	userId := UserId(NewRecordId())
 	r := newStoredPrivateTestRecord(t, db, userId)
 
 	wac := WithAccessControl[*PrivateTestRecord]{Database: db, AccessControlUser: userId}
@@ -100,10 +100,10 @@ func TestGetOneViaOwner(t *testing.T) {
 
 func TestGetOneViaSharedTo(t *testing.T) {
 	db := NewUnitTestDBProvider()
-	ownerId := NewRecordId()
+	ownerId := UserId(NewRecordId())
 	r := newStoredPrivateTestRecord(t, db, ownerId)
 
-	sharedToUserId := NewRecordId()
+	sharedToUserId := UserId(NewRecordId())
 	err := r.ShareTo(context.Background(), db, sharedToUserId, ownerId)
 	if err != nil {
 		t.Fatal(err)
@@ -122,11 +122,11 @@ func TestGetOneViaSharedTo(t *testing.T) {
 
 func TestGetOneUnauthorized(t *testing.T) {
 	db := NewUnitTestDBProvider()
-	ownerId := NewRecordId()
+	ownerId := UserId(NewRecordId())
 	r := newStoredPrivateTestRecord(t, db, ownerId)
 
 	// attempt to get the record via another user ID
-	otherUserId := NewRecordId()
+	otherUserId := UserId(NewRecordId())
 	wac := WithAccessControl[*PrivateTestRecord]{Database: db, AccessControlUser: otherUserId}
 	_, exists, err := wac.GetOneById(context.Background(), r, r.GetId())
 	if err != nil {
@@ -139,7 +139,7 @@ func TestGetOneUnauthorized(t *testing.T) {
 
 func TestDeleteOneByOwner(t *testing.T) {
 	db := NewUnitTestDBProvider()
-	ownerId := NewRecordId()
+	ownerId := UserId(NewRecordId())
 	r := newStoredPrivateTestRecord(t, db, ownerId)
 
 	wac := WithAccessControl[*PrivateTestRecord]{Database: db, AccessControlUser: ownerId}
@@ -155,10 +155,10 @@ func TestDeleteOneByOwner(t *testing.T) {
 
 func TestDeleteOneByUnauthorized(t *testing.T) {
 	db := NewUnitTestDBProvider()
-	ownerId := NewRecordId()
+	ownerId := UserId(NewRecordId())
 	r := newStoredPrivateTestRecord(t, db, ownerId)
 
-	otherUserId := NewRecordId()
+	otherUserId := UserId(NewRecordId())
 	wac := WithAccessControl[*PrivateTestRecord]{Database: db, AccessControlUser: otherUserId}
 	_, exists, err := wac.DeleteOneById(context.Background(), r, r.GetId())
 	if err != nil {
@@ -171,7 +171,7 @@ func TestDeleteOneByUnauthorized(t *testing.T) {
 
 func TestUpdateOneByOwner(t *testing.T) {
 	db := NewUnitTestDBProvider()
-	ownerId := NewRecordId()
+	ownerId := UserId(NewRecordId())
 	r := newStoredPrivateTestRecord(t, db, ownerId)
 
 	v, err := updateRecordAndReQuery(t, db, r, "new value", ownerId)
@@ -193,7 +193,7 @@ func updateRecordIntoCopy(r *PrivateTestRecord, newValue string) *PrivateTestRec
 	return copyOfRecord
 }
 
-func updateRecordAndReQuery(t *testing.T, db DatabaseProvider, r *PrivateTestRecord, newValue string, asUser RecordId) (*PrivateTestRecord, error) {
+func updateRecordAndReQuery(t *testing.T, db DatabaseProvider, r *PrivateTestRecord, newValue string, asUser UserId) (*PrivateTestRecord, error) {
 	copied := updateRecordIntoCopy(r, newValue)
 
 	wac := WithAccessControl[*PrivateTestRecord]{Database: db, AccessControlUser: asUser}
@@ -212,11 +212,11 @@ func updateRecordAndReQuery(t *testing.T, db DatabaseProvider, r *PrivateTestRec
 func TestUpdateOneByUnauthorized(t *testing.T) {
 	// create a record in the database
 	db := NewUnitTestDBProvider()
-	ownerId := NewRecordId()
+	ownerId := UserId(NewRecordId())
 	r := newStoredPrivateTestRecord(t, db, ownerId)
 
 	// attempt to update via another user ID
-	otherUserId := NewRecordId()
+	otherUserId := UserId(NewRecordId())
 	v, err := updateRecordAndReQuery(t, db, r, "new value", otherUserId)
 	if err == nil {
 		t.Fatal("expected an error updating by unauthorized user")
@@ -228,15 +228,15 @@ func TestUpdateOneByUnauthorized(t *testing.T) {
 func TestAccessibleByEveryone(t *testing.T) {
 	// create a record in the database
 	db := NewUnitTestDBProvider()
-	ownerId := NewRecordId()
+	ownerId := UserId(NewRecordId())
 	r := newStoredPrivateTestRecord(t, db, ownerId)
-	err := r.ShareTo(context.Background(), db, EveryoneRecordId, ownerId)
+	err := r.ShareTo(context.Background(), db, EveryoneUserId, ownerId)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// attempt to get via another user ID
-	otherUserId := NewRecordId()
+	otherUserId := UserId(NewRecordId())
 	wac := WithAccessControl[*PrivateTestRecord]{Database: db, AccessControlUser: otherUserId}
 	v, exists, err := wac.GetOneById(context.Background(), r, r.GetId())
 	if err != nil {
@@ -250,12 +250,12 @@ func TestAccessibleByEveryone(t *testing.T) {
 
 func TestAccessibleBySysAdmin(t *testing.T) {
 	db := NewUnitTestDBProvider()
-	ownerId := NewRecordId()
+	ownerId := UserId(NewRecordId())
 	r := newStoredPrivateTestRecord(t, db, ownerId)
 
-	sysAdminId := NewRecordId()
-	SysAdminCheck = func(ctx context.Context, db DatabaseProvider, c RecordId) (bool, error) {
-		return c == sysAdminId, nil
+	sysAdminId := UserId(NewRecordId())
+	SysAdminCheck = func(ctx context.Context, db DatabaseProvider, userId UserId) (bool, error) {
+		return userId == sysAdminId, nil
 	}
 	wac := WithAccessControl[*PrivateTestRecord]{Database: db, AccessControlUser: sysAdminId}
 	v, exists, err := wac.GetOneById(context.Background(), r, r.GetId())
@@ -270,13 +270,13 @@ func TestAccessibleBySysAdmin(t *testing.T) {
 
 func TestEditableBySysAdmin(t *testing.T) {
 	db := NewUnitTestDBProvider()
-	ownerId := NewRecordId()
+	ownerId := UserId(NewRecordId())
 	r := newStoredPrivateTestRecord(t, db, ownerId)
 	fmt.Printf("%+v\n", r)
 
-	sysAdminId := NewRecordId()
-	SysAdminCheck = func(ctx context.Context, db DatabaseProvider, c RecordId) (bool, error) {
-		return c == sysAdminId, nil
+	sysAdminId := UserId(NewRecordId())
+	SysAdminCheck = func(ctx context.Context, db DatabaseProvider, userId UserId) (bool, error) {
+		return userId == sysAdminId, nil
 	}
 	v, err := updateRecordAndReQuery(t, db, r, "new value", sysAdminId)
 	if err != nil {
@@ -290,8 +290,8 @@ func TestEditableBySysAdmin(t *testing.T) {
 
 func TestGetAllByOwner(t *testing.T) {
 	db := NewUnitTestDBProvider()
-	ownerId := NewRecordId()
-	otherId := NewRecordId()
+	ownerId := UserId(NewRecordId())
+	otherId := UserId(NewRecordId())
 
 	// Create a record owned by ownerId
 	_ = newStoredPrivateTestRecord(t, db, ownerId)
@@ -311,8 +311,8 @@ func TestGetAllByOwner(t *testing.T) {
 
 func TestGetAllByUnauthorizedUser(t *testing.T) {
 	db := NewUnitTestDBProvider()
-	ownerId := NewRecordId()
-	unauthorizedId := NewRecordId()
+	ownerId := UserId(NewRecordId())
+	unauthorizedId := UserId(NewRecordId())
 
 	newStoredPrivateTestRecord(t, db, ownerId)
 
@@ -328,13 +328,13 @@ func TestGetAllByUnauthorizedUser(t *testing.T) {
 
 func TestGetAllBySysAdmin(t *testing.T) {
 	db := NewUnitTestDBProvider()
-	ownerId := NewRecordId()
-	adminId := NewRecordId()
+	ownerId := UserId(NewRecordId())
+	adminId := UserId(NewRecordId())
 
 	newStoredPrivateTestRecord(t, db, ownerId)
 
-	SysAdminCheck = func(ctx context.Context, db DatabaseProvider, c RecordId) (bool, error) {
-		return c == adminId, nil
+	SysAdminCheck = func(ctx context.Context, db DatabaseProvider, userId UserId) (bool, error) {
+		return userId == adminId, nil
 	}
 
 	wac := WithAccessControl[*PrivateTestRecord]{Database: db, AccessControlUser: adminId}
@@ -349,7 +349,7 @@ func TestGetAllBySysAdmin(t *testing.T) {
 
 func TestDeleteOneByIdNotFoundNonOwner(t *testing.T) {
 	db := NewUnitTestDBProvider()
-	ownerId := NewRecordId()
+	ownerId := UserId(NewRecordId())
 	newStoredPrivateTestRecord(t, db, ownerId)
 
 	nonExistentId := NewRecordId()
@@ -365,7 +365,7 @@ func TestDeleteOneByIdNotFoundNonOwner(t *testing.T) {
 
 func TestUpdateOneByIdNotFound(t *testing.T) {
 	db := NewUnitTestDBProvider()
-	ownerId := NewRecordId()
+	ownerId := UserId(NewRecordId())
 	newStoredPrivateTestRecord(t, db, ownerId)
 
 	nonExistent := &PrivateTestRecord{
@@ -381,10 +381,10 @@ func TestUpdateOneByIdNotFound(t *testing.T) {
 
 func TestDeleteBySharedToUser(t *testing.T) {
 	db := NewUnitTestDBProvider()
-	ownerId := NewRecordId()
+	ownerId := UserId(NewRecordId())
 	r := newStoredPrivateTestRecord(t, db, ownerId)
 
-	sharedToId := NewRecordId()
+	sharedToId := UserId(NewRecordId())
 	err := r.ShareTo(context.Background(), db, sharedToId, ownerId)
 	if err != nil {
 		t.Fatal(err)
@@ -413,10 +413,10 @@ func TestDeleteBySharedToUser(t *testing.T) {
 
 func TestUpdateBySharedToUser(t *testing.T) {
 	db := NewUnitTestDBProvider()
-	ownerId := NewRecordId()
+	ownerId := UserId(NewRecordId())
 	r := newStoredPrivateTestRecord(t, db, ownerId)
 
-	sharedToId := NewRecordId()
+	sharedToId := UserId(NewRecordId())
 	err := r.ShareTo(context.Background(), db, sharedToId, ownerId)
 	if err != nil {
 		t.Fatal(err)
@@ -437,10 +437,10 @@ func TestUpdateBySharedToUser(t *testing.T) {
 
 func TestGetOneBySharedToUser(t *testing.T) {
 	db := NewUnitTestDBProvider()
-	ownerId := NewRecordId()
+	ownerId := UserId(NewRecordId())
 	r := newStoredPrivateTestRecord(t, db, ownerId)
 
-	sharedToId := NewRecordId()
+	sharedToId := UserId(NewRecordId())
 	err := r.ShareTo(context.Background(), db, sharedToId, ownerId)
 	if err != nil {
 		t.Fatal(err)
@@ -459,11 +459,11 @@ func TestGetOneBySharedToUser(t *testing.T) {
 
 func TestUpdateOneBySharedToUser(t *testing.T) {
 	db := NewUnitTestDBProvider()
-	ownerId := NewRecordId()
+	ownerId := UserId(NewRecordId())
 	r := newStoredPrivateTestRecord(t, db, ownerId)
 
 	// Share the record
-	sharedToId := NewRecordId()
+	sharedToId := UserId(NewRecordId())
 	err := r.ShareTo(context.Background(), db, sharedToId, ownerId)
 	if err != nil {
 		t.Fatal(err)
@@ -484,7 +484,7 @@ func TestUpdateOneBySharedToUser(t *testing.T) {
 
 func TestGetOneIdDoesNotExist(t *testing.T) {
 	db := NewUnitTestDBProvider()
-	ownerId := NewRecordId()
+	ownerId := UserId(NewRecordId())
 	newStoredPrivateTestRecord(t, db, ownerId)
 
 	wac := WithAccessControl[*PrivateTestRecord]{Database: db, AccessControlUser: ownerId}
@@ -499,9 +499,9 @@ func TestGetOneIdDoesNotExist(t *testing.T) {
 
 func TestGetAllWithMultipleOwners(t *testing.T) {
 	db := NewUnitTestDBProvider()
-	owner1 := NewRecordId()
-	owner2 := NewRecordId()
-	owner3 := NewRecordId()
+	owner1 := UserId(NewRecordId())
+	owner2 := UserId(NewRecordId())
+	owner3 := UserId(NewRecordId())
 
 	newStoredPrivateTestRecord(t, db, owner1)
 	newStoredPrivateTestRecord(t, db, owner1)
@@ -520,12 +520,12 @@ func TestGetAllWithMultipleOwners(t *testing.T) {
 
 func TestDeleteBySysAdmin(t *testing.T) {
 	db := NewUnitTestDBProvider()
-	ownerId := NewRecordId()
+	ownerId := UserId(NewRecordId())
 	r := newStoredPrivateTestRecord(t, db, ownerId)
 
-	sysAdminId := NewRecordId()
-	SysAdminCheck = func(ctx context.Context, db DatabaseProvider, c RecordId) (bool, error) {
-		return c == sysAdminId, nil
+	sysAdminId := UserId(NewRecordId())
+	SysAdminCheck = func(ctx context.Context, db DatabaseProvider, userId UserId) (bool, error) {
+		return userId == sysAdminId, nil
 	}
 
 	wac := WithAccessControl[*PrivateTestRecord]{Database: db, AccessControlUser: sysAdminId}

--- a/database/unique_constraint_test.go
+++ b/database/unique_constraint_test.go
@@ -12,8 +12,8 @@ type testUnique struct {
 	ReferenceId2 RecordId
 }
 
-func (t *testUnique) GetOwner() RecordId {
-	return InvalidRecordId
+func (t *testUnique) GetOwner() UserId {
+	return InvalidUserId
 }
 
 func (t *testUnique) UniquenessEquivalent(other *testUnique) error {
@@ -35,15 +35,15 @@ func (t *testUnique) SetId(id RecordId) {
 	t.RecordId = id
 }
 
-func (t *testUnique) EditableBy(_ context.Context, db DatabaseProvider) []RecordId {
+func (t *testUnique) EditableBy(_ context.Context, db DatabaseProvider) []UserId {
 	return nil
 }
 
-func (t *testUnique) AccessibleTo(_ context.Context, db DatabaseProvider) []RecordId {
+func (t *testUnique) AccessibleTo(_ context.Context, db DatabaseProvider) []UserId {
 	return nil
 }
 
-func (t *testUnique) SetOwner(recordId RecordId) {}
+func (t *testUnique) SetOwner(userId UserId) {}
 
 func (t *testUnique) StaticallyValid() error {
 	return nil

--- a/database/validatable_test.go
+++ b/database/validatable_test.go
@@ -11,11 +11,11 @@ type staticFailRecord struct {
 	Value string
 }
 
-func (s *staticFailRecord) GetOwner() RecordId {
-	return InvalidRecordId
+func (s *staticFailRecord) GetOwner() UserId {
+	return InvalidUserId
 }
 
-func (s *staticFailRecord) SetOwner(recordId RecordId) {}
+func (s *staticFailRecord) SetOwner(userId UserId) {}
 
 func (s *staticFailRecord) Type() string {
 	return "static_fail"
@@ -29,11 +29,11 @@ func (s *staticFailRecord) SetId(id RecordId) {
 	s.ID = id
 }
 
-func (s *staticFailRecord) EditableBy(_ context.Context, db DatabaseProvider) []RecordId {
+func (s *staticFailRecord) EditableBy(_ context.Context, db DatabaseProvider) []UserId {
 	return nil
 }
 
-func (s *staticFailRecord) AccessibleTo(_ context.Context, db DatabaseProvider) []RecordId {
+func (s *staticFailRecord) AccessibleTo(_ context.Context, db DatabaseProvider) []UserId {
 	return nil
 }
 
@@ -57,11 +57,11 @@ type dynamicFailRecord struct {
 	Value string
 }
 
-func (d *dynamicFailRecord) GetOwner() RecordId {
-	return InvalidRecordId
+func (d *dynamicFailRecord) GetOwner() UserId {
+	return InvalidUserId
 }
 
-func (d *dynamicFailRecord) SetOwner(recordId RecordId) {}
+func (d *dynamicFailRecord) SetOwner(userId UserId) {}
 
 func (d *dynamicFailRecord) Type() string {
 	return "dynamic_fail"
@@ -75,11 +75,11 @@ func (d *dynamicFailRecord) SetId(id RecordId) {
 	d.ID = id
 }
 
-func (d *dynamicFailRecord) EditableBy(_ context.Context, db DatabaseProvider) []RecordId {
+func (d *dynamicFailRecord) EditableBy(_ context.Context, db DatabaseProvider) []UserId {
 	return nil
 }
 
-func (d *dynamicFailRecord) AccessibleTo(_ context.Context, db DatabaseProvider) []RecordId {
+func (d *dynamicFailRecord) AccessibleTo(_ context.Context, db DatabaseProvider) []UserId {
 	return nil
 }
 

--- a/model/availability.go
+++ b/model/availability.go
@@ -38,13 +38,13 @@ func (opt AvailabilityOption) Valid() bool {
 
 type Availability struct {
 	ID        database.RecordId
-	UserId    UserId
+	UserId    database.UserId
 	WeekId    WeekId
 	Available AvailabilityOption
 }
 
-func (a *Availability) GetOwner() database.RecordId {
-	return a.UserId.RecordId()
+func (a *Availability) GetOwner() database.UserId {
+	return a.UserId
 }
 
 func (a *Availability) UniquenessEquivalent(other *Availability) error {
@@ -58,8 +58,8 @@ func NewAvailability() *Availability {
 	return &Availability{}
 }
 
-func (a *Availability) SetOwner(recordId database.RecordId) {
-	a.UserId = UserId(recordId)
+func (a *Availability) SetOwner(userId database.UserId) {
+	a.UserId = userId
 }
 
 func (a *Availability) Type() string {
@@ -89,8 +89,8 @@ func (a *Availability) DynamicallyValid(ctx context.Context, db database.Databas
 	return database.ExistsById(ctx, db, &Week{}, a.WeekId.RecordId())
 }
 
-func (a *Availability) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
-	return []database.RecordId{a.UserId.RecordId()}
+func (a *Availability) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.UserId {
+	return []database.UserId{a.UserId}
 }
 
 func (a *Availability) getTeam(ctx context.Context, db database.DatabaseProvider) (*Team, error) {
@@ -142,7 +142,7 @@ func (a *Availability) getTeam(ctx context.Context, db database.DatabaseProvider
 	return nil, fmt.Errorf("user %s was not found on any teams in season %s", a.UserId, season.ID)
 }
 
-func (a *Availability) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
+func (a *Availability) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.UserId {
 	team, err := a.getTeam(ctx, db)
 	if err != nil {
 		fmt.Println(err)
@@ -153,10 +153,10 @@ func (a *Availability) AccessibleTo(ctx context.Context, db database.DatabasePro
 		fmt.Println(err)
 		return nil
 	}
-	return UserIdListToRecordIdList(members)
+	return members
 }
 
-func GetAvailabilityForUser(ctx context.Context, db database.DatabaseProvider, userId UserId, draftId DraftId) ([]*Availability, error) {
+func GetAvailabilityForUser(ctx context.Context, db database.DatabaseProvider, userId database.UserId, draftId DraftId) ([]*Availability, error) {
 	weeks, err := database.GetAllWhere[*Week](ctx, db, func(_ context.Context, c *Week) bool {
 		return c.DraftId == draftId
 	})
@@ -185,8 +185,8 @@ func (a *Availability) BlankRecord() database.CrudRecord {
 	return new(Availability)
 }
 
-func GetAvailabilityForTeam(ctx context.Context, db database.DatabaseProvider, teamId TeamId, draftId DraftId) (map[UserId][]*Availability, error) {
-	output := make(map[UserId][]*Availability)
+func GetAvailabilityForTeam(ctx context.Context, db database.DatabaseProvider, teamId TeamId, draftId DraftId) (map[database.UserId][]*Availability, error) {
+	output := make(map[database.UserId][]*Availability)
 	team, err := database.GetExistingRecordById(ctx, db, &Team{}, teamId.RecordId())
 	if err != nil {
 		return nil, err

--- a/model/availability_test.go
+++ b/model/availability_test.go
@@ -8,7 +8,7 @@ import (
 	"intraclub/database"
 )
 
-func newStoredAvailability(t *testing.T, db database.DatabaseProvider, u UserId, week WeekId) *Availability {
+func newStoredAvailability(t *testing.T, db database.DatabaseProvider, u database.UserId, week WeekId) *Availability {
 
 	availability := NewAvailability()
 	availability.UserId = u
@@ -36,7 +36,7 @@ func TestAvailabilityOnlyAccessibleToTeamMembers(t *testing.T) {
 	v := newDefaultAvailability(t, db)
 
 	otherUser := newStoredUser(t, db)
-	wac := database.WithAccessControl[*Availability]{Database: db, AccessControlUser: otherUser.ID.RecordId()}
+	wac := database.WithAccessControl[*Availability]{Database: db, AccessControlUser: otherUser.ID}
 	v, exists, err := wac.GetOneById(context.Background(), &Availability{}, v.ID)
 	if err != nil {
 		t.Fatal(err)
@@ -53,7 +53,7 @@ func TestAvailabilityIsAccessibleToTeamMembers(t *testing.T) {
 	week := newStoredWeek(t, db, season)
 	v := newStoredAvailability(t, db, userId, week.ID)
 
-	wac := database.WithAccessControl[*Availability]{Database: db, AccessControlUser: userId.RecordId()}
+	wac := database.WithAccessControl[*Availability]{Database: db, AccessControlUser: userId}
 	v, exists, err := wac.GetOneById(context.Background(), &Availability{}, v.ID)
 	if err != nil {
 		t.Fatal(err)

--- a/model/blurb.go
+++ b/model/blurb.go
@@ -25,27 +25,27 @@ type Blurb struct {
 	Title     string
 	Content   string
 	Photos    []PhotoId
-	Owner     UserId
+	Owner     database.UserId
 	Season    SeasonId
 	Reactions ReactionList
 }
 
-func (b *Blurb) GetOwner() database.RecordId {
-	return b.Owner.RecordId()
+func (b *Blurb) GetOwner() database.UserId {
+	return b.Owner
 }
 
-func (b *Blurb) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
-	return []database.RecordId{
-		b.Owner.RecordId(),
+func (b *Blurb) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.UserId {
+	return []database.UserId{
+		b.Owner,
 	}
 }
 
-func (b *Blurb) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
+func (b *Blurb) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.UserId {
 	return database.AccessibleToEveryone
 }
 
-func (b *Blurb) SetOwner(recordId database.RecordId) {
-	b.Owner = UserId(recordId)
+func (b *Blurb) SetOwner(userId database.UserId) {
+	b.Owner = userId
 }
 
 func NewBlurb() *Blurb {
@@ -104,7 +104,7 @@ func (b *Blurb) SetId(id database.RecordId) {
 	b.ID = BlurbId(id)
 }
 
-func (b *Blurb) React(ctx context.Context, db database.DatabaseProvider, u UserId, t reactionType) error {
+func (b *Blurb) React(ctx context.Context, db database.DatabaseProvider, u database.UserId, t reactionType) error {
 	r := &Reaction{
 		UserId: u,
 		Type:   t,
@@ -125,7 +125,7 @@ func (b *Blurb) React(ctx context.Context, db database.DatabaseProvider, u UserI
 	return database.UpdateOne(ctx, db, b)
 }
 
-func (b *Blurb) Unreact(ctx context.Context, db database.DatabaseProvider, u UserId, t reactionType) error {
+func (b *Blurb) Unreact(ctx context.Context, db database.DatabaseProvider, u database.UserId, t reactionType) error {
 	r := &Reaction{
 		UserId: u,
 		Type:   t,
@@ -148,7 +148,7 @@ func (b *Blurb) Unreact(ctx context.Context, db database.DatabaseProvider, u Use
 	return database.UpdateOne(ctx, db, b)
 }
 
-func (b *Blurb) CanUserCommentOrReact(ctx context.Context, db database.DatabaseProvider, u UserId) error {
+func (b *Blurb) CanUserCommentOrReact(ctx context.Context, db database.DatabaseProvider, u database.UserId) error {
 	// no error when we receive an empty user ID
 	if u.RecordId() == database.InvalidRecordId {
 		return nil

--- a/model/blurb_test.go
+++ b/model/blurb_test.go
@@ -8,7 +8,7 @@ import (
 	"intraclub/database"
 )
 
-func newValidBlurb(owner UserId, season SeasonId) *Blurb {
+func newValidBlurb(owner database.UserId, season SeasonId) *Blurb {
 	b := NewBlurb()
 	b.Owner = owner
 	b.Season = season
@@ -23,7 +23,7 @@ func newDefaultBlurb(t *testing.T, db database.DatabaseProvider) (*Blurb, *Seaso
 	return b, season
 }
 
-func newStoredBlurb(t *testing.T, db database.DatabaseProvider, owner UserId, season SeasonId) *Blurb {
+func newStoredBlurb(t *testing.T, db database.DatabaseProvider, owner database.UserId, season SeasonId) *Blurb {
 	b := newValidBlurb(owner, season)
 	v, err := database.CreateOne(context.Background(), db, b)
 	if err != nil {
@@ -74,7 +74,7 @@ func TestBlurbContentIsOnlyWhitespace(t *testing.T) {
 
 func TestBlurbUserIdDoesNotExist(t *testing.T) {
 	db := database.NewUnitTestDBProvider()
-	b := newValidBlurb(UserId(database.InvalidRecordId), SeasonId(0))
+	b := newValidBlurb(database.InvalidUserId, SeasonId(0))
 	err := b.DynamicallyValid(context.Background(), db)
 	if err == nil {
 		t.Fatal("expected error on invalid user ID")

--- a/model/comment.go
+++ b/model/comment.go
@@ -21,22 +21,22 @@ func (id CommentId) String() string {
 }
 
 type Comment struct {
-	ID        CommentId    `json:"id"`                           // unique ID for this comment
-	Blurb     BlurbId      `json:"references"`                   // ID of the Blurb that this comment is on
-	ReplyTo   CommentId    `json:"references_comment"`           // ID of the Comment that this is in reference to (if any)
-	Owner     UserId       `json:"user_id" bson:"user_id"`       // ID of the User that created this comment
-	Content   string       `json:"content" bson:"content"`       // content of the comment itself
-	EditedAt  time.Time    `json:"edited_at" bson:"edited_at"`   // time that this Comment was edited (if applicable)
-	CreatedAt time.Time    `json:"created_at" bson:"created_at"` // when this comment was created
-	Reactions ReactionList `json:"reactions" bson:"reactions"`   // list of user reactions to this comment, if any
+	ID        CommentId       `json:"id"`                           // unique ID for this comment
+	Blurb     BlurbId         `json:"references"`                   // ID of the Blurb that this comment is on
+	ReplyTo   CommentId       `json:"references_comment"`           // ID of the Comment that this is in reference to (if any)
+	Owner     database.UserId `json:"user_id" bson:"user_id"`       // ID of the User that created this comment
+	Content   string          `json:"content" bson:"content"`       // content of the comment itself
+	EditedAt  time.Time       `json:"edited_at" bson:"edited_at"`   // time that this Comment was edited (if applicable)
+	CreatedAt time.Time       `json:"created_at" bson:"created_at"` // when this comment was created
+	Reactions ReactionList    `json:"reactions" bson:"reactions"`   // list of user reactions to this comment, if any
 }
 
-func (c *Comment) GetOwner() database.RecordId {
-	return c.Owner.RecordId()
+func (c *Comment) GetOwner() database.UserId {
+	return c.Owner
 }
 
-func (c *Comment) CanOnlyDelete(ctx context.Context, db database.DatabaseProvider, userId database.RecordId) bool {
-	return UserId(userId) != c.Owner
+func (c *Comment) CanOnlyDelete(ctx context.Context, db database.DatabaseProvider, userId database.UserId) bool {
+	return userId != c.Owner
 }
 
 func (c *Comment) GetTimeStamps() (created, updated time.Time) {
@@ -71,37 +71,37 @@ func (c *Comment) SetId(id database.RecordId) {
 	c.ID = CommentId(id)
 }
 
-func (c *Comment) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
+func (c *Comment) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.UserId {
 	blurb, err := database.GetExistingRecordById(ctx, db, &Blurb{}, c.Blurb.RecordId())
 	if err != nil {
-		return []database.RecordId{}
+		return []database.UserId{}
 	}
 	season, err := database.GetExistingRecordById(ctx, db, &Season{}, blurb.Season.RecordId())
 	if err != nil {
-		return []database.RecordId{}
+		return []database.UserId{}
 	}
 
-	editors := []database.RecordId{
-		database.SysAdminRecordId,
-		c.Owner.RecordId(),
-		blurb.Owner.RecordId(),
+	editors := []database.UserId{
+		database.SysAdminUserId,
+		c.Owner,
+		blurb.Owner,
 	}
 
 	commissioners, err := season.GetCommissioners(ctx, db)
 	if err == nil {
 		for _, commissioner := range commissioners {
-			editors = append(editors, commissioner.RecordId())
+			editors = append(editors, commissioner)
 		}
 	}
 	return editors
 }
 
-func (c *Comment) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
+func (c *Comment) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.UserId {
 	return database.AccessibleToEveryone
 }
 
-func (c *Comment) SetOwner(recordId database.RecordId) {
-	c.Owner = UserId(recordId)
+func (c *Comment) SetOwner(userId database.UserId) {
+	c.Owner = userId
 }
 
 func (c *Comment) StaticallyValid() error {

--- a/model/comment_test.go
+++ b/model/comment_test.go
@@ -8,7 +8,7 @@ import (
 	"intraclub/database"
 )
 
-func newValidComment(u UserId, blurb BlurbId) *Comment {
+func newValidComment(u database.UserId, blurb BlurbId) *Comment {
 	c := NewComment()
 	c.Owner = u
 	c.Content = "content"
@@ -16,7 +16,7 @@ func newValidComment(u UserId, blurb BlurbId) *Comment {
 	return c
 }
 
-func getAnyTeamCaptain(t *testing.T, db database.DatabaseProvider, season *Season) UserId {
+func getAnyTeamCaptain(t *testing.T, db database.DatabaseProvider, season *Season ) database.UserId {
 	teams, err := season.GetTeams(context.Background(), db)
 	if err != nil {
 		t.Fatal(err)
@@ -41,7 +41,7 @@ func copyComment(c *Comment) *Comment {
 	}
 }
 
-func newStoredComment(t *testing.T, db database.DatabaseProvider, user UserId, blurb *Blurb) *Comment {
+func newStoredComment(t *testing.T, db database.DatabaseProvider, user database.UserId, blurb *Blurb) *Comment {
 	c := newValidComment(user, blurb.ID)
 
 	v, err := database.CreateOne(context.Background(), db, c)
@@ -97,7 +97,7 @@ func TestCommentCreateDateIsEmpty(t *testing.T) {
 func TestCommentUserIdIsInvalid(t *testing.T) {
 	db := database.NewUnitTestDBProvider()
 	blurb, _ := newDefaultBlurb(t, db)
-	c := newValidComment(UserId(database.InvalidRecordId), blurb.ID)
+	c := newValidComment(database.InvalidUserId, blurb.ID)
 	err := c.DynamicallyValid(context.Background(), db)
 	if err == nil {
 		t.Error("Invalid user id should produce error")
@@ -115,7 +115,7 @@ func TestEditBySysAdmin(t *testing.T) {
 	copied := copyComment(c)
 	copied.Content = "new content"
 
-	wac := database.WithAccessControl[*Comment]{Database: db, AccessControlUser: sysAdmin.ID.RecordId()}
+	wac := database.WithAccessControl[*Comment]{Database: db, AccessControlUser: sysAdmin.ID}
 	err := wac.UpdateOneById(context.Background(), copied)
 	if err == nil {
 		t.Error("Edit by privileged non-owner should produce error")
@@ -136,7 +136,7 @@ func TestEditByCommissioner(t *testing.T) {
 	copied := copyComment(c)
 	copied.Content = "new content"
 
-	wac := database.WithAccessControl[*Comment]{Database: db, AccessControlUser: commissioner.RecordId()}
+	wac := database.WithAccessControl[*Comment]{Database: db, AccessControlUser: commissioner}
 	err := wac.UpdateOneById(context.Background(), copied)
 	if err == nil {
 		t.Error("Edit by commissioner should produce error")
@@ -154,7 +154,7 @@ func TestEditByOwner(t *testing.T) {
 	copied := copyComment(c)
 	copied.Content = "new content"
 
-	wac := database.WithAccessControl[*Comment]{Database: db, AccessControlUser: c.Owner.RecordId()}
+	wac := database.WithAccessControl[*Comment]{Database: db, AccessControlUser: c.Owner}
 	err := wac.UpdateOneById(context.Background(), copied)
 	if err != nil {
 		t.Error("Edit by owner should not produce error")
@@ -182,7 +182,7 @@ func TestDeleteBySysAdmin(t *testing.T) {
 	c := newStoredComment(t, db, blurb.Owner, blurb)
 	sysAdmin := newSysAdmin(t, db)
 
-	wac := database.WithAccessControl[*Comment]{Database: db, AccessControlUser: sysAdmin.ID.RecordId()}
+	wac := database.WithAccessControl[*Comment]{Database: db, AccessControlUser: sysAdmin.ID}
 	_, _, err := wac.DeleteOneById(context.Background(), c, c.ID.RecordId())
 	if err != nil {
 		t.Fatal(err)
@@ -201,7 +201,7 @@ func TestDeleteByCommissioner(t *testing.T) {
 	copied := copyComment(c)
 	copied.Content = "new content"
 
-	wac := database.WithAccessControl[*Comment]{Database: db, AccessControlUser: commissioner.RecordId()}
+	wac := database.WithAccessControl[*Comment]{Database: db, AccessControlUser: commissioner}
 	err := wac.UpdateOneById(context.Background(), copied)
 	if err == nil {
 		t.Error("Edit by commissioner should produce error")
@@ -215,7 +215,7 @@ func TestDeleteByOwner(t *testing.T) {
 	blurb, _ := newDefaultBlurb(t, db)
 	c := newStoredComment(t, db, blurb.Owner, blurb)
 
-	wac := database.WithAccessControl[*Comment]{Database: db, AccessControlUser: c.Owner.RecordId()}
+	wac := database.WithAccessControl[*Comment]{Database: db, AccessControlUser: c.Owner}
 	_, _, err := wac.DeleteOneById(context.Background(), c, c.ID.RecordId())
 	if err != nil {
 		t.Fatal(err)

--- a/model/commissioner_proposal.go
+++ b/model/commissioner_proposal.go
@@ -18,12 +18,12 @@ type CommissionerProposal struct {
 	ID              database.RecordId // unique ID for this proposal
 	Description     string            // description of the change or action
 	SeasonId        SeasonId          // season that this pertains to
-	Votes           map[UserId]bool   // votes of all commissioners or team captains, true == vote in favor, false == vote against
+	Votes           map[database.UserId]bool   // votes of all commissioners or team captains, true == vote in favor, false == vote against
 	MustBeUnanimous bool              // true if this proposal must get unanimous consent to pass
 }
 
-func (c *CommissionerProposal) GetOwner() database.RecordId {
-	return database.InvalidRecordId
+func (c *CommissionerProposal) GetOwner() database.UserId {
+	return database.InvalidUserId
 }
 
 func (c *CommissionerProposal) PreUpdate(ctx context.Context, db database.DatabaseProvider, existingValues database.CrudRecord) error {
@@ -36,7 +36,7 @@ func (c *CommissionerProposal) PreUpdate(ctx context.Context, db database.Databa
 
 func NewCommissionerProposal() *CommissionerProposal {
 	return &CommissionerProposal{
-		Votes: make(map[UserId]bool),
+		Votes: make(map[database.UserId]bool),
 	}
 }
 
@@ -52,22 +52,22 @@ func (c *CommissionerProposal) SetId(id database.RecordId) {
 	c.ID = id
 }
 
-func (c *CommissionerProposal) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
+func (c *CommissionerProposal) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.UserId {
 	// proposal is editable only by the
 	return EditableBySeason(ctx, db, c.SeasonId)
 }
 
-func (c *CommissionerProposal) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
+func (c *CommissionerProposal) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.UserId {
 	// a commissioner proposal is only accessible to the other commissioners and the
 	// team captains involved in the given Season.
 	voters, err := c.GetAllVoterIds(ctx, db)
 	if err != nil {
 		fmt.Printf("Failed to get voters for commissioner proposal: %s\n", err.Error())
 	}
-	return UserIdListToRecordIdList(voters)
+	return voters
 }
 
-func (c *CommissionerProposal) SetOwner(recordId database.RecordId) {
+func (c *CommissionerProposal) SetOwner(userId database.UserId) {
 	// don't need to do anything here as the ownership of the
 	// CommissionerProposal record type is automatically inferred &
 	// enforced by the associated Season assigned to it
@@ -105,14 +105,14 @@ func (c *CommissionerProposal) DynamicallyValid(ctx context.Context, db database
 	return nil
 }
 
-func (c *CommissionerProposal) GetAllVoterIds(ctx context.Context, db database.DatabaseProvider) ([]UserId, error) {
+func (c *CommissionerProposal) GetAllVoterIds(ctx context.Context, db database.DatabaseProvider) ([]database.UserId, error) {
 	// get underlying season
 	season, err := database.GetExistingRecordById(ctx, db, &Season{}, c.SeasonId.RecordId())
 	if err != nil {
 		return nil, err
 	}
 	// add all commissioners as valid voters
-	output := make([]UserId, 0)
+	output := make([]database.UserId, 0)
 	commissioners, err := season.GetCommissioners(ctx, db)
 	if err == nil {
 		output = append(output, commissioners...)
@@ -126,7 +126,7 @@ func (c *CommissionerProposal) GetAllVoterIds(ctx context.Context, db database.D
 	return append(output, teamCaptains...), nil
 }
 
-func (c *CommissionerProposal) Vote(ctx context.Context, db database.DatabaseProvider, voterId UserId, vote bool) error {
+func (c *CommissionerProposal) Vote(ctx context.Context, db database.DatabaseProvider, voterId database.UserId, vote bool) error {
 	// add vote to the map
 	c.Votes[voterId] = vote
 
@@ -134,7 +134,7 @@ func (c *CommissionerProposal) Vote(ctx context.Context, db database.DatabasePro
 	return database.UpdateOne(ctx, db, c)
 }
 
-func (c *CommissionerProposal) VotesToPassOrFail(voterIds []UserId) (votesToPass, votesToFail int) {
+func (c *CommissionerProposal) VotesToPassOrFail(voterIds []database.UserId) (votesToPass, votesToFail int) {
 	if c.MustBeUnanimous {
 		// if the vote must be unanimous, then we need all voters to vote yes
 		// to pass, and one voter to vote not to fail

--- a/model/dev_data.go
+++ b/model/dev_data.go
@@ -37,7 +37,7 @@ func seedDevUsers(db database.DatabaseProvider) *User {
 	return v
 }
 
-func seedDevScoringStructures(db database.DatabaseProvider, u UserId) {
+func seedDevScoringStructures(db database.DatabaseProvider, u database.UserId) {
 	ctx := getDevContext()
 	scoringStructure := NewScoringStructure()
 	scoringStructure.Name = "Tennis standard set"
@@ -76,7 +76,7 @@ var MensOne = "Men's 1"
 var MensTwo = "Men's 2"
 var MensThree = "Men's 3"
 
-func seedDevRatings(db database.DatabaseProvider, u UserId) {
+func seedDevRatings(db database.DatabaseProvider, u database.UserId) {
 	ctx := getDevContext()
 	r := NewRating()
 	r.UserId = u
@@ -109,7 +109,7 @@ func seedDevRatings(db database.DatabaseProvider, u UserId) {
 	}
 }
 
-func seedDevFormat(db database.DatabaseProvider, u UserId) {
+func seedDevFormat(db database.DatabaseProvider, u database.UserId) {
 	ctx := getDevContext()
 	ratings, err := database.GetAll[*Rating](ctx, db)
 	if err != nil {

--- a/model/draft.go
+++ b/model/draft.go
@@ -15,8 +15,8 @@ import (
 // e.g. who is on the clock, captains picking themselves, etc. without having
 // to re-query the team from the database on each call
 type TeamCaptainAssignment struct {
-	TeamId    TeamId `json:"team_id"`
-	CaptainId UserId `json:"captain_idt"`
+	TeamId    TeamId          `json:"team_id"`
+	CaptainId database.UserId `json:"captain_idt"`
 }
 
 func getDraftContext() context.Context {
@@ -30,7 +30,7 @@ func (t TeamCaptainAssignment) StaticallyValid() error {
 }
 
 // DynamicallyValid validates that the TeamCaptainAssignment has a real TeamId and a
-// captain corresponding to a valid UserId, and that the UserId is actually the captain on
+// captain corresponding to a valid database.UserId, and that the UserId is actually the captain on
 // the Team record corresponding to the TeamId
 func (t TeamCaptainAssignment) DynamicallyValid(ctx context.Context, db database.DatabaseProvider) error {
 	team, err := database.GetExistingRecordById(ctx, db, &Team{}, t.TeamId.RecordId())
@@ -74,19 +74,19 @@ func (id DraftId) String() string {
 type Draft struct {
 	ID                DraftId           `json:"id"`
 	Name              string            `json:"name"`                // descriptive name for the draft, e.g. "2025 Men's Intraclub". this will become the default name of the Season post-draft
-	Owner             UserId            `json:"owner"`               // This will be the commissioner of the league
+	Owner             database.UserId   `json:"owner"`               // This will be the commissioner of the league
 	Format            FormatId          `json:"format"`              // Format in which the Season associated with this draft will be played
 	RatingCutoffs     map[RatingId]int  `json:"rating_cutoffs"`      // map from rating ID to the last selection index matching that ID
 	CompletedAt       time.Time         `json:"completed_at"`        // timestamp when the draft was completed
 	DraftOrderPattern DraftOrderPattern `json:"draft_order_pattern"` // draft order pattern, e.g. snake, straight-up, etc.
 }
 
-func (d *Draft) SetOwner(recordId database.RecordId) {
-	d.Owner = UserId(recordId)
+func (d *Draft) SetOwner(userId database.UserId) {
+	d.Owner = userId
 }
 
-func (d *Draft) GetOwner() database.RecordId {
-	return d.Owner.RecordId()
+func (d *Draft) GetOwner() database.UserId {
+	return d.Owner
 }
 
 func NewDraft() *Draft {
@@ -95,11 +95,11 @@ func NewDraft() *Draft {
 	}
 }
 
-func (d *Draft) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
-	return []database.RecordId{d.Owner.RecordId()}
+func (d *Draft) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.UserId {
+	return []database.UserId{d.Owner}
 }
 
-func (d *Draft) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
+func (d *Draft) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.UserId {
 	return database.AccessibleToEveryone
 }
 
@@ -150,7 +150,7 @@ func (d *Draft) DynamicallyValid(ctx context.Context, db database.DatabaseProvid
 		return err
 	}
 
-	availablePlayerMap := make(map[UserId]bool)
+	availablePlayerMap := make(map[database.UserId]bool)
 	for _, ap := range availablePlayers {
 		availablePlayerMap[ap] = true
 	}
@@ -178,7 +178,7 @@ func (d *Draft) SetId(id database.RecordId) {
 
 // IsInDraftList returns true if a particular UserId is present in
 // the available-to-draft list for this Draft
-func (d *Draft) IsInDraftList(ctx context.Context, db database.DatabaseProvider, userId UserId) bool {
+func (d *Draft) IsInDraftList(ctx context.Context, db database.DatabaseProvider, userId database.UserId) bool {
 	availablePlayers, err := d.GetAvailablePlayers(ctx, db)
 	if err != nil {
 		return false
@@ -192,7 +192,7 @@ func (d *Draft) IsInDraftList(ctx context.Context, db database.DatabaseProvider,
 }
 
 // IsSelected returns true if this particular User has been selected
-func (d *Draft) IsSelected(ctx context.Context, db database.DatabaseProvider, userId UserId) bool {
+func (d *Draft) IsSelected(ctx context.Context, db database.DatabaseProvider, userId database.UserId) bool {
 	picks, err := d.GetPicks(ctx, db)
 	if err != nil {
 		return false
@@ -206,14 +206,14 @@ func (d *Draft) IsSelected(ctx context.Context, db database.DatabaseProvider, us
 }
 
 // GetAvailablePlayers returns all userIds who are available to be drafted
-func (d *Draft) GetAvailablePlayers(ctx context.Context, db database.DatabaseProvider) ([]UserId, error) {
+func (d *Draft) GetAvailablePlayers(ctx context.Context, db database.DatabaseProvider) ([]database.UserId, error) {
 	availablePlayers, err := database.GetAllWhere[*DraftAvailablePlayer](ctx, db, func(_ context.Context, dap *DraftAvailablePlayer) bool {
 		return dap.DraftId == d.ID
 	})
 	if err != nil {
 		return nil, err
 	}
-	result := make([]UserId, 0, len(availablePlayers))
+	result := make([]database.UserId, 0, len(availablePlayers))
 	for _, ap := range availablePlayers {
 		result = append(result, ap.PlayerId)
 	}
@@ -245,9 +245,9 @@ func (d *Draft) GetCaptains(ctx context.Context, db database.DatabaseProvider) (
 
 // GetAllAvailableToSelect returns a list of all UserId values which the provided captain
 // is allowed to select. This excludes captains (except themselves) and already-selected players.
-func (d *Draft) GetAllAvailableToSelect(captainId UserId, db database.DatabaseProvider) []UserId {
+func (d *Draft) GetAllAvailableToSelect(captainId database.UserId, db database.DatabaseProvider) []database.UserId {
 	ctx := getDraftContext()
-	output := make([]UserId, 0)
+	output := make([]database.UserId, 0)
 	availablePlayers, _ := d.GetAvailablePlayers(ctx, db)
 	for _, v := range availablePlayers {
 		// check if this user is a different captain
@@ -264,7 +264,7 @@ func (d *Draft) GetAllAvailableToSelect(captainId UserId, db database.DatabasePr
 
 // GetCaptainOnTheClock determines which captain is currently on the clock to make a selection,
 // based on the draft order pattern and the current round/pick count.
-func (d *Draft) GetCaptainOnTheClock(ctx context.Context, db database.DatabaseProvider) (UserId, error) {
+func (d *Draft) GetCaptainOnTheClock(ctx context.Context, db database.DatabaseProvider) (database.UserId, error) {
 	captains, err := d.GetCaptains(ctx, db)
 	if err != nil {
 		return 0, fmt.Errorf("no captains set for draft")
@@ -285,7 +285,7 @@ func (d *Draft) GetCaptainOnTheClock(ctx context.Context, db database.DatabasePr
 // IsADifferentCaptainId checks if the given player ID belongs to a different captain
 // assigned to this Draft. Returns an error if the player is a different captain,
 // which prevents a captain from drafting another captain.
-func (d *Draft) IsADifferentCaptainId(ctx context.Context, player, captain UserId, db database.DatabaseProvider) error {
+func (d *Draft) IsADifferentCaptainId(ctx context.Context, player, captain database.UserId, db database.DatabaseProvider) error {
 	captains, err := d.GetCaptains(ctx, db)
 	if err != nil {
 		return nil
@@ -304,7 +304,7 @@ func (d *Draft) IsADifferentCaptainId(ctx context.Context, player, captain UserI
 // 2. The player is not another captain
 // 3. The player is in the available-to-draft list
 // 4. The player has not already been selected
-func (d *Draft) SelectByCaptain(ctx context.Context, player, captain UserId, db database.DatabaseProvider) error {
+func (d *Draft) SelectByCaptain(ctx context.Context, player, captain database.UserId, db database.DatabaseProvider) error {
 	// get the captain who is currently on the clock. If the
 	// captains have not yet been set, this will return an error
 	onTheClock, err := d.GetCaptainOnTheClock(ctx, db)
@@ -331,7 +331,7 @@ func (d *Draft) SelectByCaptain(ctx context.Context, player, captain UserId, db 
 // 1. The player is in the available-to-draft list
 // 2. The player has not already been selected
 // The round, pick number, and rating are automatically calculated based on the draft state.
-func (d *Draft) Select(ctx context.Context, player UserId, db database.DatabaseProvider) error {
+func (d *Draft) Select(ctx context.Context, player database.UserId, db database.DatabaseProvider) error {
 	if !d.IsInDraftList(getDraftContext(), db, player) {
 		return fmt.Errorf("user with id %s is not in the available-to-draft list", player)
 	}
@@ -387,7 +387,7 @@ func (d *Draft) GetTeamIndexByTeam(ctx context.Context, db database.DatabaseProv
 
 // GetTeamIndexByCaptain returns the 0-based index for a team captain in the draft order.
 // This is used to retrieve draft results for a particular captain.
-func (d *Draft) GetTeamIndexByCaptain(ctx context.Context, db database.DatabaseProvider, captainId UserId) (int, error) {
+func (d *Draft) GetTeamIndexByCaptain(ctx context.Context, db database.DatabaseProvider, captainId database.UserId) (int, error) {
 	captains, err := d.GetCaptains(ctx, db)
 	if err != nil {
 		return -1, err
@@ -426,7 +426,7 @@ func (d *Draft) GetDraftSelections(db database.DatabaseProvider, teamId TeamId) 
 
 // GetDraftSelectionsByCaptainId returns the list of DraftSelection results for a particular captain.
 // This is a convenience method that looks up the captain's team and retrieves their selections.
-func (d *Draft) GetDraftSelectionsByCaptainId(ctx context.Context, db database.DatabaseProvider, captainId UserId) ([]DraftSelection, error) {
+func (d *Draft) GetDraftSelectionsByCaptainId(ctx context.Context, db database.DatabaseProvider, captainId database.UserId) ([]DraftSelection, error) {
 	teamIndex, err := d.GetTeamIndexByCaptain(getDraftContext(), db, captainId)
 	if err != nil {
 		return nil, err
@@ -512,7 +512,7 @@ func (d *Draft) GetAvailableRatings(ctx context.Context, db database.DatabasePro
 	return format.PossibleRatings, nil
 }
 
-func (d *Draft) Initialize(ctx context.Context, db database.DatabaseProvider, captains []UserId) error {
+func (d *Draft) Initialize(ctx context.Context, db database.DatabaseProvider, captains []database.UserId) error {
 	captainsList, err := d.GetCaptains(getDraftContext(), db)
 	if err != nil || len(captainsList) != 0 {
 		return errors.New("draft is already initialized")
@@ -562,7 +562,7 @@ func (d *Draft) Initialize(ctx context.Context, db database.DatabaseProvider, ca
 	return database.UpdateOne(ctx, db, d)
 }
 
-func (d *Draft) AssignDraftablePlayers(ctx context.Context, db database.DatabaseProvider, players []UserId) error {
+func (d *Draft) AssignDraftablePlayers(ctx context.Context, db database.DatabaseProvider, players []database.UserId) error {
 	if d.IsDraftCompleted(ctx, db) {
 		return errors.New("draft is already completed")
 	}

--- a/model/draft_available_player.go
+++ b/model/draft_available_player.go
@@ -12,18 +12,18 @@ import (
 type DraftAvailablePlayer struct {
 	ID        database.RecordId `json:"id"`
 	DraftId   DraftId           `json:"draft_id"`
-	PlayerId  UserId            `json:"player_id"`
+	PlayerId  database.UserId            `json:"player_id"`
 	CreatedAt time.Time         `json:"created_at"`
 	UpdatedAt time.Time         `json:"updated_at"`
 }
 
 // GetOwner returns InvalidRecordId as DraftAvailablePlayer has no specific owner.
-func (d *DraftAvailablePlayer) GetOwner() database.RecordId {
-	return database.InvalidRecordId
+func (d *DraftAvailablePlayer) GetOwner() database.UserId {
+	return database.InvalidUserId
 }
 
 // SetOwner is a no-op as DraftAvailablePlayer has no specific owner.
-func (d *DraftAvailablePlayer) SetOwner(recordId database.RecordId) {}
+func (d *DraftAvailablePlayer) SetOwner(userId database.UserId) {}
 
 // Type returns the record type identifier for DraftAvailablePlayer.
 func (d *DraftAvailablePlayer) Type() string {
@@ -56,12 +56,12 @@ func (d *DraftAvailablePlayer) DynamicallyValid(ctx context.Context, db database
 	return nil
 }
 
-func (d *DraftAvailablePlayer) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
+func (d *DraftAvailablePlayer) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.UserId {
 	return database.AccessibleToEveryone
 }
 
-func (d *DraftAvailablePlayer) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
-	return []database.RecordId{database.SysAdminRecordId}
+func (d *DraftAvailablePlayer) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.UserId {
+	return []database.UserId{database.SysAdminUserId}
 }
 
 // Timestamps returns the create and update timestamps for this DraftAvailablePlayer record.

--- a/model/draft_captain.go
+++ b/model/draft_captain.go
@@ -14,19 +14,19 @@ type DraftCaptain struct {
 	ID         database.RecordId `json:"id"`
 	DraftId    DraftId           `json:"draft_id"`
 	TeamId     TeamId            `json:"team_id"`
-	CaptainId  UserId            `json:"captain_id"`
+	CaptainId  database.UserId            `json:"captain_id"`
 	DraftOrder int               `json:"draft_order"`
 	CreatedAt  time.Time         `json:"created_at"`
 	UpdatedAt  time.Time         `json:"updated_at"`
 }
 
 // GetOwner returns InvalidRecordId as DraftCaptain has no specific owner.
-func (d *DraftCaptain) GetOwner() database.RecordId {
-	return database.InvalidRecordId
+func (d *DraftCaptain) GetOwner() database.UserId {
+	return database.InvalidUserId
 }
 
 // SetOwner is a no-op as DraftCaptain has no specific owner.
-func (d *DraftCaptain) SetOwner(recordId database.RecordId) {}
+func (d *DraftCaptain) SetOwner(userId database.UserId) {}
 
 // Type returns the record type identifier for DraftCaptain.
 func (d *DraftCaptain) Type() string {
@@ -79,12 +79,12 @@ func (d *DraftCaptain) DynamicallyValid(ctx context.Context, db database.Databas
 	return nil
 }
 
-func (d *DraftCaptain) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
+func (d *DraftCaptain) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.UserId {
 	return database.AccessibleToEveryone
 }
 
-func (d *DraftCaptain) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
-	return []database.RecordId{database.SysAdminRecordId}
+func (d *DraftCaptain) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.UserId {
+	return []database.UserId{database.SysAdminUserId}
 }
 
 // Timestamps returns the create and update timestamps for this DraftCaptain record.

--- a/model/draft_pick.go
+++ b/model/draft_pick.go
@@ -14,7 +14,7 @@ type DraftPick struct {
 	ID        database.RecordId `json:"id"`
 	DraftId   DraftId           `json:"draft_id"`
 	TeamId    TeamId            `json:"team_id"`
-	UserId    UserId            `json:"user_id"`
+	UserId    database.UserId            `json:"user_id"`
 	Round     int               `json:"round"`
 	Pick      int               `json:"pick"`
 	Rating    RatingId          `json:"rating"`
@@ -23,12 +23,12 @@ type DraftPick struct {
 }
 
 // GetOwner returns InvalidRecordId as DraftPick has no specific owner.
-func (d *DraftPick) GetOwner() database.RecordId {
-	return database.InvalidRecordId
+func (d *DraftPick) GetOwner() database.UserId {
+	return database.InvalidUserId
 }
 
 // SetOwner is a no-op as DraftPick has no specific owner.
-func (d *DraftPick) SetOwner(recordId database.RecordId) {}
+func (d *DraftPick) SetOwner(userId database.UserId) {}
 
 // Type returns the record type identifier for DraftPick.
 func (d *DraftPick) Type() string {
@@ -64,12 +64,12 @@ func (d *DraftPick) DynamicallyValid(ctx context.Context, db database.DatabasePr
 	return nil
 }
 
-func (d *DraftPick) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
+func (d *DraftPick) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.UserId {
 	return database.AccessibleToEveryone
 }
 
-func (d *DraftPick) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
-	return []database.RecordId{database.SysAdminRecordId}
+func (d *DraftPick) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.UserId {
+	return []database.UserId{database.SysAdminUserId}
 }
 
 // Timestamps returns the create and update timestamps for this DraftPick record.

--- a/model/draft_test.go
+++ b/model/draft_test.go
@@ -14,7 +14,7 @@ func newDefaultStoredDraft(t *testing.T, db database.DatabaseProvider) *Draft {
 	return newStoredDraft(t, db, user.ID)
 }
 
-func newStoredDraft(t *testing.T, db database.DatabaseProvider, commissioner UserId) *Draft {
+func newStoredDraft(t *testing.T, db database.DatabaseProvider, commissioner database.UserId) *Draft {
 	draft := NewDraft()
 	draft.Owner = commissioner
 	draft.Format = newDefaultStoredFormat(t, db).ID
@@ -69,7 +69,7 @@ func newRandomDraft(t *testing.T, db database.DatabaseProvider, playerCount, tea
 	draft := newUninitializedRandomDraft(t, db, playerCount, teamCount)
 
 	// create random captains
-	users := make([]UserId, 0, playerCount)
+	users := make([]database.UserId, 0, playerCount)
 	for i := 0; i < teamCount; i++ {
 		user := newStoredUser(t, db)
 		users = append(users, user.ID)
@@ -121,7 +121,7 @@ func doRandomDraft(t *testing.T, db database.DatabaseProvider, playerCount int, 
 	return draft
 }
 
-func selectRandomAvailableByCaptain(t *testing.T, draft *Draft, captain UserId, db database.DatabaseProvider) {
+func selectRandomAvailableByCaptain(t *testing.T, draft *Draft, captain database.UserId, db database.DatabaseProvider) {
 	available := draft.GetAllAvailableToSelect(captain, db)
 	index := rand.Intn(len(available))
 	err := draft.SelectByCaptain(context.Background(), available[index], captain, db)
@@ -519,7 +519,7 @@ func TestDoubleInitializeDraft(t *testing.T) {
 	db := database.NewUnitTestDBProvider()
 	draft := newRandomDraft(t, db, 100, 4)
 
-	err := draft.Initialize(context.Background(), db, []UserId{})
+	err := draft.Initialize(context.Background(), db, []database.UserId{})
 	if err == nil {
 		t.Fatal("Expected draft double-initialize to be invalid")
 	}
@@ -530,7 +530,7 @@ func TestInitializeDraftWithInvalidCaptain(t *testing.T) {
 	db := database.NewUnitTestDBProvider()
 	draft := newUninitializedRandomDraft(t, db, 100, 4)
 
-	err := draft.Initialize(context.Background(), db, []UserId{UserId(database.InvalidRecordId)})
+	err := draft.Initialize(context.Background(), db, []database.UserId{database.InvalidUserId})
 	if err == nil {
 		t.Fatal("Expected invalid captain ID to be invalid")
 	}
@@ -556,7 +556,7 @@ func TestInvalidAvailablePlayerId(t *testing.T) {
 	// Try to add invalid player - this should fail validation
 	availablePlayer := &DraftAvailablePlayer{
 		DraftId:  draft.ID,
-		PlayerId: UserId(database.InvalidRecordId),
+		PlayerId: database.InvalidUserId,
 	}
 	_, err := database.CreateOne(context.Background(), db, availablePlayer)
 	if err == nil {
@@ -580,7 +580,7 @@ func TestDraftHasSelectionBeforeInitialization(t *testing.T) {
 		t.Fatal("Expected draft to have no captains before initialization")
 	}
 
-	err = draft.Initialize(context.Background(), db, []UserId{newStoredUser(t, db).ID})
+	err = draft.Initialize(context.Background(), db, []database.UserId{newStoredUser(t, db).ID})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -593,7 +593,7 @@ func TestDraftAddAvailablePlayers(t *testing.T) {
 	draft := newRandomDraft(t, db, 9, 2)
 	playerToAdd := newStoredUser(t, db)
 
-	err := draft.AssignDraftablePlayers(context.Background(), db, []UserId{playerToAdd.ID})
+	err := draft.AssignDraftablePlayers(context.Background(), db, []database.UserId{playerToAdd.ID})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -615,7 +615,7 @@ func TestDraftReAddAvailablePlayers(t *testing.T) {
 	availablePlayers, _ := draft.GetAvailablePlayers(context.Background(), db)
 	playerToAdd := availablePlayers[0]
 
-	err := draft.AssignDraftablePlayers(context.Background(), db, []UserId{playerToAdd})
+	err := draft.AssignDraftablePlayers(context.Background(), db, []database.UserId{playerToAdd})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/model/facility.go
+++ b/model/facility.go
@@ -37,15 +37,15 @@ func (id FacilityId) MarshalJSON() ([]byte, error) {
 // NumberOfCourts. It may also have a
 type Facility struct {
 	ID             FacilityId `json:"id"`           // Unique ID for this Facility
-	UserId         UserId     `json:"user_id"`      // ID of the User who owns the record
+	UserId         database.UserId     `json:"user_id"`      // ID of the User who owns the record
 	Name           string     `json:"name"`         // Unique name for the Facility (to prevent duplicate records)
 	Address        string     `json:"address"`      // Unique street address for the Facility (to prevent duplicate records)
 	NumberOfCourts int        `json:"courts"`       // Number of courts available at the Facility
 	LayoutPhoto    PhotoId    `json:"layout_photo"` // ID of a Photo showing the layout of the Facility (i.e. orientation of courts, parking, etc.)
 }
 
-func (f *Facility) GetOwner() database.RecordId {
-	return f.UserId.RecordId()
+func (f *Facility) GetOwner() database.UserId {
+	return f.UserId
 }
 
 func (f *Facility) UniquenessEquivalent(other *Facility) error {
@@ -80,25 +80,25 @@ func (f *Facility) PreDelete(ctx context.Context, db database.DatabaseProvider) 
 }
 
 // SetOwner assigns the owner of this common.CrudRecord
-func (f *Facility) SetOwner(recordId database.RecordId) {
-	f.UserId = UserId(recordId)
+func (f *Facility) SetOwner(userId database.UserId) {
+	f.UserId = userId
 }
 
 // EditableBy returns a list of common.RecordId values who are allowed
 // to edit (or possibly delete) this common.CrudRecord
-func (f *Facility) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
+func (f *Facility) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.UserId {
 	// This record can only be edited by the owner. It should
 	// probably be created once and reused many times without
 	// modification, so it is unlikely that updates will occur
 	// very often. It also may not be deleted after assignment
 	// to a particular season (as described in PreDelete)
-	return database.SysAdminAndUsers(f.UserId.RecordId())
+	return database.SysAdminAndUsers(f.UserId)
 }
 
 // AccessibleTo returns a list of common.RecordId values who are allowed
 // to view this record (in this instance, all users, regardless of their
 // authentication status)
-func (f *Facility) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
+func (f *Facility) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.UserId {
 	return database.AccessibleToEveryone
 }
 

--- a/model/facility_test.go
+++ b/model/facility_test.go
@@ -8,7 +8,7 @@ import (
 	"intraclub/database"
 )
 
-func newStoredFacility(t *testing.T, db database.DatabaseProvider, owner UserId) *Facility {
+func newStoredFacility(t *testing.T, db database.DatabaseProvider, owner database.UserId) *Facility {
 	facility := NewFacility()
 	facility.UserId = owner
 	facility.Name = fmt.Sprintf("Test facility %s", database.NewRecordId())
@@ -39,7 +39,7 @@ func TestFacilityCrud(t *testing.T) {
 	fmt.Printf("%+v\n", facility)
 
 	// do CRUD via the WithAccessControl construct
-	wac := database.WithAccessControl[*Facility]{Database: db, AccessControlUser: user.GetId()}
+	wac := database.WithAccessControl[*Facility]{Database: db, AccessControlUser: user.ID}
 
 	// copy facility to a new record and update in the database
 	f2 := copyFacility(facility)
@@ -77,7 +77,7 @@ func TestEditableBySysAdmin(t *testing.T) {
 	sysAdmin := newSysAdmin(t, db)
 	facility := newStoredFacility(t, db, user.ID)
 
-	wac := database.WithAccessControl[*Facility]{Database: db, AccessControlUser: sysAdmin.GetId()}
+	wac := database.WithAccessControl[*Facility]{Database: db, AccessControlUser: sysAdmin.ID}
 	canEdit := wac.CanUserEdit(facility)
 	if !canEdit {
 		t.Fatalf("Sys admin should be able to edit facility")
@@ -119,7 +119,7 @@ func TestFacilityAppliedToSeasonCannotBeDeleted(t *testing.T) {
 
 	facilityId := season.Facility.RecordId()
 
-	wac := database.NewWithAccessControl[*Facility](context.Background(), db, commish.ID.RecordId())
+	wac := database.NewWithAccessControl[*Facility](context.Background(), db, commish.ID)
 	_, _, err := wac.DeleteOneById(context.Background(), &Facility{}, facilityId)
 	if err == nil {
 		t.Fatal("expected error on delete")

--- a/model/format.go
+++ b/model/format.go
@@ -109,14 +109,14 @@ func (id FormatId) String() string {
 //   - young guy / young guy.
 type Format struct {
 	ID              FormatId     `json:"id"`               // unique ID for the Format
-	UserId          UserId       `json:"user_id"`          // owner of the Format
+	UserId          database.UserId       `json:"user_id"`          // owner of the Format
 	Name            string       `json:"name"`             // name for the Format, e.g. "Men's Intraclub 1/2/3"
 	PossibleRatings RatingList   `json:"possible_ratings"` // list of possible Rating values for the lines, highest to lowest skill
 	Lines           []FormatLine `json:"lines"`            // Rating pairings that will play during a matchup
 }
 
-func (f *Format) GetOwner() database.RecordId {
-	return f.UserId.RecordId()
+func (f *Format) GetOwner() database.UserId {
+	return f.UserId
 }
 
 func (f *Format) PreUpdate(ctx context.Context, db database.DatabaseProvider, existingValues database.CrudRecord) error {
@@ -127,19 +127,19 @@ func (f *Format) PreDelete(ctx context.Context, db database.DatabaseProvider) er
 	return f.CheckHasAssignedDrafts(ctx, db, false)
 }
 
-func (f *Format) SetOwner(recordId database.RecordId) {
-	f.UserId = UserId(recordId)
+func (f *Format) SetOwner(userId database.UserId) {
+	f.UserId = userId
 }
 
 func NewFormat() *Format {
 	return &Format{}
 }
 
-func (f *Format) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
-	return []database.RecordId{f.UserId.RecordId()}
+func (f *Format) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.UserId {
+	return []database.UserId{f.UserId}
 }
 
-func (f *Format) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
+func (f *Format) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.UserId {
 	return database.AccessibleToEveryone
 }
 

--- a/model/format_test.go
+++ b/model/format_test.go
@@ -119,7 +119,7 @@ func TestFormatHasInvalidUserId(t *testing.T) {
 	db := database.NewUnitTestDBProvider()
 	format := newDefaultFormat(t, db)
 
-	format.UserId = UserId(database.InvalidRecordId)
+	format.UserId = database.InvalidUserId
 	err := format.DynamicallyValid(context.Background(), db)
 	if err == nil {
 		t.Fatal("Expected invalid user id to fail")

--- a/model/individual_match.go
+++ b/model/individual_match.go
@@ -59,7 +59,7 @@ func (sc CompletedSecondary) Won() bool {
 
 type IndividualMatch struct {
 	ID             IndividualMatchId
-	Editors        []UserId
+	Editors        []database.UserId
 	Opponent       IndividualMatchId
 	Structure      ScoringStructureId
 	MainValue      int
@@ -71,8 +71,8 @@ type IndividualMatch struct {
 	_completed     []CompletedSecondary
 }
 
-func (s *IndividualMatch) GetOwner() database.RecordId {
-	return s.Editors[0].RecordId()
+func (s *IndividualMatch) GetOwner() database.UserId {
+	return s.Editors[0]
 }
 
 func NewMatch() *IndividualMatch {
@@ -91,16 +91,16 @@ func (s *IndividualMatch) SetId(id database.RecordId) {
 	s.ID = IndividualMatchId(id)
 }
 
-func (s *IndividualMatch) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
-	return UserIdListToRecordIdList(s.Editors)
+func (s *IndividualMatch) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.UserId {
+	return s.Editors
 }
 
-func (s *IndividualMatch) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
+func (s *IndividualMatch) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.UserId {
 	return database.AccessibleToEveryone
 }
 
-func (s *IndividualMatch) SetOwner(recordId database.RecordId) {
-	s.Editors = append(s.Editors, UserId(recordId))
+func (s *IndividualMatch) SetOwner(userId database.UserId) {
+	s.Editors = append(s.Editors, userId)
 }
 
 func (s *IndividualMatch) StaticallyValid() error {

--- a/model/individual_match_test.go
+++ b/model/individual_match_test.go
@@ -15,8 +15,8 @@ func newStoredMatchPair(t *testing.T, db database.DatabaseProvider, s *ScoringSt
 	match1.Structure = s.ID
 	match2.Structure = s.ID
 
-	match1.Editors = []UserId{s.Owner}
-	match2.Editors = []UserId{s.Owner}
+	match1.Editors = []database.UserId{s.Owner}
+	match2.Editors = []database.UserId{s.Owner}
 
 	created1, err := database.CreateOne(context.Background(), db, match1)
 	if err != nil {

--- a/model/lineup.go
+++ b/model/lineup.go
@@ -23,8 +23,8 @@ type Lineup struct {
 	WeekId WeekId // Week that this Lineup applies to
 }
 
-func (l *Lineup) GetOwner() database.RecordId {
-	return database.InvalidRecordId
+func (l *Lineup) GetOwner() database.UserId {
+	return database.InvalidUserId
 }
 
 func (l *Lineup) UniquenessEquivalent(other *Lineup) error {
@@ -34,16 +34,16 @@ func (l *Lineup) UniquenessEquivalent(other *Lineup) error {
 	return nil
 }
 
-func (l *Lineup) SetOwner(recordId database.RecordId) {
+func (l *Lineup) SetOwner(userId database.UserId) {
 	// don't need to do anything here as ownership is enforced by
 	// team captain or co-captain status
 }
 
-func (l *Lineup) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
+func (l *Lineup) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.UserId {
 	return EditableByTeamCaptainOrCoCaptains(ctx, db, l.TeamId)
 }
 
-func (l *Lineup) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
+func (l *Lineup) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.UserId {
 	return AccessibleByTeamMembers(ctx, db, l.TeamId)
 }
 

--- a/model/lineup_pairing.go
+++ b/model/lineup_pairing.go
@@ -21,8 +21,8 @@ type LineupPairing struct {
 	ID              LineupPairingId // unique ID for this LineupPairing
 	LineupId        LineupId        // This correlates a LineupPairing into a group with other pairing and assigns to a Week
 	TeamId          TeamId          // Players must be on this team
-	Player1         UserId          // Player in slot 1 for the format / line
-	Player2         UserId          // Player in slot 2 for the format / line
+	Player1         database.UserId          // Player in slot 1 for the format / line
+	Player2         database.UserId          // Player in slot 2 for the format / line
 	FormatLineIndex int             // index in the Format.Lines list that this pairing applies to
 }
 
@@ -38,8 +38,8 @@ func (l *LineupPairing) UniquenessEquivalent(other *LineupPairing) error {
 	return nil
 }
 
-func (l *LineupPairing) GetOwner() database.RecordId {
-	return database.InvalidRecordId
+func (l *LineupPairing) GetOwner() database.UserId {
+	return database.InvalidUserId
 }
 
 func (l *LineupPairing) Type() string {
@@ -54,15 +54,15 @@ func (l *LineupPairing) SetId(id database.RecordId) {
 	l.ID = LineupPairingId(id)
 }
 
-func (l *LineupPairing) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
+func (l *LineupPairing) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.UserId {
 	return EditableByTeamCaptainOrCoCaptains(ctx, db, l.TeamId)
 }
 
-func (l *LineupPairing) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
+func (l *LineupPairing) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.UserId {
 	return AccessibleByTeamMembers(ctx, db, l.TeamId)
 }
 
-func (l *LineupPairing) SetOwner(recordId database.RecordId) {
+func (l *LineupPairing) SetOwner(userId database.UserId) {
 	// don't need to do anything here as editable-by rights
 	// are enforced via the team ID
 }

--- a/model/photo.go
+++ b/model/photo.go
@@ -61,30 +61,30 @@ func (id PhotoId) UnmarshalJSON(data []byte) error {
 
 type Photo struct {
 	ID       PhotoId
-	Owner    UserId
+	Owner    database.UserId
 	AltText  string
 	Contents []byte
 	FileType PhotoType
 }
 
-func (p *Photo) GetOwner() database.RecordId {
-	return p.Owner.RecordId()
+func (p *Photo) GetOwner() database.UserId {
+	return p.Owner
 }
 
 func NewPhoto() *Photo {
 	return &Photo{}
 }
 
-func (p *Photo) SetOwner(recordId database.RecordId) {
-	p.Owner = UserId(recordId)
+func (p *Photo) SetOwner(userId database.UserId) {
+	p.Owner = userId
 }
 
-func (p *Photo) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
-	return []database.RecordId{p.Owner.RecordId(), database.SysAdminRecordId}
+func (p *Photo) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.UserId {
+	return []database.UserId{p.Owner, database.SysAdminUserId}
 }
 
-func (p *Photo) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
-	return []database.RecordId{database.EveryoneRecordId}
+func (p *Photo) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.UserId {
+	return []database.UserId{database.EveryoneUserId}
 }
 
 func (p *Photo) StaticallyValid() error {

--- a/model/photo_test.go
+++ b/model/photo_test.go
@@ -8,7 +8,7 @@ import (
 	"intraclub/database"
 )
 
-func newStoredPhoto(t *testing.T, db database.DatabaseProvider, owner UserId) *Photo {
+func newStoredPhoto(t *testing.T, db database.DatabaseProvider, owner database.UserId) *Photo {
 	b := make([]byte, 64)
 	n, err := rand.Read(b)
 	if n != 64 {

--- a/model/player.go
+++ b/model/player.go
@@ -1,1 +1,0 @@
-package model

--- a/model/playoff_structure.go
+++ b/model/playoff_structure.go
@@ -21,13 +21,13 @@ func (id PlayoffStructureId) String() string {
 
 type PlayoffStructure struct {
 	ID            PlayoffStructureId // unique ID for this record
-	UserId        UserId
+	UserId        database.UserId
 	Byes          int // number of teams which get a bye week
 	NumberOfTeams int // number of teams which make the playoffs
 }
 
-func (p *PlayoffStructure) GetOwner() database.RecordId {
-	return p.UserId.RecordId()
+func (p *PlayoffStructure) GetOwner() database.UserId {
+	return p.UserId
 }
 
 func (p *PlayoffStructure) PreUpdate(ctx context.Context, db database.DatabaseProvider, existingValues database.CrudRecord) error {
@@ -56,15 +56,15 @@ func NewPlayoffStructure() *PlayoffStructure {
 	return &PlayoffStructure{}
 }
 
-func (p *PlayoffStructure) SetOwner(recordId database.RecordId) {
-	p.UserId = UserId(recordId)
+func (p *PlayoffStructure) SetOwner(userId database.UserId) {
+	p.UserId = userId
 }
 
-func (p *PlayoffStructure) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
-	return []database.RecordId{p.UserId.RecordId()}
+func (p *PlayoffStructure) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.UserId {
+	return []database.UserId{p.UserId}
 }
 
-func (p *PlayoffStructure) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
+func (p *PlayoffStructure) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.UserId {
 	return database.AccessibleToEveryone
 }
 

--- a/model/pre_draft_grade.go
+++ b/model/pre_draft_grade.go
@@ -22,15 +22,15 @@ func (p PreDraftRatingModifier) Int() int {
 
 type PreDraftGrade struct {
 	ID       database.RecordId      // unique ID of this PreDraftGrade
-	PlayerId UserId                 // ID of the User who is being graded
+	PlayerId database.UserId                 // ID of the User who is being graded
 	DraftId  DraftId                // ID of the Draft that this PreDraftGrade pertains to
-	GraderId UserId                 // ID of the User providing a Grade
+	GraderId database.UserId                 // ID of the User providing a Grade
 	Modifier PreDraftRatingModifier // 0, 1, or 2 to indicate that this is a weak, average, or strong version of this Rating
 	Rating   RatingId
 }
 
-func (p *PreDraftGrade) GetOwner() database.RecordId {
-	return p.GraderId.RecordId()
+func (p *PreDraftGrade) GetOwner() database.UserId {
+	return p.GraderId
 }
 
 func (p *PreDraftGrade) UniquenessEquivalent(other *PreDraftGrade) error {
@@ -41,12 +41,12 @@ func (p *PreDraftGrade) UniquenessEquivalent(other *PreDraftGrade) error {
 }
 
 type PreDraftAggregate struct {
-	PlayerId  UserId
+	PlayerId  database.UserId
 	Aggregate float64 // average of the ratings for this player (higher is better)
 }
 
-func (p *PreDraftGrade) SetOwner(recordId database.RecordId) {
-	p.GraderId = UserId(recordId)
+func (p *PreDraftGrade) SetOwner(userId database.UserId) {
+	p.GraderId = userId
 }
 
 func NewPreDraftGrade() *PreDraftGrade {
@@ -65,11 +65,11 @@ func (p *PreDraftGrade) SetId(id database.RecordId) {
 	p.ID = id
 }
 
-func (p *PreDraftGrade) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
-	return []database.RecordId{p.GraderId.RecordId()}
+func (p *PreDraftGrade) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.UserId {
+	return []database.UserId{p.GraderId}
 }
 
-func (p *PreDraftGrade) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
+func (p *PreDraftGrade) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.UserId {
 	return database.AccessibleToEveryone
 }
 
@@ -160,13 +160,13 @@ func (p *PreDraftGrade) NumericRating(format *Format) float64 {
 	return float64(ratingBaseValue + p.Modifier.Int())
 }
 
-func GetPreDraftGradesByGraderId(ctx context.Context, db database.DatabaseProvider, graderId UserId) ([]*PreDraftGrade, error) {
+func GetPreDraftGradesByGraderId(ctx context.Context, db database.DatabaseProvider, graderId database.UserId) ([]*PreDraftGrade, error) {
 	return database.GetAllWhere[*PreDraftGrade](ctx, db, func(_ context.Context, c *PreDraftGrade) bool {
 		return c.GraderId == graderId
 	})
 }
 
-func GetPreDraftGradesByPlayerId(ctx context.Context, db database.DatabaseProvider, playerId UserId) ([]*PreDraftGrade, error) {
+func GetPreDraftGradesByPlayerId(ctx context.Context, db database.DatabaseProvider, playerId database.UserId) ([]*PreDraftGrade, error) {
 	return database.GetAllWhere[*PreDraftGrade](ctx, db, func(_ context.Context, c *PreDraftGrade) bool {
 		return c.PlayerId == playerId
 	})
@@ -182,7 +182,7 @@ func GetPreDraftGradesByDraftId(ctx context.Context, db database.DatabaseProvide
 	})
 }
 
-func GetDraftAggregateForPlayer(allGrades []*PreDraftGrade, format *Format, id UserId) PreDraftAggregate {
+func GetDraftAggregateForPlayer(allGrades []*PreDraftGrade, format *Format, id database.UserId) PreDraftAggregate {
 
 	// filter down to only the grades for this particular player ID
 	gradesForThisPlayer := make([]*PreDraftGrade, 0)

--- a/model/pre_draft_grade_test.go
+++ b/model/pre_draft_grade_test.go
@@ -123,7 +123,7 @@ func TestPreDraftInvalidRating(t *testing.T) {
 func TestPreDraftInvalidPlayerId(t *testing.T) {
 	db := database.NewUnitTestDBProvider()
 	grade := newValidGrade(t, db)
-	grade.PlayerId = UserId(database.InvalidRecordId)
+	grade.PlayerId = database.InvalidUserId
 	err := grade.DynamicallyValid(context.Background(), db)
 	if err == nil {
 		t.Fatal("Expected error, got nil")
@@ -134,7 +134,7 @@ func TestPreDraftInvalidPlayerId(t *testing.T) {
 func TestPreDraftInvalidGraderId(t *testing.T) {
 	db := database.NewUnitTestDBProvider()
 	grade := newValidGrade(t, db)
-	grade.GraderId = UserId(database.InvalidRecordId)
+	grade.GraderId = database.InvalidUserId
 	err := grade.DynamicallyValid(context.Background(), db)
 	if err == nil {
 		t.Fatal("Expected error, got nil")

--- a/model/rating.go
+++ b/model/rating.go
@@ -48,7 +48,7 @@ func (r *RatingList) UnmarshalJSON(bytes []byte) error {
 
 type Rating struct {
 	ID          RatingId `json:"id"`
-	UserId      UserId   `json:"user_id"`
+	UserId      database.UserId   `json:"user_id"`
 	Name        string   `json:"name"`
 	Description string   `json:"description"`
 }
@@ -60,8 +60,8 @@ func (r *Rating) UniquenessEquivalent(other *Rating) error {
 	return nil
 }
 
-func (r *Rating) GetOwner() database.RecordId {
-	return r.UserId.RecordId()
+func (r *Rating) GetOwner() database.UserId {
+	return r.UserId
 }
 
 func (r *Rating) PreDelete(ctx context.Context, db database.DatabaseProvider) error {
@@ -77,19 +77,19 @@ func (r *Rating) PreDelete(ctx context.Context, db database.DatabaseProvider) er
 	return nil
 }
 
-func (r *Rating) SetOwner(recordId database.RecordId) {
-	r.UserId = UserId(recordId)
+func (r *Rating) SetOwner(userId database.UserId) {
+	r.UserId = userId
 }
 
 func NewRating() *Rating {
 	return &Rating{}
 }
 
-func (r *Rating) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
-	return database.SysAdminAndUsers(r.UserId.RecordId())
+func (r *Rating) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.UserId {
+	return database.SysAdminAndUsers(r.UserId)
 }
 
-func (r *Rating) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
+func (r *Rating) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.UserId {
 	return database.AccessibleToEveryone
 }
 

--- a/model/rating_test.go
+++ b/model/rating_test.go
@@ -8,7 +8,7 @@ import (
 	"intraclub/database"
 )
 
-func newValidRating(u UserId) *Rating {
+func newValidRating(u database.UserId) *Rating {
 	return &Rating{
 		UserId:      u,
 		Name:        "name",
@@ -48,7 +48,7 @@ func TestRatingNameEmpty(t *testing.T) {
 }
 
 func TestRatingNameWhitespace(t *testing.T) {
-	r := newValidRating(UserId(database.InvalidRecordId))
+	r := newValidRating(database.InvalidUserId)
 	r.Name = "   "
 	err := r.StaticallyValid()
 	if err == nil {
@@ -58,7 +58,7 @@ func TestRatingNameWhitespace(t *testing.T) {
 }
 
 func TestRatingDescriptionEmpty(t *testing.T) {
-	r := newValidRating(UserId(database.InvalidRecordId))
+	r := newValidRating(database.InvalidUserId)
 	r.Description = ""
 
 	err := r.StaticallyValid()
@@ -69,7 +69,7 @@ func TestRatingDescriptionEmpty(t *testing.T) {
 }
 
 func TestRatingDescriptionWhitespace(t *testing.T) {
-	r := newValidRating(UserId(database.InvalidRecordId))
+	r := newValidRating(database.InvalidUserId)
 	r.Description = "\n\n\n\n"
 
 	err := r.StaticallyValid()
@@ -81,7 +81,7 @@ func TestRatingDescriptionWhitespace(t *testing.T) {
 
 func TestRatingUserIdNotValid(t *testing.T) {
 	db := database.NewUnitTestDBProvider()
-	r := newValidRating(UserId(database.InvalidRecordId))
+	r := newValidRating(database.InvalidUserId)
 
 	err := r.DynamicallyValid(context.Background(), db)
 	if err == nil {
@@ -95,7 +95,7 @@ func TestRatingUpdateBySysAdmin(t *testing.T) {
 	r := newStoredRating(t, db)
 	sysAdmin := newSysAdmin(t, db)
 
-	wac := database.WithAccessControl[*Rating]{Database: db, AccessControlUser: sysAdmin.ID.RecordId()}
+	wac := database.WithAccessControl[*Rating]{Database: db, AccessControlUser: sysAdmin.ID}
 
 	copied := copyRating(r)
 	copied.Name = "new name"
@@ -124,7 +124,7 @@ func TestRatingCannotBeDeletedWhenInUse(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	wac := database.WithAccessControl[*Rating]{Database: db, AccessControlUser: rating.UserId.RecordId()}
+	wac := database.WithAccessControl[*Rating]{Database: db, AccessControlUser: rating.UserId}
 	_, _, err = wac.DeleteOneById(context.Background(), &Rating{}, ratingId)
 	if err == nil {
 		t.Fatal("Expected error on delete of in-use rating")

--- a/model/reaction.go
+++ b/model/reaction.go
@@ -87,7 +87,7 @@ var AllowedReactions = []reactionType{
 // directly in the database but are instead stored on a []Reaction in the
 // Blurb.Reactions and Comment.Reactions fields.
 type Reaction struct {
-	UserId UserId       `json:"user_id" bson:"user_id"`
+	UserId database.UserId       `json:"user_id" bson:"user_id"`
 	Type   reactionType `json:"reaction_type" bson:"reaction_type"`
 }
 

--- a/model/recap.go
+++ b/model/recap.go
@@ -1,8 +1,0 @@
-package model
-
-type Recap struct {
-	LeagueId string
-	WeekId   string
-	Summary  string
-	PhotoIds []string
-}

--- a/model/role.go
+++ b/model/role.go
@@ -61,25 +61,25 @@ func (r Role) Valid() bool {
 
 type UserRoleAssignment struct {
 	ID          database.RecordId // ID of this assignment
-	UserId      UserId            // ID of the User being assigned a role
+	UserId      database.UserId   // ID of the User being assigned a role
 	Role        Role              // Role being assigned to this user
 	ReferenceId database.RecordId // ID of referenced record base on role, e.g. Team ID for a TeamMember role
 }
 
-func (u *UserRoleAssignment) GetOwner() database.RecordId {
-	return database.InvalidRecordId
+func (u *UserRoleAssignment) GetOwner() database.UserId {
+	return database.InvalidUserId
 }
 
-func (u *UserRoleAssignment) SetOwner(recordId database.RecordId) {
+func (u *UserRoleAssignment) SetOwner(userId database.UserId) {
 	// don't need to do anything as the Owner field this record type
 	// will necessarily be present in the Create request
 }
 
-func (u *UserRoleAssignment) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
+func (u *UserRoleAssignment) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.UserId {
 	return database.SysAdminAndUsers() // only changeable by system administrator
 }
 
-func (u *UserRoleAssignment) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
+func (u *UserRoleAssignment) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.UserId {
 	// TODO implement me
 	panic("implement me")
 }
@@ -121,7 +121,7 @@ func (u *UserRoleAssignment) BlankRecord() database.CrudRecord {
 	return new(UserRoleAssignment)
 }
 
-func IsUserAssignedToTeam(ctx context.Context, db database.DatabaseProvider, userId UserId, teamId TeamId) (bool, error) {
+func IsUserAssignedToTeam(ctx context.Context, db database.DatabaseProvider, userId database.UserId, teamId TeamId) (bool, error) {
 	err := database.ExistsById(ctx, db, &User{}, userId.RecordId())
 	if err != nil {
 		return false, err
@@ -137,7 +137,7 @@ func IsUserAssignedToTeam(ctx context.Context, db database.DatabaseProvider, use
 	return team.IsTeamMember(ctx, db, userId)
 }
 
-func IsUserAssignedToSeason(ctx context.Context, db database.DatabaseProvider, userId UserId, seasonId database.RecordId) (bool, error) {
+func IsUserAssignedToSeason(ctx context.Context, db database.DatabaseProvider, userId database.UserId, seasonId database.RecordId) (bool, error) {
 	err := database.ExistsById(ctx, db, &User{}, userId.RecordId())
 	if err != nil {
 		return false, err
@@ -154,8 +154,8 @@ func IsUserAssignedToSeason(ctx context.Context, db database.DatabaseProvider, u
 	return season.IsUserIdASeasonParticipant(ctx, db, userId)
 }
 
-func IsUserSystemAdministrator(ctx context.Context, db database.DatabaseProvider, userId database.RecordId) (bool, error) {
-	user, exists, err := database.GetOneById(ctx, db, &User{}, userId)
+func IsUserSystemAdministrator(ctx context.Context, db database.DatabaseProvider, userId database.UserId) (bool, error) {
+	user, exists, err := database.GetOneById(ctx, db, &User{}, userId.RecordId())
 	if err != nil {
 		return false, err
 	}

--- a/model/ruleset.go
+++ b/model/ruleset.go
@@ -63,7 +63,7 @@ type Ruleset struct {
 	// cannot edit this Ruleset, but may always Fork it into a
 	// new Ruleset if they would like to modify it for their
 	// own Season, for example.
-	Owner UserId `json:"owner"`
+	Owner database.UserId `json:"owner"`
 }
 
 func (r *Ruleset) PreUpdate(ctx context.Context, db database.DatabaseProvider, existingValues database.CrudRecord) error {
@@ -102,20 +102,20 @@ func (r *Ruleset) SetId(id database.RecordId) {
 	r.ID = RulesetId(id)
 }
 
-func (r *Ruleset) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
-	return database.SysAdminAndUsers(r.Owner.RecordId())
+func (r *Ruleset) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.UserId {
+	return database.SysAdminAndUsers(r.Owner)
 }
 
-func (r *Ruleset) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
+func (r *Ruleset) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.UserId {
 	return database.AccessibleToEveryone
 }
 
-func (r *Ruleset) SetOwner(recordId database.RecordId) {
-	r.Owner = UserId(recordId)
+func (r *Ruleset) SetOwner(userId database.UserId) {
+	r.Owner = userId
 }
 
-func (r *Ruleset) GetOwner() database.RecordId {
-	return r.Owner.RecordId()
+func (r *Ruleset) GetOwner() database.UserId {
+	return r.Owner
 }
 
 func (r *Ruleset) StaticallyValid() error {
@@ -253,7 +253,7 @@ func (r *Ruleset) BlankRecord() database.CrudRecord {
 	return new(Ruleset)
 }
 
-func (r *Ruleset) Fork(ctx context.Context, db database.DatabaseProvider, newUserId UserId) (*Ruleset, error) {
+func (r *Ruleset) Fork(ctx context.Context, db database.DatabaseProvider, newUserId database.UserId) (*Ruleset, error) {
 	sectionRelations, err := r.GetSectionRelations(ctx, db)
 	if err != nil {
 		return nil, err
@@ -315,11 +315,11 @@ func (id RuleSectionId) Empty() bool {
 }
 
 type RuleSection struct {
-	ID       RuleSectionId `json:"section_id"`
-	Parent   RulesetId     `json:"parent"`
-	Title    string        `json:"title"`
-	Markdown string        `json:"markdown"`
-	Owner    UserId        `json:"owner"`
+	ID       RuleSectionId   `json:"section_id"`
+	Parent   RulesetId       `json:"parent"`
+	Title    string          `json:"title"`
+	Markdown string          `json:"markdown"`
+	Owner    database.UserId `json:"owner"`
 }
 
 func (section *RuleSection) Type() string {
@@ -334,20 +334,20 @@ func (section *RuleSection) SetId(id database.RecordId) {
 	section.ID = RuleSectionId(id)
 }
 
-func (section *RuleSection) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
-	return database.SysAdminAndUsers(section.Owner.RecordId())
+func (section *RuleSection) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.UserId {
+	return database.SysAdminAndUsers(section.Owner)
 }
 
-func (section *RuleSection) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
+func (section *RuleSection) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.UserId {
 	return database.AccessibleToEveryone
 }
 
-func (section *RuleSection) SetOwner(recordId database.RecordId) {
-	section.Owner = UserId(recordId)
+func (section *RuleSection) SetOwner(userId database.UserId) {
+	section.Owner = userId
 }
 
-func (section *RuleSection) GetOwner() database.RecordId {
-	return section.Owner.RecordId()
+func (section *RuleSection) GetOwner() database.UserId {
+	return section.Owner
 }
 
 func (section *RuleSection) StaticallyValid() error {

--- a/model/ruleset_section.go
+++ b/model/ruleset_section.go
@@ -19,12 +19,12 @@ type RulesetSection struct {
 }
 
 // GetOwner returns InvalidRecordId as RulesetSection has no specific owner.
-func (r *RulesetSection) GetOwner() database.RecordId {
-	return database.InvalidRecordId
+func (r *RulesetSection) GetOwner() database.UserId {
+	return database.InvalidUserId
 }
 
 // SetOwner is a no-op as RulesetSection has no specific owner.
-func (r *RulesetSection) SetOwner(recordId database.RecordId) {}
+func (r *RulesetSection) SetOwner(userId database.UserId) {}
 
 // Type returns the record type identifier for RulesetSection.
 func (r *RulesetSection) Type() string {
@@ -57,12 +57,12 @@ func (r *RulesetSection) DynamicallyValid(ctx context.Context, db database.Datab
 	return nil
 }
 
-func (r *RulesetSection) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
+func (r *RulesetSection) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.UserId {
 	return database.AccessibleToEveryone
 }
 
-func (r *RulesetSection) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
-	return []database.RecordId{database.SysAdminRecordId}
+func (r *RulesetSection) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.UserId {
+	return []database.UserId{database.SysAdminUserId}
 }
 
 // Timestamps returns the create and update timestamps for this RulesetSection record.

--- a/model/ruleset_test.go
+++ b/model/ruleset_test.go
@@ -33,7 +33,7 @@ func assertRulesetIsDynamicallyInvalid(t *testing.T, db database.DatabaseProvide
 	fmt.Println(err.Error())
 }
 
-func newValidRuleset(t *testing.T, owner UserId) *Ruleset {
+func newValidRuleset(t *testing.T, owner database.UserId) *Ruleset {
 	x := NewRuleset()
 	x.Name = fmt.Sprintf("test ruleset #%d", rand.Int())
 	x.Owner = owner

--- a/model/schedule.go
+++ b/model/schedule.go
@@ -23,8 +23,8 @@ type Schedule struct {
 	Matchups []WeeklyMatchupId
 }
 
-func (s *Schedule) GetOwner() database.RecordId {
-	return database.InvalidRecordId
+func (s *Schedule) GetOwner() database.UserId {
+	return database.InvalidUserId
 }
 
 func (s *Schedule) UniquenessEquivalent(other *Schedule) error {
@@ -35,7 +35,7 @@ func (s *Schedule) UniquenessEquivalent(other *Schedule) error {
 	return nil
 }
 
-func (s *Schedule) SetOwner(recordId database.RecordId) {
+func (s *Schedule) SetOwner(userId database.UserId) {
 	// don't need to do anything here as the ownership of the
 	// Schedule record type is automatically inferred &
 	// enforced by the associated Season assigned to it
@@ -45,11 +45,11 @@ func NewSchedule() *Schedule {
 	return &Schedule{}
 }
 
-func (s *Schedule) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
+func (s *Schedule) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.UserId {
 	return EditableBySeason(ctx, db, s.SeasonId)
 }
 
-func (s *Schedule) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
+func (s *Schedule) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.UserId {
 	return database.AccessibleToEveryone
 }
 

--- a/model/scoring_structure.go
+++ b/model/scoring_structure.go
@@ -180,7 +180,7 @@ type ScoringStructure struct {
 	// Owner is the UserId who created this ScoringStructure.
 	// This is only used to allow deletion / update and to
 	// filter on one's own ScoringStructure records
-	Owner UserId `json:"owner"`
+	Owner database.UserId `json:"owner"`
 
 	// Name is a descriptive name for this ScoringStructure
 	Name string `json:"name"`
@@ -223,8 +223,8 @@ func (c *ScoringStructure) UniquenessEquivalent(other *ScoringStructure) error {
 	return nil
 }
 
-func (c *ScoringStructure) GetOwner() database.RecordId {
-	return c.Owner.RecordId()
+func (c *ScoringStructure) GetOwner() database.UserId {
+	return c.Owner
 }
 
 func NewScoringStructure() *ScoringStructure {
@@ -243,16 +243,16 @@ func (c *ScoringStructure) SetId(id database.RecordId) {
 	c.ID = ScoringStructureId(id)
 }
 
-func (c *ScoringStructure) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
-	return database.SysAdminAndUsers(c.Owner.RecordId())
+func (c *ScoringStructure) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.UserId {
+	return database.SysAdminAndUsers(c.Owner)
 }
 
-func (c *ScoringStructure) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
+func (c *ScoringStructure) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.UserId {
 	return database.AccessibleToEveryone
 }
 
-func (c *ScoringStructure) SetOwner(recordId database.RecordId) {
-	c.Owner = UserId(recordId)
+func (c *ScoringStructure) SetOwner(userId database.UserId) {
+	c.Owner = userId
 }
 
 func (c *ScoringStructure) MaximumScoreCountingUnitsPlayed() (int, error) {

--- a/model/season.go
+++ b/model/season.go
@@ -51,11 +51,11 @@ type Season struct {
 	DraftId          DraftId            // Draft results for this Season
 	ScheduleID       ScheduleId         // ID of the Schedule for this Season
 	PlayoffStructure PlayoffStructureId // ID of the PlayoffStructure for the Season
-	Owner            UserId             // commissioner who owns this season
+	Owner            database.UserId    // commissioner who owns this season
 }
 
-func (s *Season) GetOwner() database.RecordId {
-	return s.Owner.RecordId()
+func (s *Season) GetOwner() database.UserId {
+	return s.Owner
 }
 
 func (s *Season) UniquenessEquivalent(other *Season) error {
@@ -65,8 +65,8 @@ func (s *Season) UniquenessEquivalent(other *Season) error {
 	return nil
 }
 
-func (s *Season) SetOwner(recordId database.RecordId) {
-	s.Owner = UserId(recordId)
+func (s *Season) SetOwner(userId database.UserId) {
+	s.Owner = userId
 }
 
 // NewSeason creates a new empty Season record.
@@ -79,15 +79,15 @@ func NewSeason() *Season {
 // StaticallyValid checks the basic validity of the Season record,
 // ensuring the name is set and start time is valid.
 
-func (s *Season) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
+func (s *Season) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.UserId {
 	commissioners, err := s.GetCommissioners(ctx, db)
 	if err != nil {
 		return nil
 	}
-	return UserIdListToRecordIdList(commissioners)
+	return commissioners
 }
 
-func (s *Season) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
+func (s *Season) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.UserId {
 	return database.AccessibleToEveryone
 }
 
@@ -169,7 +169,7 @@ func (s *Season) GetDraft(ctx context.Context, db database.DatabaseProvider) (*D
 
 // IsUserIdASeasonParticipant checks if a user is a participant in the season,
 // either as a commissioner, late addition, or as a member of a team in the season.
-func (s *Season) IsUserIdASeasonParticipant(ctx context.Context, db database.DatabaseProvider, u UserId) (bool, error) {
+func (s *Season) IsUserIdASeasonParticipant(ctx context.Context, db database.DatabaseProvider, u database.UserId) (bool, error) {
 	commissioners, err := s.GetCommissioners(ctx, db)
 	if err != nil {
 		return false, err
@@ -209,7 +209,7 @@ func (s *Season) IsUserIdASeasonParticipant(ctx context.Context, db database.Dat
 
 // IsUserIdACommissionerViaDB checks if a user ID is one of the commissioners for this season.
 // Returns false if an error occurs during the database query.
-func (s *Season) IsUserIdACommissionerViaDB(ctx context.Context, db database.DatabaseProvider, u UserId) bool {
+func (s *Season) IsUserIdACommissionerViaDB(ctx context.Context, db database.DatabaseProvider, u database.UserId) bool {
 	commissioners, err := s.GetCommissioners(ctx, db)
 	if err != nil {
 		return false
@@ -224,14 +224,14 @@ func (s *Season) IsUserIdACommissionerViaDB(ctx context.Context, db database.Dat
 
 // GetCommissioners retrieves all commissioner User IDs for this season by querying
 // the SeasonCommissioner join table.
-func (s *Season) GetCommissioners(ctx context.Context, db database.DatabaseProvider) ([]UserId, error) {
+func (s *Season) GetCommissioners(ctx context.Context, db database.DatabaseProvider) ([]database.UserId, error) {
 	commissioners, err := database.GetAllWhere[*SeasonCommissioner](ctx, db, func(_ context.Context, c *SeasonCommissioner) bool {
 		return c.SeasonId == s.ID
 	})
 	if err != nil {
 		return nil, err
 	}
-	result := make([]UserId, 0, len(commissioners))
+	result := make([]database.UserId, 0, len(commissioners))
 	for _, c := range commissioners {
 		result = append(result, c.UserId)
 	}
@@ -260,14 +260,14 @@ func (s *Season) GetTeams(ctx context.Context, db database.DatabaseProvider) ([]
 
 // GetLateAdditions retrieves all late addition User IDs for this season by querying
 // the SeasonLateAddition join table.
-func (s *Season) GetLateAdditions(ctx context.Context, db database.DatabaseProvider) ([]UserId, error) {
+func (s *Season) GetLateAdditions(ctx context.Context, db database.DatabaseProvider) ([]database.UserId, error) {
 	lateAdditions, err := database.GetAllWhere[*SeasonLateAddition](ctx, db, func(_ context.Context, sla *SeasonLateAddition) bool {
 		return sla.SeasonId == s.ID
 	})
 	if err != nil {
 		return nil, err
 	}
-	result := make([]UserId, 0, len(lateAdditions))
+	result := make([]database.UserId, 0, len(lateAdditions))
 	for _, l := range lateAdditions {
 		result = append(result, l.UserId)
 	}
@@ -275,7 +275,7 @@ func (s *Season) GetLateAdditions(ctx context.Context, db database.DatabaseProvi
 }
 
 // AddCommissioner creates a new SeasonCommissioner record to add a commissioner to this season.
-func (s *Season) AddCommissioner(ctx context.Context, db database.DatabaseProvider, userId UserId) error {
+func (s *Season) AddCommissioner(ctx context.Context, db database.DatabaseProvider, userId database.UserId) error {
 	commissioner := &SeasonCommissioner{
 		SeasonId: s.ID,
 		UserId:   userId,
@@ -285,7 +285,7 @@ func (s *Season) AddCommissioner(ctx context.Context, db database.DatabaseProvid
 }
 
 // RemoveCommissioner removes all SeasonCommissioner records for a given user from this season.
-func (s *Season) RemoveCommissioner(ctx context.Context, db database.DatabaseProvider, userId UserId) error {
+func (s *Season) RemoveCommissioner(ctx context.Context, db database.DatabaseProvider, userId database.UserId) error {
 	commissioners, err := database.GetAllWhere[*SeasonCommissioner](ctx, db, func(_ context.Context, c *SeasonCommissioner) bool {
 		return c.SeasonId == s.ID && c.UserId == userId
 	})
@@ -329,7 +329,7 @@ func (s *Season) RemoveTeam(ctx context.Context, db database.DatabaseProvider, t
 }
 
 // AddLateAddition creates a new SeasonLateAddition record to add a late addition user to this season.
-func (s *Season) AddLateAddition(ctx context.Context, db database.DatabaseProvider, userId UserId) error {
+func (s *Season) AddLateAddition(ctx context.Context, db database.DatabaseProvider, userId database.UserId) error {
 	lateAddition := &SeasonLateAddition{
 		SeasonId: s.ID,
 		UserId:   userId,
@@ -339,7 +339,7 @@ func (s *Season) AddLateAddition(ctx context.Context, db database.DatabaseProvid
 }
 
 // RemoveLateAddition removes all SeasonLateAddition records for a given user from this season.
-func (s *Season) RemoveLateAddition(ctx context.Context, db database.DatabaseProvider, userId UserId) error {
+func (s *Season) RemoveLateAddition(ctx context.Context, db database.DatabaseProvider, userId database.UserId) error {
 	lateAdditions, err := database.GetAllWhere[*SeasonLateAddition](ctx, db, func(_ context.Context, sla *SeasonLateAddition) bool {
 		return sla.SeasonId == s.ID && sla.UserId == userId
 	})
@@ -367,7 +367,7 @@ func (s *Season) AddTeams(ctx context.Context, db database.DatabaseProvider, tea
 }
 
 // AddCommissioners creates multiple SeasonCommissioner records to add commissioners to this season.
-func (s *Season) AddCommissioners(ctx context.Context, db database.DatabaseProvider, userIds []UserId) error {
+func (s *Season) AddCommissioners(ctx context.Context, db database.DatabaseProvider, userIds []database.UserId) error {
 	for _, userId := range userIds {
 		err := s.AddCommissioner(ctx, db, userId)
 		if err != nil {
@@ -378,7 +378,7 @@ func (s *Season) AddCommissioners(ctx context.Context, db database.DatabaseProvi
 }
 
 // AddLateAdditions creates multiple SeasonLateAddition records to add late addition users to this season.
-func (s *Season) AddLateAdditions(ctx context.Context, db database.DatabaseProvider, userIds []UserId) error {
+func (s *Season) AddLateAdditions(ctx context.Context, db database.DatabaseProvider, userIds []database.UserId) error {
 	for _, userId := range userIds {
 		err := s.AddLateAddition(ctx, db, userId)
 		if err != nil {
@@ -393,7 +393,7 @@ func (s *Season) AddLateAdditions(ctx context.Context, db database.DatabaseProvi
 // used as a reusable way to compose the common.CrudRecord.EditableBy() list for record
 // types which are downstream of a Season and editable by the commissioners, e.g. a Schedule
 // or Week belonging to a Season
-func EditableBySeason(ctx context.Context, db database.DatabaseProvider, seasonId SeasonId) []database.RecordId {
+func EditableBySeason(ctx context.Context, db database.DatabaseProvider, seasonId SeasonId) []database.UserId {
 	season, err := database.GetExistingRecordById(ctx, db, &Season{}, seasonId.RecordId())
 	if err != nil {
 		fmt.Println(err) // shouldn't get here, but print an error if so for debugging
@@ -403,12 +403,12 @@ func EditableBySeason(ctx context.Context, db database.DatabaseProvider, seasonI
 }
 
 // GetTeamCaptains returns the list of captain User IDs for all teams in this season.
-func (s *Season) GetTeamCaptains(ctx context.Context, db database.DatabaseProvider) ([]UserId, error) {
+func (s *Season) GetTeamCaptains(ctx context.Context, db database.DatabaseProvider) ([]database.UserId, error) {
 	teams, err := s.GetTeams(ctx, db)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to get teams for season: %s\n", err.Error())
 	}
-	output := make([]UserId, 0)
+	output := make([]database.UserId, 0)
 	for _, team := range teams {
 		captain, err := team.GetCaptain(ctx, db)
 		if err != nil {

--- a/model/season_commissioner.go
+++ b/model/season_commissioner.go
@@ -12,26 +12,26 @@ import (
 type SeasonCommissioner struct {
 	ID        database.RecordId `json:"id"`
 	SeasonId  SeasonId          `json:"season_id"`
-	UserId    UserId            `json:"user_id"`
+	UserId    database.UserId            `json:"user_id"`
 	CreatedAt time.Time         `json:"created_at"`
 	UpdatedAt time.Time         `json:"updated_at"`
 }
 
 // GetOwner returns InvalidRecordId as SeasonCommissioner has no specific owner.
-func (s *SeasonCommissioner) GetOwner() database.RecordId {
-	return database.InvalidRecordId
+func (s *SeasonCommissioner) GetOwner() database.UserId {
+	return database.InvalidUserId
 }
 
 // SetOwner is a no-op as SeasonCommissioner has no specific owner.
-func (s *SeasonCommissioner) SetOwner(recordId database.RecordId) {}
+func (s *SeasonCommissioner) SetOwner(userId database.UserId) {}
 
 // AccessibleTo returns everyone as SeasonCommissioner records are public.
-func (s *SeasonCommissioner) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
+func (s *SeasonCommissioner) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.UserId {
 	return database.AccessibleToEveryone
 }
 
-func (s *SeasonCommissioner) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
-	return []database.RecordId{database.SysAdminRecordId}
+func (s *SeasonCommissioner) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.UserId {
+	return []database.UserId{database.SysAdminUserId}
 }
 
 // Type returns the record type identifier for SeasonCommissioner.

--- a/model/season_composite.go
+++ b/model/season_composite.go
@@ -53,13 +53,13 @@ func GetMySeasonsAsPlayerOrCommissioner(ctx context.Context, db database.Databas
 
 // isUserPlayer checks if this user is a player in a particular season,
 // by checking if they were selected in the season's draft.
-func isUserPlayer(ctx context.Context, c *Draft, userId database.RecordId, db database.DatabaseProvider) bool {
+func isUserPlayer(ctx context.Context, c *Draft, userId database.UserId, db database.DatabaseProvider) bool {
 	picks, err := c.GetPicks(ctx, db)
 	if err != nil {
 		return false
 	}
 	for _, pick := range picks {
-		if pick.UserId.RecordId() == userId {
+		if pick.UserId == userId {
 			return true
 		}
 	}
@@ -67,13 +67,13 @@ func isUserPlayer(ctx context.Context, c *Draft, userId database.RecordId, db da
 }
 
 // isUserCommissioner checks if the user is the commissioner of the provided draft
-func isUserCommissioner(c *Draft, userId database.RecordId) bool {
-	return c.Owner.RecordId() == userId
+func isUserCommissioner(c *Draft, userId database.UserId) bool {
+	return c.Owner == userId
 }
 
 // isUserPlayerOrCommissioner checks if the user is either a player or
 // the commissioner of the provided Draft
-func isUserPlayerOrCommissioner(ctx context.Context, c *Draft, userId database.RecordId, db database.DatabaseProvider) bool {
+func isUserPlayerOrCommissioner(ctx context.Context, c *Draft, userId database.UserId, db database.DatabaseProvider) bool {
 	return isUserCommissioner(c, userId) || isUserPlayer(ctx, c, userId, db)
 }
 

--- a/model/season_late_addition.go
+++ b/model/season_late_addition.go
@@ -12,26 +12,26 @@ import (
 type SeasonLateAddition struct {
 	ID        database.RecordId `json:"id"`
 	SeasonId  SeasonId          `json:"season_id"`
-	UserId    UserId            `json:"user_id"`
+	UserId    database.UserId            `json:"user_id"`
 	CreatedAt time.Time         `json:"created_at"`
 	UpdatedAt time.Time         `json:"updated_at"`
 }
 
 // GetOwner returns InvalidRecordId as SeasonLateAddition has no specific owner.
-func (s *SeasonLateAddition) GetOwner() database.RecordId {
-	return database.InvalidRecordId
+func (s *SeasonLateAddition) GetOwner() database.UserId {
+	return database.InvalidUserId
 }
 
 // SetOwner is a no-op as SeasonLateAddition has no specific owner.
-func (s *SeasonLateAddition) SetOwner(recordId database.RecordId) {}
+func (s *SeasonLateAddition) SetOwner(userId database.UserId) {}
 
 // AccessibleTo returns everyone as SeasonLateAddition records are public.
-func (s *SeasonLateAddition) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
+func (s *SeasonLateAddition) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.UserId {
 	return database.AccessibleToEveryone
 }
 
-func (s *SeasonLateAddition) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
-	return []database.RecordId{database.SysAdminRecordId}
+func (s *SeasonLateAddition) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.UserId {
+	return []database.UserId{database.SysAdminUserId}
 }
 
 // Type returns the record type identifier for SeasonLateAddition.

--- a/model/season_team.go
+++ b/model/season_team.go
@@ -18,20 +18,20 @@ type SeasonTeam struct {
 }
 
 // GetOwner returns InvalidRecordId as SeasonTeam has no specific owner.
-func (s *SeasonTeam) GetOwner() database.RecordId {
-	return database.InvalidRecordId
+func (s *SeasonTeam) GetOwner() database.UserId {
+	return database.InvalidUserId
 }
 
 // SetOwner is a no-op as SeasonTeam has no specific owner.
-func (s *SeasonTeam) SetOwner(recordId database.RecordId) {}
+func (s *SeasonTeam) SetOwner(userId database.UserId) {}
 
 // AccessibleTo returns everyone as SeasonTeam records are public.
-func (s *SeasonTeam) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
+func (s *SeasonTeam) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.UserId {
 	return database.AccessibleToEveryone
 }
 
-func (s *SeasonTeam) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
-	return []database.RecordId{database.SysAdminRecordId}
+func (s *SeasonTeam) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.UserId {
+	return []database.UserId{database.SysAdminUserId}
 }
 
 // Type returns the record type identifier for SeasonTeam.

--- a/model/season_test.go
+++ b/model/season_test.go
@@ -24,7 +24,7 @@ func newDefaultSeasonWithTeams(t *testing.T, db database.DatabaseProvider, teamC
 	return newStoredSeason(t, db, commissioner.ID, teams), commissioner
 }
 
-func newStoredSeason(t *testing.T, db database.DatabaseProvider, commissioner UserId, teams []*Team) *Season {
+func newStoredSeason(t *testing.T, db database.DatabaseProvider, commissioner database.UserId, teams []*Team) *Season {
 	draft := newStoredDraft(t, db, commissioner)
 	facility := newStoredFacility(t, db, commissioner)
 	playoffStructure := newStoredPlayoffStructure(t, db)

--- a/model/skill_info.go
+++ b/model/skill_info.go
@@ -24,7 +24,7 @@ var LeagueTypes = []LeagueType{
 // Men's seniors team in 2024"
 type SkillInfo struct {
 	ID             database.RecordId `json:"id" bson:"_id"`          // unique ID, only queryable field (entry IDs are stored in a list on the User collection)
-	UserId         UserId            `json:"user_id" bson:"user_id"` // ID of the User that this record belongs to
+	UserId         database.UserId            `json:"user_id" bson:"user_id"` // ID of the User that this record belongs to
 	LeagueType     LeagueType        `json:"league_type"`            // Type of league (USTA / ALTA / T2)
 	MostRecentYear int               `json:"most_recent_year"`       // Year that you played on this team, e.g. 2024
 	Captain        string            `json:"captain"`                // Captain of the team for search convenience, e.g. John Smith
@@ -32,8 +32,8 @@ type SkillInfo struct {
 	Line           string            `json:"line"`                   // line that you played at, e.g. line 1 or line 5
 }
 
-func (s *SkillInfo) GetOwner() database.RecordId {
-	return s.UserId.RecordId()
+func (s *SkillInfo) GetOwner() database.UserId {
+	return s.UserId
 }
 
 func (s *SkillInfo) Type() string {
@@ -51,17 +51,17 @@ func (s *SkillInfo) SetId(id database.RecordId) {
 	panic("implement me")
 }
 
-func (s *SkillInfo) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
+func (s *SkillInfo) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.UserId {
 	// TODO implement me
 	panic("implement me")
 }
 
-func (s *SkillInfo) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
+func (s *SkillInfo) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.UserId {
 	// TODO implement me
 	panic("implement me")
 }
 
-func (s *SkillInfo) SetOwner(recordId database.RecordId) {
+func (s *SkillInfo) SetOwner(userId database.UserId) {
 	// TODO implement me
 	panic("implement me")
 }

--- a/model/start_login.go
+++ b/model/start_login.go
@@ -24,7 +24,7 @@ var BaseUrl = "https://localhost:5000"
 var UseDevTokenMode = false
 
 type LoginToken struct {
-	UserId   UserId    `json:"user_id"`
+	UserId   database.UserId    `json:"user_id"`
 	Expiry   time.Time `json:"expiry"`
 	UsedAt   time.Time `json:"used_at"`
 	Token    string    `json:"token"`
@@ -33,7 +33,7 @@ type LoginToken struct {
 
 // NewLoginToken creates a new one-time-use login token for a particular UserId with
 // a random token value and which expires LoginTokenDefaultExpirationTime from now
-func NewLoginToken(userId UserId) (*LoginToken, error) {
+func NewLoginToken(userId database.UserId) (*LoginToken, error) {
 	b := make([]byte, LoginTokenLength)
 	n, err := rand.Read(b)
 	if err != nil {
@@ -241,7 +241,7 @@ func (m *StartLoginTokenManager) GenerateTokenEmail(ctx context.Context, db data
 }
 
 type LoginResponse struct {
-	UserId   UserId `json:"user_id"`
+	UserId   database.UserId `json:"user_id"`
 	JWT      string `json:"jwt"`
 	ReturnTo string `json:"return_to"`
 	Error    error  `json:"error"`

--- a/model/team.go
+++ b/model/team.go
@@ -29,35 +29,35 @@ const (
 type TeamAssignment struct {
 	ID        database.RecordId `json:"id"`
 	TeamId    TeamId            `json:"team_id"`
-	UserId    UserId            `json:"user_id"`
+	UserId    database.UserId   `json:"user_id"`
 	Role      TeamRole          `json:"role"`
 	CreatedAt time.Time         `json:"created_at"`
 	UpdatedAt time.Time         `json:"updated_at"`
 	DeletedAt *time.Time        `json:"deleted_at"`
 }
 
-func (a *TeamAssignment) GetOwner() database.RecordId {
-	return database.InvalidRecordId
+func (a *TeamAssignment) GetOwner() database.UserId {
+	return database.InvalidUserId
 }
 
-func (a *TeamAssignment) SetOwner(recordId database.RecordId) {
+func (a *TeamAssignment) SetOwner(userId database.UserId) {
 	// No owner field to set
 }
 
-func (a *TeamAssignment) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
+func (a *TeamAssignment) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.UserId {
 	// Team assignments are editable by captains/co-captains of team
 	team, exists, err := database.GetOneById(ctx, db, &Team{}, a.TeamId.RecordId())
 	if err != nil || !exists {
-		return []database.RecordId{}
+		return []database.UserId{}
 	}
 	return team.EditableBy(ctx, db)
 }
 
-func (a *TeamAssignment) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
+func (a *TeamAssignment) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.UserId {
 	// Team assignments are accessible to team members
 	team, exists, err := database.GetOneById(ctx, db, &Team{}, a.TeamId.RecordId())
 	if err != nil || !exists {
-		return []database.RecordId{database.EveryoneRecordId}
+		return []database.UserId{database.EveryoneUserId}
 	}
 	return team.AccessibleTo(ctx, db)
 }
@@ -136,34 +136,34 @@ func (a *TeamAssignment) BlankRecord() database.CrudRecord {
 }
 
 type Team struct {
-	ID          TeamId              `json:"id"`
-	Name        string              `json:"name"`
-	Color       TeamColor           `json:"color"`
-	RatingsMap  map[UserId]RatingId `json:"ratings_map"`
-	tempCaptain UserId              `json:"-"`
-	CreatedAt   time.Time           `json:"created_at"`
-	UpdatedAt   time.Time           `json:"updated_at"`
-	DeletedAt   *time.Time          `json:"deleted_at"`
+	ID          TeamId                       `json:"id"`
+	Name        string                       `json:"name"`
+	Color       TeamColor                    `json:"color"`
+	RatingsMap  map[database.UserId]RatingId `json:"ratings_map"`
+	tempCaptain database.UserId              `json:"-"`
+	CreatedAt   time.Time                    `json:"created_at"`
+	UpdatedAt   time.Time                    `json:"updated_at"`
+	DeletedAt   *time.Time                   `json:"deleted_at"`
 }
 
-func (t *Team) GetOwner() database.RecordId {
-	return database.InvalidRecordId
+func (t *Team) GetOwner() database.UserId {
+	return database.InvalidUserId
 }
 
-func (t *Team) SetOwner(recordId database.RecordId) {
+func (t *Team) SetOwner(userId database.UserId) {
 	// don't need to do anything as Captain will not necessarily
-	// be the same as the RecordId that was passed into the
+	// be the same as the UserId that was passed into the
 	// Create request for this type. The Captain for a given
 	// Team will be set after creation via the draft initialization
 }
 
 func NewTeam() *Team {
 	return &Team{
-		RatingsMap: make(map[UserId]RatingId),
+		RatingsMap: make(map[database.UserId]RatingId),
 	}
 }
 
-func NewDefaultTeam(captain UserId, name string) *Team {
+func NewDefaultTeam(captain database.UserId, name string) *Team {
 	team := NewTeam()
 	team.Name = name
 	team.Color = TeamColor{
@@ -181,25 +181,25 @@ func (t *Team) getAssignments(ctx context.Context, db database.DatabaseProvider)
 	return database.GetAllWhere[*TeamAssignment](ctx, db, filter)
 }
 
-func (t *Team) GetCaptain(ctx context.Context, db database.DatabaseProvider) (UserId, error) {
+func (t *Team) GetCaptain(ctx context.Context, db database.DatabaseProvider) (database.UserId, error) {
 	assignments, err := t.getAssignments(ctx, db)
 	if err != nil {
-		return UserId(0), err
+		return database.InvalidUserId, err
 	}
 	for _, a := range assignments {
 		if a.Role == TeamRoleCaptain {
 			return a.UserId, nil
 		}
 	}
-	return UserId(0), fmt.Errorf("no captain found for team %s", t.ID)
+	return database.InvalidUserId, fmt.Errorf("no captain found for team %s", t.ID)
 }
 
-func (t *Team) GetCoCaptains(ctx context.Context, db database.DatabaseProvider) ([]UserId, error) {
+func (t *Team) GetCoCaptains(ctx context.Context, db database.DatabaseProvider) ([]database.UserId, error) {
 	assignments, err := t.getAssignments(ctx, db)
 	if err != nil {
 		return nil, err
 	}
-	coCaptains := make([]UserId, 0)
+	coCaptains := make([]database.UserId, 0)
 	for _, a := range assignments {
 		if a.Role == TeamRoleCoCaptain {
 			coCaptains = append(coCaptains, a.UserId)
@@ -208,19 +208,19 @@ func (t *Team) GetCoCaptains(ctx context.Context, db database.DatabaseProvider) 
 	return coCaptains, nil
 }
 
-func (t *Team) GetMembers(ctx context.Context, db database.DatabaseProvider) ([]UserId, error) {
+func (t *Team) GetMembers(ctx context.Context, db database.DatabaseProvider) ([]database.UserId, error) {
 	assignments, err := t.getAssignments(ctx, db)
 	if err != nil {
 		return nil, err
 	}
-	members := make([]UserId, 0, len(assignments))
+	members := make([]database.UserId, 0, len(assignments))
 	for _, a := range assignments {
 		members = append(members, a.UserId)
 	}
 	return members, nil
 }
 
-func (t *Team) IsTeamMember(ctx context.Context, db database.DatabaseProvider, u UserId) (bool, error) {
+func (t *Team) IsTeamMember(ctx context.Context, db database.DatabaseProvider, u database.UserId) (bool, error) {
 	members, err := t.GetMembers(ctx, db)
 	if err != nil {
 		return false, err
@@ -233,30 +233,30 @@ func (t *Team) IsTeamMember(ctx context.Context, db database.DatabaseProvider, u
 	return false, nil
 }
 
-func (t *Team) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
+func (t *Team) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.UserId {
 	// Captains and co-captains can edit
-	ids := make([]database.RecordId, 0)
+	ids := make([]database.UserId, 0)
 
 	// Get captain
 	if captain, err := t.GetCaptain(ctx, db); err == nil {
-		ids = append(ids, captain.RecordId())
+		ids = append(ids, captain)
 	}
 
 	// Get co-captains
 	if coCaptains, err := t.GetCoCaptains(ctx, db); err == nil {
-		ids = append(ids, UserIdListToRecordIdList(coCaptains)...)
+		ids = append(ids, coCaptains...)
 	}
 
 	return ids
 }
 
-func (t *Team) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
+func (t *Team) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.UserId {
 	// All team members can access
 	members, err := t.GetMembers(ctx, db)
 	if err != nil {
-		return []database.RecordId{database.EveryoneRecordId}
+		return []database.UserId{database.EveryoneUserId}
 	}
-	return UserIdListToRecordIdList(members)
+	return members
 }
 
 func (t *Team) StaticallyValid() error {
@@ -265,7 +265,7 @@ func (t *Team) StaticallyValid() error {
 
 func (t *Team) DynamicallyValid(ctx context.Context, db database.DatabaseProvider) error {
 	// If tempCaptain is set, skip captain validation (it will be created in PostCreate)
-	if t.tempCaptain != UserId(0) {
+	if t.tempCaptain != database.InvalidUserId {
 		// Still verify tempCaptain is a valid user
 		if err := database.ExistsById(ctx, db, &User{}, t.tempCaptain.RecordId()); err != nil {
 			return err
@@ -336,7 +336,7 @@ func (t *Team) PreCreate(db database.DatabaseProvider) error {
 
 func (t *Team) PostCreate(ctx context.Context, db database.DatabaseProvider) error {
 	// If a captain was set during creation, create the team assignment for them
-	if t.tempCaptain != UserId(0) {
+	if t.tempCaptain != database.InvalidUserId {
 		assignment := &TeamAssignment{
 			TeamId: t.ID,
 			UserId: t.tempCaptain,
@@ -347,7 +347,7 @@ func (t *Team) PostCreate(ctx context.Context, db database.DatabaseProvider) err
 			return err
 		}
 		// Clear the temp captain after creating the assignment
-		t.tempCaptain = UserId(0)
+		t.tempCaptain = database.InvalidUserId
 	}
 	return nil
 }
@@ -388,7 +388,7 @@ func (t *Team) BlankRecord() database.CrudRecord {
 	return new(Team)
 }
 
-func AccessibleByTeamMembers(ctx context.Context, db database.DatabaseProvider, t TeamId) []database.RecordId {
+func AccessibleByTeamMembers(ctx context.Context, db database.DatabaseProvider, t TeamId) []database.UserId {
 	team, exists, err := database.GetOneById(ctx, db, &Team{}, t.RecordId())
 	if err != nil {
 		fmt.Println(err)
@@ -403,10 +403,10 @@ func AccessibleByTeamMembers(ctx context.Context, db database.DatabaseProvider, 
 		fmt.Println(err)
 		return nil
 	}
-	return UserIdListToRecordIdList(members)
+	return members
 }
 
-func EditableByTeamCaptainOrCoCaptains(ctx context.Context, db database.DatabaseProvider, t TeamId) []database.RecordId {
+func EditableByTeamCaptainOrCoCaptains(ctx context.Context, db database.DatabaseProvider, t TeamId) []database.UserId {
 	team, exists, err := database.GetOneById(ctx, db, &Team{}, t.RecordId())
 	if err != nil {
 		fmt.Println(err)

--- a/model/team_test.go
+++ b/model/team_test.go
@@ -7,7 +7,7 @@ import (
 	"intraclub/database"
 )
 
-func newStoredTeam(t *testing.T, db database.DatabaseProvider, captain UserId) *Team {
+func newStoredTeam(t *testing.T, db database.DatabaseProvider, captain database.UserId) *Team {
 	team := NewDefaultTeam(captain, "Test Team")
 
 	v, err := database.CreateOne(context.Background(), db, team)

--- a/model/user.go
+++ b/model/user.go
@@ -8,48 +8,15 @@ import (
 	"intraclub/database"
 )
 
-type UserId database.RecordId
-
-func (id UserId) MarshalJSON() ([]byte, error) {
-	return id.RecordId().MarshalJSON()
-}
-
-func (id UserId) RecordId() database.RecordId {
-	return database.RecordId(id)
-}
-
-func (id UserId) String() string {
-	return id.RecordId().String()
-}
-
-func UserIdListToRecordIdList(input []UserId) []database.RecordId {
-	output := make([]database.RecordId, 0, len(input))
-	for _, id := range input {
-		output = append(output, id.RecordId())
-	}
-	return output
-}
-
-func UserIdSliceToUserSlice(ctx context.Context, input []UserId, db database.DatabaseProvider) []*User {
-	output := make([]*User, 0, len(input))
-	for _, id := range input {
-		user, err := database.GetExistingRecordById(ctx, db, &User{}, id.RecordId())
-		if err == nil {
-			output = append(output, user)
-		}
-	}
-	return output
-}
-
 type User struct {
-	ID          UserId       `json:"id"`
-	FirstName   string       `json:"first_name"`
-	LastName    string       `json:"last_name"`
-	PhoneNumber PhoneNumber  `json:"phone_number"`
-	Email       EmailAddress `json:"email"`
+	ID          database.UserId `json:"id"`
+	FirstName   string          `json:"first_name"`
+	LastName    string          `json:"last_name"`
+	PhoneNumber PhoneNumber     `json:"phone_number"`
+	Email       EmailAddress    `json:"email"`
 }
 
-func (u *User) GetOwner() database.RecordId {
+func (u *User) GetOwner() database.UserId {
 	// TODO implement me
 	panic("implement me")
 }
@@ -67,16 +34,16 @@ func (u *User) UniquenessEquivalent(other *User) error {
 	return nil
 }
 
-func (u *User) SetOwner(recordId database.RecordId) {
+func (u *User) SetOwner(userId database.UserId) {
 	// don't need to do anything as User records are self-owned
 }
 
-func (u *User) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
-	return []database.RecordId{u.ID.RecordId(), database.SysAdminRecordId}
+func (u *User) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.UserId {
+	return []database.UserId{u.ID, database.SysAdminUserId}
 }
 
-func (u *User) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
-	return []database.RecordId{database.EveryoneRecordId}
+func (u *User) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.UserId {
+	return []database.UserId{database.EveryoneUserId}
 }
 
 func NewUser() *User {
@@ -92,7 +59,7 @@ func (u *User) GetId() database.RecordId {
 }
 
 func (u *User) SetId(id database.RecordId) {
-	u.ID = UserId(id)
+	u.ID = database.UserId(id)
 }
 
 func (u *User) TrimValues() {

--- a/model/week.go
+++ b/model/week.go
@@ -27,8 +27,8 @@ type Week struct {
 	Note    string
 }
 
-func (w *Week) GetOwner() database.RecordId {
-	return database.InvalidRecordId
+func (w *Week) GetOwner() database.UserId {
+	return database.InvalidUserId
 }
 
 func (w *Week) PreDelete(ctx context.Context, db database.DatabaseProvider) error {
@@ -78,7 +78,7 @@ func (w *Week) PreUpdate(_ context.Context, db database.DatabaseProvider, existi
 	return nil
 }
 
-func (w *Week) SetOwner(recordId database.RecordId) {
+func (w *Week) SetOwner(userId database.UserId) {
 	// don't need to do anything as Week records have
 	// ownership automatically inferred / enforced by the
 	// values of the SeasonId field
@@ -88,7 +88,7 @@ func NewWeek() *Week {
 	return &Week{}
 }
 
-func (w *Week) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
+func (w *Week) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.UserId {
 
 	draft, err := database.GetExistingRecordById(ctx, db, &Draft{}, w.DraftId.RecordId())
 	if err != nil {
@@ -107,11 +107,11 @@ func (w *Week) EditableBy(ctx context.Context, db database.DatabaseProvider) []d
 	if season != nil {
 		EditableBySeason(ctx, db, season.ID)
 	}
-	return []database.RecordId{draft.Owner.RecordId()}
+	return []database.UserId{draft.Owner}
 }
 
-func (w *Week) AccessibleTo(_ context.Context, _ database.DatabaseProvider) []database.RecordId {
-	return []database.RecordId{database.EveryoneRecordId}
+func (w *Week) AccessibleTo(_ context.Context, _ database.DatabaseProvider) []database.UserId {
+	return []database.UserId{database.EveryoneUserId}
 }
 
 func (w *Week) StaticallyValid() error {

--- a/model/weekly_matchup.go
+++ b/model/weekly_matchup.go
@@ -59,8 +59,8 @@ type WeeklyMatchup struct {
 	Matchups []*TeamMatchup // List of TeamMatchup s for this WeeklyMatchup, e.g. team 1 playing team 2, team 3 on bye, etc.
 }
 
-func (w *WeeklyMatchup) GetOwner() database.RecordId {
-	return database.InvalidRecordId
+func (w *WeeklyMatchup) GetOwner() database.UserId {
+	return database.InvalidUserId
 }
 
 func (w *WeeklyMatchup) UniquenessEquivalent(other *WeeklyMatchup) error {
@@ -86,15 +86,15 @@ func (w *WeeklyMatchup) SetId(id database.RecordId) {
 	w.ID = WeeklyMatchupId(id)
 }
 
-func (w *WeeklyMatchup) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.RecordId {
+func (w *WeeklyMatchup) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.UserId {
 	return EditableBySeason(ctx, db, w.SeasonId)
 }
 
-func (w *WeeklyMatchup) AccessibleTo(_ context.Context, db database.DatabaseProvider) []database.RecordId {
+func (w *WeeklyMatchup) AccessibleTo(_ context.Context, db database.DatabaseProvider) []database.UserId {
 	return database.AccessibleToEveryone
 }
 
-func (w *WeeklyMatchup) SetOwner(recordId database.RecordId) {
+func (w *WeeklyMatchup) SetOwner(userId database.UserId) {
 	// don't need to do anything here as the ownership of the
 	// WeeklyMatchup record type is automatically inferred &
 	// enforced by the associated Season assigned to it

--- a/route/user.go
+++ b/route/user.go
@@ -54,7 +54,7 @@ func (c WhoAmI) Handler(req api.ApiRequest[*model.User]) (any, int, error) {
 		return nil, http.StatusUnauthorized, errors.New("token must be passed into create user route")
 	}
 
-	user, err := database.GetExistingRecordById(req.Context, req.DatabaseProvider, &model.User{}, req.Token.UserId)
+	user, err := database.GetExistingRecordById(req.Context, req.DatabaseProvider, &model.User{}, req.Token.UserId.RecordId())
 	if err != nil {
 		return nil, http.StatusUnauthorized, err
 	}


### PR DESCRIPTION
#  Refactor: Make `UserId` a first-class type in `database` package

Moves `UserId` from the `model` package to `database`, making it a first-class type. The `Authorizable` interface and all access control mechanisms now work with `UserId` instead of `RecordId`, eliminating the need for conversion functions and making the authorization layer more intuitive.

## Why

Previously, `UserId` was defined in `model` to avoid a circular import (`model` imports `database`, so `database` couldn't reference `model.User`). The `Authorizable` interface used `RecordId` as a workaround, requiring frequent conversions between `UserId` and `RecordId` via `UserIdListToRecordIdList()` and `.RecordId()` calls. This refactor makes the access control layer type-safe and intuitive by using `UserId` directly.

## Changes by Layer

### \`database/\` package

**\`crud_record.go\`**
- Added \`UserId\` type (\`type UserId RecordId\`) with full JSON serialization support
- Renamed sentinel values: \`EveryoneUserId\`, \`SysAdminUserId\`, \`InvalidUserId\`
- Updated \`AccessibleToEveryone\` to \`[]UserId{EveryoneUserId}\`
- Updated \`SysAdminAndUsers(...UserId) []UserId\`
- Updated \`Authorizable\` interface: \`EditableBy()\`, \`AccessibleTo()\`, \`GetOwner()\`, \`SetOwner()\` now use \`UserId\`
- Updated \`CanOnlyDelete\` interface to use \`UserId\`

**\`db_with_access_control.go\`**
- \`WithAccessControl.AccessControlUser\` is now \`UserId\`
- \`SysAdminCheck\` callback signature now takes \`UserId\`

#### \`model/\` package (30+ files)

**\`user.go\`**
- Removed local \`UserId\` type definition and methods (\`RecordId()\`, \`String()\`, \`MarshalJSON()\`)
- Removed \`UserIdListToRecordIdList()\` (no longer needed)
- \`User.ID\` field now uses \`database.UserId\`
- All \`Authorizable\` methods use \`database.UserId\`

**All model types implementing \`Authorizable\`**
- \`GetOwner()\` returns \`database.UserId\` (was \`database.RecordId\`)
- \`SetOwner()\` takes \`database.UserId\` (was \`database.RecordId\`)
- \`EditableBy()\` returns \`[]database.UserId\` (was \`[]database.RecordId\`)
- \`AccessibleTo()\` returns \`[]database.UserId\` (was \`[]database.RecordId\`)
- \`database.InvalidRecordId\` replaced with \`database.InvalidUserId\`
- \`database.EveryoneRecordId\` replaced with \`database.EveryoneUserId\`
- \`database.SysAdminRecordId\` replaced with \`database.SysAdminUserId\`
- Removed all \`UserIdListToRecordIdList()\` calls (lists are already \`[]database.UserId\`)
- All \`UserId\` struct fields now use \`database.UserId\` type

### \`api/\` package

- \`AuthToken.UserId\` is now \`database.UserId\`
- \`getTokenUserIdIfExists()\` returns \`database.UserId\`
- \`ValidateToken()\` converts JWT subject to \`database.UserId\`

## Files Changed

| Layer | Files |
|-------|-------|
| \`database/\` | \`crud_record.go\`, \`db_with_access_control.go\` + 4 test files |
| \`model/\` | 30+ model files + test files |
| \`api/\` | \`api_auth.go\`, \`crud_common.go\` + test files |
| **Total** | 64 files (+726/-609 lines) |

## Migration Notes

- \`RecordId\` is still used for record IDs (\`GetId()\`, \`SetId()\`) and non-user references
- \`UserId\` is now the correct type for all user identity contexts
- Conversion between \`UserId\` and \`RecordId\` is via \`UserId.RecordId()\` and \`database.UserId(recordId)\`
