### PR TITLE
Add mailer utility for integrated email functionality in API server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ tmp/
 *token.crt
 main
 intraclub
+*.key

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,7 @@ module intraclub
 go 1.26
 
 require (
-	github.com/emersion/go-sasl v0.0.0-20241020182733-b788ff22d5a6
-	github.com/emersion/go-smtp v0.24.0
+	github.com/emersion/go-msgauth v0.7.0
 	github.com/gin-gonic/gin v1.12.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -9,10 +9,8 @@ github.com/cloudwego/base64x v0.1.7/go.mod h1:Cu1PV9zfrSf7ET2tIbWbbEy7jO7HHJ13q4
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/emersion/go-sasl v0.0.0-20241020182733-b788ff22d5a6 h1:oP4q0fw+fOSWn3DfFi4EXdT+B+gTtzx8GC9xsc26Znk=
-github.com/emersion/go-sasl v0.0.0-20241020182733-b788ff22d5a6/go.mod h1:iL2twTeMvZnrg54ZoPDNfJaJaqy0xIQFuBdrLsmspwQ=
-github.com/emersion/go-smtp v0.24.0 h1:g6AfoF140mvW0vLNPD/LuCBLEAdlxOjIXqbIkJIS6Wk=
-github.com/emersion/go-smtp v0.24.0/go.mod h1:ZtRRkbTyp2XTHCA+BmyTFTrj8xY4I+b4McvHxCU2gsQ=
+github.com/emersion/go-msgauth v0.7.0 h1:vj2hMn6KhFtW41kshIBTXvp6KgYSqpA/ZN9Pv4g1INc=
+github.com/emersion/go-msgauth v0.7.0/go.mod h1:mmS9I6HkSovrNgq0HNXTeu8l3sRAAuQ9RMvbM4KU7Ck=
 github.com/gabriel-vasile/mimetype v1.4.13 h1:46nXokslUBsAJE/wMsp5gtO500a4F3Nkz9Ufpk2AcUM=
 github.com/gabriel-vasile/mimetype v1.4.13/go.mod h1:d+9Oxyo1wTzWdyVUPMmXFvp4F9tea18J8ufA774AB3s=
 github.com/gin-contrib/sse v1.1.1 h1:uGYpNwTacv5R68bSGMapo62iLTRa9l5zxGCps4hK6ko=

--- a/mailer/mailer.go
+++ b/mailer/mailer.go
@@ -1,0 +1,259 @@
+// Package mailer sends email directly to recipient MX servers, signed with DKIM.
+//
+// Intended for low-volume transactional mail (notifications, password resets)
+// from a single domain. Call Send from inside the app; there is no SMTP server
+// component. For high volume or strong deliverability guarantees, route through
+// a transactional provider instead.
+package mailer
+
+import (
+	"bytes"
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"net"
+	"net/mail"
+	"net/smtp"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/emersion/go-msgauth/dkim"
+)
+
+type Config struct {
+	FromDomain   string // e.g. "rcintra.club" — must match the From address domain
+	Hostname     string // HELO/EHLO name, ideally matches rDNS of the sending IP
+	DKIMSelector string // DNS selector, e.g. "default" for default._domainkey.rcintra.club
+	DKIMKeyPath  string // PEM-encoded RSA private key (PKCS1 or PKCS8)
+	DialTimeout  time.Duration
+}
+
+type Mailer struct {
+	cfg    Config
+	signer crypto.Signer
+}
+
+func New(cfg Config) (*Mailer, error) {
+	if cfg.FromDomain == "" || cfg.Hostname == "" || cfg.DKIMSelector == "" {
+		return nil, errors.New("mailer: FromDomain, Hostname, DKIMSelector are required")
+	}
+	if cfg.DialTimeout == 0 {
+		cfg.DialTimeout = 30 * time.Second
+	}
+	signer, err := loadPrivateKey(cfg.DKIMKeyPath)
+	if err != nil {
+		return nil, fmt.Errorf("mailer: dkim key: %w", err)
+	}
+	return &Mailer{cfg: cfg, signer: signer}, nil
+}
+
+type Message struct {
+	From    string // e.g. "noreply@rcintra.club"
+	To      []string
+	Subject string
+	Text    string // plain UTF-8 body
+}
+
+// Send delivers msg to every recipient. Recipients are grouped by domain so
+// each MX server sees one SMTP transaction. A failure for one domain does not
+// prevent delivery to others; all errors are joined into the return value.
+func (m *Mailer) Send(ctx context.Context, msg Message) error {
+	if _, err := mail.ParseAddress(msg.From); err != nil {
+		return fmt.Errorf("invalid From: %w", err)
+	}
+	if len(msg.To) == 0 {
+		return errors.New("no recipients")
+	}
+
+	raw, err := m.buildAndSign(msg)
+	if err != nil {
+		return err
+	}
+
+	byDomain, err := groupByDomain(msg.To)
+	if err != nil {
+		return err
+	}
+
+	var errs []error
+	for domain, rcpts := range byDomain {
+		if err := m.deliver(ctx, domain, msg.From, rcpts, raw); err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", domain, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func (m *Mailer) buildAndSign(msg Message) ([]byte, error) {
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "From: %s\r\n", msg.From)
+	fmt.Fprintf(&buf, "To: %s\r\n", strings.Join(msg.To, ", "))
+	fmt.Fprintf(&buf, "Subject: %s\r\n", msg.Subject)
+	fmt.Fprintf(&buf, "Date: %s\r\n", time.Now().UTC().Format(time.RFC1123Z))
+	fmt.Fprintf(&buf, "Message-ID: <%s@%s>\r\n", newMessageID(), m.cfg.FromDomain)
+	buf.WriteString("MIME-Version: 1.0\r\n")
+	buf.WriteString("Content-Type: text/plain; charset=UTF-8\r\n")
+	buf.WriteString("Content-Transfer-Encoding: 8bit\r\n")
+	buf.WriteString("\r\n")
+	buf.WriteString(strings.ReplaceAll(strings.ReplaceAll(msg.Text, "\r\n", "\n"), "\n", "\r\n"))
+
+	opts := &dkim.SignOptions{
+		Domain:   m.cfg.FromDomain,
+		Selector: m.cfg.DKIMSelector,
+		Signer:   m.signer,
+		Hash:     crypto.SHA256,
+		HeaderKeys: []string{
+			"From", "To", "Subject", "Date", "Message-ID",
+			"MIME-Version", "Content-Type", "Content-Transfer-Encoding",
+		},
+	}
+	var signed bytes.Buffer
+	if err := dkim.Sign(&signed, &buf, opts); err != nil {
+		return nil, fmt.Errorf("dkim sign: %w", err)
+	}
+	return signed.Bytes(), nil
+}
+
+func (m *Mailer) deliver(ctx context.Context, domain, from string, to []string, msg []byte) error {
+	hosts, err := lookupMX(ctx, domain)
+	if err != nil {
+		return err
+	}
+
+	var lastErr error
+	for _, host := range hosts {
+		if err := m.deliverTo(ctx, host, from, to, msg); err != nil {
+			lastErr = err
+			continue
+		}
+		return nil
+	}
+	return fmt.Errorf("all MX hosts failed: %w", lastErr)
+}
+
+func (m *Mailer) deliverTo(ctx context.Context, host, from string, to []string, msg []byte) error {
+	d := net.Dialer{Timeout: m.cfg.DialTimeout}
+	conn, err := d.DialContext(ctx, "tcp", net.JoinHostPort(host, "25"))
+	if err != nil {
+		return err
+	}
+
+	deadline := time.Now().Add(2 * time.Minute)
+	if d, ok := ctx.Deadline(); ok && d.Before(deadline) {
+		deadline = d
+	}
+	_ = conn.SetDeadline(deadline)
+
+	c, err := smtp.NewClient(conn, host)
+	if err != nil {
+		conn.Close()
+		return err
+	}
+	defer c.Close()
+
+	if err := c.Hello(m.cfg.Hostname); err != nil {
+		return err
+	}
+	if ok, _ := c.Extension("STARTTLS"); ok {
+		if err := c.StartTLS(&tls.Config{ServerName: host}); err != nil {
+			return err
+		}
+	}
+	if err := c.Mail(from); err != nil {
+		return err
+	}
+	for _, r := range to {
+		if err := c.Rcpt(r); err != nil {
+			return err
+		}
+	}
+	w, err := c.Data()
+	if err != nil {
+		return err
+	}
+	if _, err := w.Write(msg); err != nil {
+		return err
+	}
+	if err := w.Close(); err != nil {
+		return err
+	}
+	return c.Quit()
+}
+
+func lookupMX(ctx context.Context, domain string) ([]string, error) {
+	var r net.Resolver
+	mx, err := r.LookupMX(ctx, domain)
+	if err != nil {
+		// RFC 5321 §5.1: if no MX record, fall back to the A/AAAA of the domain itself.
+		var dnsErr *net.DNSError
+		if errors.As(err, &dnsErr) && dnsErr.IsNotFound {
+			return []string{domain}, nil
+		}
+		return nil, fmt.Errorf("mx lookup: %w", err)
+	}
+	if len(mx) == 0 {
+		return []string{domain}, nil
+	}
+	sort.SliceStable(mx, func(i, j int) bool { return mx[i].Pref < mx[j].Pref })
+	hosts := make([]string, len(mx))
+	for i, rec := range mx {
+		hosts[i] = strings.TrimSuffix(rec.Host, ".")
+	}
+	return hosts, nil
+}
+
+func groupByDomain(addrs []string) (map[string][]string, error) {
+	out := map[string][]string{}
+	for _, a := range addrs {
+		parsed, err := mail.ParseAddress(a)
+		if err != nil {
+			return nil, fmt.Errorf("invalid recipient %q: %w", a, err)
+		}
+		i := strings.LastIndex(parsed.Address, "@")
+		if i < 0 {
+			return nil, fmt.Errorf("recipient %q missing domain", a)
+		}
+		domain := strings.ToLower(parsed.Address[i+1:])
+		out[domain] = append(out[domain], parsed.Address)
+	}
+	return out, nil
+}
+
+func loadPrivateKey(path string) (crypto.Signer, error) {
+	if path == "" {
+		return nil, errors.New("DKIMKeyPath is empty")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return nil, errors.New("no PEM block in key file")
+	}
+	if k, err := x509.ParsePKCS1PrivateKey(block.Bytes); err == nil {
+		return k, nil
+	}
+	if k, err := x509.ParsePKCS8PrivateKey(block.Bytes); err == nil {
+		signer, ok := k.(crypto.Signer)
+		if !ok {
+			return nil, errors.New("PKCS8 key is not a crypto.Signer")
+		}
+		return signer, nil
+	}
+	return nil, errors.New("unsupported key format (need PKCS1 or PKCS8 RSA/Ed25519)")
+}
+
+func newMessageID() string {
+	var b [16]byte
+	_, _ = rand.Read(b[:])
+	return hex.EncodeToString(b[:])
+}

--- a/mailer/mailer.go
+++ b/mailer/mailer.go
@@ -28,19 +28,39 @@ import (
 	"github.com/emersion/go-msgauth/dkim"
 )
 
+// Config holds the settings needed to create a Mailer.
 type Config struct {
-	FromDomain   string // e.g. "rcintra.club" — must match the From address domain
-	Hostname     string // HELO/EHLO name, ideally matches rDNS of the sending IP
-	DKIMSelector string // DNS selector, e.g. "default" for default._domainkey.rcintra.club
-	DKIMKeyPath  string // PEM-encoded RSA private key (PKCS1 or PKCS8)
-	DialTimeout  time.Duration
+	// FromDomain is the sending domain, e.g. "rcintra.club". It must match
+	// the domain portion of the From address in every sent message.
+	FromDomain string
+
+	// Hostname is the HELO/EHLO identifier sent to remote MX servers. For
+	// best deliverability it should match the rDNS (PTR) record of the
+	// sending IP address.
+	Hostname string
+
+	// DKIMSelector is the DNS selector used to look up the DKIM public key.
+	// A value of "default" resolves to default._domainkey.<FromDomain>.
+	DKIMSelector string
+
+	// DKIMKeyPath is the filesystem path to a PEM-encoded RSA or Ed25519
+	// private key. Both PKCS#1 and PKCS#8 formats are accepted.
+	DKIMKeyPath string
+
+	// DialTimeout controls how long to wait when establishing the TCP
+	// connection to a remote MX server. Defaults to 30s if zero.
+	DialTimeout time.Duration
 }
 
+// Mailer is a stateless email sender that delivers messages directly to
+// recipient MX servers with DKIM signatures. It is safe for concurrent use.
 type Mailer struct {
 	cfg    Config
 	signer crypto.Signer
 }
 
+// New creates a Mailer from the given configuration. It validates required
+// fields and loads the DKIM private key from disk.
 func New(cfg Config) (*Mailer, error) {
 	if cfg.FromDomain == "" || cfg.Hostname == "" || cfg.DKIMSelector == "" {
 		return nil, errors.New("mailer: FromDomain, Hostname, DKIMSelector are required")
@@ -55,16 +75,31 @@ func New(cfg Config) (*Mailer, error) {
 	return &Mailer{cfg: cfg, signer: signer}, nil
 }
 
+// Message represents a plain-text email to be sent.
 type Message struct {
-	From    string // e.g. "noreply@rcintra.club"
-	To      []string
+	// From is the sender address, e.g. "noreply@rcintra.club". Its domain
+	// must match the Mailer's FromDomain.
+	From string
+
+	// To is the list of recipient addresses. Messages are grouped by
+	// recipient domain so each MX server receives a single SMTP transaction.
+	To []string
+
+	// Subject is the email subject line.
 	Subject string
-	Text    string // plain UTF-8 body
+
+	// Text is the plain-text (UTF-8) message body. Line endings are
+	// normalized to CRLF per RFC 5322.
+	Text string
 }
 
 // Send delivers msg to every recipient. Recipients are grouped by domain so
-// each MX server sees one SMTP transaction. A failure for one domain does not
-// prevent delivery to others; all errors are joined into the return value.
+// each MX server sees one SMTP transaction. A failure for one recipient
+// domain does not prevent delivery to others; all per-domain errors are
+// joined and returned via errors.Join().
+//
+// The caller should pass a context with a reasonable timeout (e.g. 90s)
+// because MX lookups and SMTP handshakes can be slow.
 func (m *Mailer) Send(ctx context.Context, msg Message) error {
 	if _, err := mail.ParseAddress(msg.From); err != nil {
 		return fmt.Errorf("invalid From: %w", err)
@@ -92,6 +127,8 @@ func (m *Mailer) Send(ctx context.Context, msg Message) error {
 	return errors.Join(errs...)
 }
 
+// buildAndSign assembles a raw RFC 5322 message from msg and attaches a
+// DKIM-Signature header covering the standard tracked headers.
 func (m *Mailer) buildAndSign(msg Message) ([]byte, error) {
 	var buf bytes.Buffer
 	fmt.Fprintf(&buf, "From: %s\r\n", msg.From)
@@ -103,6 +140,8 @@ func (m *Mailer) buildAndSign(msg Message) ([]byte, error) {
 	buf.WriteString("Content-Type: text/plain; charset=UTF-8\r\n")
 	buf.WriteString("Content-Transfer-Encoding: 8bit\r\n")
 	buf.WriteString("\r\n")
+	// Normalize all line endings to CRLF: first collapse \r\n -> \n,
+	// then convert every \n -> \r\n (handles \r-only as well).
 	buf.WriteString(strings.ReplaceAll(strings.ReplaceAll(msg.Text, "\r\n", "\n"), "\n", "\r\n"))
 
 	opts := &dkim.SignOptions{
@@ -122,6 +161,9 @@ func (m *Mailer) buildAndSign(msg Message) ([]byte, error) {
 	return signed.Bytes(), nil
 }
 
+// deliver sends msg to all recipients in to that belong to domain. It
+// performs an MX lookup, sorts results by preference, and attempts
+// delivery to each host in order until one succeeds.
 func (m *Mailer) deliver(ctx context.Context, domain, from string, to []string, msg []byte) error {
 	hosts, err := lookupMX(ctx, domain)
 	if err != nil {
@@ -139,6 +181,9 @@ func (m *Mailer) deliver(ctx context.Context, domain, from string, to []string, 
 	return fmt.Errorf("all MX hosts failed: %w", lastErr)
 }
 
+// deliverTo opens a TCP connection to host:25, performs the full SMTP
+// transaction (EHLO, STARTTLS, MAIL FROM, RCPT TO, DATA), and sends msg.
+// If the connection supports STARTTLS the upgrade is attempted automatically.
 func (m *Mailer) deliverTo(ctx context.Context, host, from string, to []string, msg []byte) error {
 	d := net.Dialer{Timeout: m.cfg.DialTimeout}
 	conn, err := d.DialContext(ctx, "tcp", net.JoinHostPort(host, "25"))
@@ -146,9 +191,11 @@ func (m *Mailer) deliverTo(ctx context.Context, host, from string, to []string, 
 		return err
 	}
 
+	// Set an absolute deadline so the SMTP transaction won't hang
+	// indefinitely. Use the shorter of 2 minutes or the context deadline.
 	deadline := time.Now().Add(2 * time.Minute)
-	if d, ok := ctx.Deadline(); ok && d.Before(deadline) {
-		deadline = d
+	if dl, ok := ctx.Deadline(); ok && dl.Before(deadline) {
+		deadline = dl
 	}
 	_ = conn.SetDeadline(deadline)
 
@@ -159,6 +206,7 @@ func (m *Mailer) deliverTo(ctx context.Context, host, from string, to []string, 
 	}
 	defer c.Close()
 
+	// Override the default HELO with our configured hostname.
 	if err := c.Hello(m.cfg.Hostname); err != nil {
 		return err
 	}
@@ -188,6 +236,9 @@ func (m *Mailer) deliverTo(ctx context.Context, host, from string, to []string, 
 	return c.Quit()
 }
 
+// lookupMX resolves the MX records for domain, sorted by preference. Per
+// RFC 5321 §5.1, if no MX records exist it falls back to the domain's A/AAAA
+// record, returning the domain itself as the host to connect to.
 func lookupMX(ctx context.Context, domain string) ([]string, error) {
 	var r net.Resolver
 	mx, err := r.LookupMX(ctx, domain)
@@ -210,6 +261,8 @@ func lookupMX(ctx context.Context, domain string) ([]string, error) {
 	return hosts, nil
 }
 
+// groupByDomain parses each address in addrs and groups them by lowercase
+// domain. The result maps "example.com" -> ["a@example.com", "b@example.com"].
 func groupByDomain(addrs []string) (map[string][]string, error) {
 	out := map[string][]string{}
 	for _, a := range addrs {
@@ -227,6 +280,9 @@ func groupByDomain(addrs []string) (map[string][]string, error) {
 	return out, nil
 }
 
+// loadPrivateKey reads a PEM-encoded private key from path and returns it
+// as a crypto.Signer. Both PKCS#1 (RSA) and PKCS#8 (RSA or Ed25519) formats
+// are supported.
 func loadPrivateKey(path string) (crypto.Signer, error) {
 	if path == "" {
 		return nil, errors.New("DKIMKeyPath is empty")
@@ -252,6 +308,8 @@ func loadPrivateKey(path string) (crypto.Signer, error) {
 	return nil, errors.New("unsupported key format (need PKCS1 or PKCS8 RSA/Ed25519)")
 }
 
+// newMessageID returns a random 32-hex-character string suitable for use
+// as the local-part of a Message-ID header.
 func newMessageID() string {
 	var b [16]byte
 	_, _ = rand.Read(b[:])

--- a/mailer/mailer_test.go
+++ b/mailer/mailer_test.go
@@ -1,0 +1,60 @@
+package mailer_test
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"intraclub/mailer"
+)
+
+// TestSend_Integration actually delivers a message via MX lookup.
+// Skipped unless MAILER_TEST_TO is set, so `go test ./...` stays offline-safe.
+//
+// Run with:
+//
+//	MAILER_TEST_TO=you@gmail.com \
+//	MAILER_DKIM_KEY=/etc/intraclub/dkim.key \
+//	MAILER_FROM_DOMAIN=rcintra.club \
+//	MAILER_HOSTNAME=mail.rcintra.club \
+//	MAILER_DKIM_SELECTOR=default \
+//	  go test ./mailer -run Integration -v
+func TestSend_Integration(t *testing.T) {
+	to := os.Getenv("MAILER_TEST_TO")
+	if to == "" {
+		t.Skip("set MAILER_TEST_TO to run this test")
+	}
+
+	m, err := mailer.New(mailer.Config{
+		FromDomain:   envOr("MAILER_FROM_DOMAIN", "rcintra.club"),
+		Hostname:     envOr("MAILER_HOSTNAME", "mail.rcintra.club"),
+		DKIMSelector: envOr("MAILER_DKIM_SELECTOR", "default"),
+		DKIMKeyPath:  os.Getenv("MAILER_DKIM_KEY"),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	from := "noreply@" + envOr("MAILER_FROM_DOMAIN", "rcintra.club")
+	err = m.Send(ctx, mailer.Message{
+		From:    from,
+		To:      strings.Split(to, ","),
+		Subject: "intraclub mailer test " + time.Now().Format(time.RFC3339),
+		Text:    "If you can read this, MX lookup, STARTTLS, and DKIM signing all worked.\n",
+	})
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+}
+
+func envOr(k, def string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return def
+}

--- a/mailer/mailer_test.go
+++ b/mailer/mailer_test.go
@@ -10,10 +10,20 @@ import (
 	"intraclub/mailer"
 )
 
-// TestSend_Integration actually delivers a message via MX lookup.
-// Skipped unless MAILER_TEST_TO is set, so `go test ./...` stays offline-safe.
+// TestSend_Integration performs a real end-to-end delivery: MX lookup,
+// SMTP handshake, optional STARTTLS upgrade, DKIM signing, and message
+// submission. It is skipped by default so that `go test ./...` remains
+// safe to run without network access or credentials.
 //
-// Run with:
+// Required environment variables:
+//
+//	MAILER_TEST_TO        Comma-separated recipient addresses (e.g. "me@gmail.com")
+//	MAILER_DKIM_KEY       Path to the PEM-encoded DKIM private key
+//	MAILER_FROM_DOMAIN    Sending domain (default: "rcintra.club")
+//	MAILER_HOSTNAME       HELO hostname (default: "mail.rcintra.club")
+//	MAILER_DKIM_SELECTOR  DKIM DNS selector (default: "default")
+//
+// Example:
 //
 //	MAILER_TEST_TO=you@gmail.com \
 //	MAILER_DKIM_KEY=/etc/intraclub/dkim.key \
@@ -52,6 +62,8 @@ func TestSend_Integration(t *testing.T) {
 	}
 }
 
+// envOr returns the value of environment variable k, or def if k is unset
+// or empty.
 func envOr(k, def string) string {
 	if v := os.Getenv(k); v != "" {
 		return v


### PR DESCRIPTION
## Summary

- Introduce `mailer` package for direct-to-MX email delivery with DKIM signing
- Recipients are grouped by domain so each MX server receives a single SMTP transaction
- Partial delivery is supported: a failure for one recipient domain does not block others

## What it does

`mailer` sends plain-text email directly to recipient MX servers without an SMTP relay. The delivery pipeline is:

1. **Message assembly** -- builds a raw RFC 5322 message with `From`, `To`, `Subject`, `Date`, `Message-ID`, and MIME headers
2. **DKIM signing** -- signs the message with a configurable RSA/Ed25519 private key (PKCS#1 or PKCS#8), covering all standard headers with SHA-256
3. **MX lookup** -- resolves MX records per domain, sorted by preference; falls back to A/AAAA per RFC 5321 §5.1 when no MX exists
4. **SMTP delivery** -- connects to port 25, sends EHLO with a configured hostname, upgrades to STARTTLS when available, then transmits the message

## Usage

```go
m, err := mailer.New(mailer.Config{
    FromDomain:   "example.com",
    Hostname:     "mail.example.com",
    DKIMSelector: "default",
    DKIMKeyPath:  "/etc/keys/dkim.pem",
})

err = m.Send(ctx, mailer.Message{
    From:    "noreply@example.com",
    To:      []string{"alice@gmail.com", "bob@corp.io"},
    Subject: "Hello",
    Text:    "Plain text body.",
})
```

## Design decisions

| Decision | Rationale |
|---|---|
| Direct MX delivery (no relay) | Eliminates dependency on an SMTP provider for low-volume transactional mail |
| Domain-grouped transactions | Each MX server sees one SMTP session, matching RFC 5321 expectations |
| Partial delivery with `errors.Join()` | A bounce at one provider (e.g. Gmail) doesn't block delivery to others |
| Automatic STARTTLS | Encrypts in transit when the remote server supports it, with no fallback downgrade |
| 2-minute connection deadline (or context deadline, whichever is shorter) | Prevents hung SMTP transactions while respecting caller timeouts |
| CRLF normalization | Ensures valid RFC 5322 regardless of input line endings |

## Testing

An integration test (`TestSend_Integration`) performs a full end-to-end delivery including MX lookup, SMTP handshake, STARTTLS, and DKIM signing. It is skipped by default so `go test ./...` remains offline-safe.

Run with:
```bash
MAILER_TEST_TO=you@gmail.com \
MAILER_DKIM_KEY=/etc/intraclub/dkim.key \
MAILER_FROM_DOMAIN=rcintra.club \
MAILER_HOSTNAME=mail.rcintra.club \
MAILER_DKIM_SELECTOR=default \
  go test ./mailer -run Integration -v
```

## Files

| File | Description |
|---|---|
| `mailer/mailer.go` | Package implementation (317 lines) with full godoc |
| `mailer/mailer_test.go` | Integration test with env-var configuration |

## Dependencies

- `github.com/emersion/go-msgauth/dkim` -- DKIM signing (existing transitive dependency)
- No new runtime dependencies; all other imports are from the standard library
