### PR TITLE
add junction tables for rating / format / draft assignments

### DIFF
--- a/model/draft.go
+++ b/model/draft.go
@@ -164,6 +164,40 @@ func (d *Draft) DynamicallyValid(ctx context.Context, db database.DatabaseProvid
 	return nil
 }
 
+func (d *Draft) PostCreate(ctx context.Context, db database.DatabaseProvider) error {
+	return d.syncDraftFormat(ctx, db)
+}
+
+func (d *Draft) PostUpdate(ctx context.Context, db database.DatabaseProvider) error {
+	return d.syncDraftFormat(ctx, db)
+}
+
+func (d *Draft) syncDraftFormat(ctx context.Context, db database.DatabaseProvider) error {
+	existing, err := database.GetAllWhere[*DraftFormat](ctx, db, func(_ context.Context, df *DraftFormat) bool {
+		return df.DraftId == d.ID
+	})
+	if err != nil {
+		return err
+	}
+
+	if len(existing) == 0 {
+		draftFormat := &DraftFormat{
+			DraftId:  d.ID,
+			FormatId: d.Format,
+		}
+		_, err = database.CreateOne(ctx, db, draftFormat)
+		return err
+	}
+
+	df := existing[0]
+	if df.FormatId != d.Format {
+		df.FormatId = d.Format
+		err = database.UpdateOne(ctx, db, df)
+	}
+
+	return err
+}
+
 func (d *Draft) Type() string {
 	return "draft"
 }

--- a/model/draft_format.go
+++ b/model/draft_format.go
@@ -1,0 +1,72 @@
+package model
+
+import (
+	"context"
+	"fmt"
+
+	"intraclub/database"
+)
+
+// DraftFormat is a join table record that links a Draft to its Format.
+// This enables efficient reverse lookups from Format to Drafts without
+// scanning the entire Draft collection.
+type DraftFormat struct {
+	ID       database.RecordId `json:"id"`
+	DraftId  DraftId           `json:"draft_id"`
+	FormatId FormatId          `json:"format_id"`
+}
+
+func (d *DraftFormat) GetOwner() database.UserId {
+	return database.InvalidUserId
+}
+
+func (d *DraftFormat) SetOwner(userId database.UserId) {}
+
+func (d *DraftFormat) Type() string {
+	return "draft_format"
+}
+
+func (d *DraftFormat) GetId() database.RecordId {
+	return d.ID
+}
+
+func (d *DraftFormat) SetId(id database.RecordId) {
+	d.ID = id
+}
+
+func (d *DraftFormat) StaticallyValid() error {
+	return nil
+}
+
+func (d *DraftFormat) DynamicallyValid(ctx context.Context, db database.DatabaseProvider) error {
+	_, err := database.GetExistingRecordById(ctx, db, &Draft{}, d.DraftId.RecordId())
+	if err != nil {
+		return err
+	}
+
+	_, err = database.GetExistingRecordById(ctx, db, &Format{}, d.FormatId.RecordId())
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (d *DraftFormat) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.UserId {
+	return database.AccessibleToEveryone
+}
+
+func (d *DraftFormat) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.UserId {
+	return []database.UserId{database.SysAdminUserId}
+}
+
+func (d *DraftFormat) BlankRecord() database.CrudRecord {
+	return new(DraftFormat)
+}
+
+func (d *DraftFormat) UniquenessEquivalent(other *DraftFormat) error {
+	if d.DraftId == other.DraftId {
+		return fmt.Errorf("draft %s already has an assigned format", d.DraftId)
+	}
+	return nil
+}

--- a/model/format.go
+++ b/model/format.go
@@ -108,11 +108,11 @@ func (id FormatId) String() string {
 //   - old guy / young guy
 //   - young guy / young guy.
 type Format struct {
-	ID              FormatId     `json:"id"`               // unique ID for the Format
-	UserId          database.UserId       `json:"user_id"`          // owner of the Format
-	Name            string       `json:"name"`             // name for the Format, e.g. "Men's Intraclub 1/2/3"
-	PossibleRatings RatingList   `json:"possible_ratings"` // list of possible Rating values for the lines, highest to lowest skill
-	Lines           []FormatLine `json:"lines"`            // Rating pairings that will play during a matchup
+	ID              FormatId        `json:"id"`               // unique ID for the Format
+	UserId          database.UserId `json:"user_id"`          // owner of the Format
+	Name            string          `json:"name"`             // name for the Format, e.g. "Men's Intraclub 1/2/3"
+	PossibleRatings RatingList      `json:"possible_ratings"` // list of possible Rating values for the lines, highest to lowest skill
+	Lines           []FormatLine    `json:"lines"`            // Rating pairings that will play during a matchup
 }
 
 func (f *Format) GetOwner() database.UserId {
@@ -125,6 +125,51 @@ func (f *Format) PreUpdate(ctx context.Context, db database.DatabaseProvider, ex
 
 func (f *Format) PreDelete(ctx context.Context, db database.DatabaseProvider) error {
 	return f.CheckHasAssignedDrafts(ctx, db, false)
+}
+
+func (f *Format) PostCreate(ctx context.Context, db database.DatabaseProvider) error {
+	return f.syncFormatRatings(ctx, db)
+}
+
+func (f *Format) PostUpdate(ctx context.Context, db database.DatabaseProvider) error {
+	return f.syncFormatRatings(ctx, db)
+}
+
+func (f *Format) syncFormatRatings(ctx context.Context, db database.DatabaseProvider) error {
+	existing, err := database.GetAllWhere[*FormatRating](ctx, db, func(_ context.Context, fr *FormatRating) bool {
+		return fr.FormatId == f.ID
+	})
+	if err != nil {
+		return err
+	}
+
+	existingMap := make(map[RatingId]*FormatRating)
+	for _, fr := range existing {
+		existingMap[fr.RatingId] = fr
+	}
+
+	for _, ratingId := range f.PossibleRatings {
+		if _, exists := existingMap[ratingId]; !exists {
+			formatRating := &FormatRating{
+				FormatId: f.ID,
+				RatingId: ratingId,
+			}
+			_, err = database.CreateOne(ctx, db, formatRating)
+			if err != nil {
+				return err
+			}
+		}
+		delete(existingMap, ratingId)
+	}
+
+	for _, fr := range existingMap {
+		_, _, err = database.DeleteOneById(ctx, db, fr, fr.ID)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (f *Format) SetOwner(userId database.UserId) {
@@ -222,13 +267,28 @@ func (f *Format) IsRatingValidForFormat(r RatingId) bool {
 }
 
 func (f *Format) GetAssignedDrafts(ctx context.Context, db database.DatabaseProvider) ([]*Draft, error) {
-	return database.GetAllWhere[*Draft](ctx, db, func(_ context.Context, c *Draft) bool {
-		return c.Format == f.ID
+	draftFormats, err := database.GetAllWhere[*DraftFormat](ctx, db, func(_ context.Context, df *DraftFormat) bool {
+		return df.FormatId == f.ID
 	})
+	if err != nil {
+		return nil, err
+	}
+
+	drafts := make([]*Draft, 0, len(draftFormats))
+	for _, df := range draftFormats {
+		d, err := database.GetExistingRecordById(ctx, db, &Draft{}, df.DraftId.RecordId())
+		if err != nil {
+			return nil, err
+		}
+		drafts = append(drafts, d)
+	}
+	return drafts, nil
 }
 
 func (f *Format) CheckHasAssignedDrafts(ctx context.Context, db database.DatabaseProvider, isUpdate bool) error {
-	drafts, err := f.GetAssignedDrafts(ctx, db)
+	draftFormats, err := database.GetAllWhere[*DraftFormat](ctx, db, func(_ context.Context, df *DraftFormat) bool {
+		return df.FormatId == f.ID
+	})
 	if err != nil {
 		return err
 	}
@@ -238,8 +298,8 @@ func (f *Format) CheckHasAssignedDrafts(ctx context.Context, db database.Databas
 		verb = "delete"
 	}
 
-	if len(drafts) != 0 {
-		return fmt.Errorf("cannot %s format with %d assigned drafts", verb, len(drafts))
+	if len(draftFormats) != 0 {
+		return fmt.Errorf("cannot %s format with %d assigned drafts", verb, len(draftFormats))
 	}
 	return nil
 }

--- a/model/format_rating.go
+++ b/model/format_rating.go
@@ -1,0 +1,72 @@
+package model
+
+import (
+	"context"
+	"fmt"
+
+	"intraclub/database"
+)
+
+// FormatRating is a join table record that links a Format to a Rating.
+// This enables efficient reverse lookups from Rating to Formats without
+// scanning the entire Format collection.
+type FormatRating struct {
+	ID       database.RecordId `json:"id"`
+	FormatId FormatId          `json:"format_id"`
+	RatingId RatingId          `json:"rating_id"`
+}
+
+func (f *FormatRating) GetOwner() database.UserId {
+	return database.InvalidUserId
+}
+
+func (f *FormatRating) SetOwner(userId database.UserId) {}
+
+func (f *FormatRating) Type() string {
+	return "format_rating"
+}
+
+func (f *FormatRating) GetId() database.RecordId {
+	return f.ID
+}
+
+func (f *FormatRating) SetId(id database.RecordId) {
+	f.ID = id
+}
+
+func (f *FormatRating) StaticallyValid() error {
+	return nil
+}
+
+func (f *FormatRating) DynamicallyValid(ctx context.Context, db database.DatabaseProvider) error {
+	_, err := database.GetExistingRecordById(ctx, db, &Format{}, f.FormatId.RecordId())
+	if err != nil {
+		return err
+	}
+
+	_, err = database.GetExistingRecordById(ctx, db, &Rating{}, f.RatingId.RecordId())
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (f *FormatRating) AccessibleTo(ctx context.Context, db database.DatabaseProvider) []database.UserId {
+	return database.AccessibleToEveryone
+}
+
+func (f *FormatRating) EditableBy(ctx context.Context, db database.DatabaseProvider) []database.UserId {
+	return []database.UserId{database.SysAdminUserId}
+}
+
+func (f *FormatRating) BlankRecord() database.CrudRecord {
+	return new(FormatRating)
+}
+
+func (f *FormatRating) UniquenessEquivalent(other *FormatRating) error {
+	if f.FormatId == other.FormatId && f.RatingId == other.RatingId {
+		return fmt.Errorf("format %s already has rating %s assigned", f.FormatId, f.RatingId)
+	}
+	return nil
+}

--- a/model/rating.go
+++ b/model/rating.go
@@ -47,10 +47,10 @@ func (r *RatingList) UnmarshalJSON(bytes []byte) error {
 }
 
 type Rating struct {
-	ID          RatingId `json:"id"`
-	UserId      database.UserId   `json:"user_id"`
-	Name        string   `json:"name"`
-	Description string   `json:"description"`
+	ID          RatingId        `json:"id"`
+	UserId      database.UserId `json:"user_id"`
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
 }
 
 func (r *Rating) UniquenessEquivalent(other *Rating) error {
@@ -65,14 +65,14 @@ func (r *Rating) GetOwner() database.UserId {
 }
 
 func (r *Rating) PreDelete(ctx context.Context, db database.DatabaseProvider) error {
-	formats, err := database.GetAllWhere[*Format](ctx, db, func(_ context.Context, c *Format) bool {
-		return c.IsRatingInOptionsList(r.ID)
+	formatRatings, err := database.GetAllWhere[*FormatRating](ctx, db, func(_ context.Context, fr *FormatRating) bool {
+		return fr.RatingId == r.ID
 	})
 	if err != nil {
 		return err
 	}
-	if len(formats) >= 0 {
-		return fmt.Errorf("rating with ID %s is in-use by %d formats", r.ID, len(formats))
+	if len(formatRatings) > 0 {
+		return fmt.Errorf("rating with ID %s is in-use by %d formats", r.ID, len(formatRatings))
 	}
 	return nil
 }


### PR DESCRIPTION
## New junction models:

- `DraftFormat (model/draft_format.go)`— links `Draft` to `Format`, with uniqueness constraint on `DraftId`
- `FormatRating (model/format_rating.go)` — links `Format` to `Rating`, with uniqueness constraint on (`FormatId`, `RatingId`) pair

## Sync hooks:

- `Draft.PostCreate / Draft.PostUpdate` — automatically creates/updates the `DraftFormat` record when a `Draft` is created or its `Format` changes
`Format.PostCreate` / `Format.PostUpdate` — syncs `FormatRating` records to match `Format.PossibleRatings`, adding new ones and removing stale ones

## Updated validation:

- `Format.CheckHasAssignedDrafts` — now scans the smaller `DraftFormat` collection instead of all `Draft`s
- `Format.GetAssignedDrafts` — resolves `Draft`s through the junction table
- `Rating.PreDelete` — now scans `FormatRating` instead of all `Format`s

The `Draft.Format` and `Format.PossibleRatings` fields are kept for convenience in normal operations — the junction tables exist purely to make reverse-lookup validation cheaper.