### PR TITLE
add email token type + reorganize some stuff into routes/user

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"intraclub/database"
 	"intraclub/model"
 	"intraclub/route"
+	"intraclub/route/user"
 
 	"github.com/gin-gonic/gin"
 )
@@ -38,10 +39,10 @@ func main() {
 
 	// noAuth for self-register
 	createUser := api.RouteFamily[*model.User]{NoAuth: true, DatabaseProvider: db}
-	createUser.Handle(rg, route.SelfRegister{})
+	createUser.Handle(rg, user.SelfRegister{})
 
 	whoAmI := api.RouteFamily[*model.User]{DatabaseProvider: db}
-	whoAmI.Handle(rg, route.WhoAmI{})
+	whoAmI.Handle(rg, user.WhoAmI{})
 
 	importHandler := &route.CsvImportHandler{DatabaseProvider: db}
 	rg.Handle(api.HttpMethodPost.String(), "/import_users_from_csv", importHandler.HandleCsvImport)

--- a/model/email_token.go
+++ b/model/email_token.go
@@ -1,0 +1,114 @@
+package model
+
+import (
+	"context"
+	"crypto/rand"
+	"errors"
+
+	"intraclub/database"
+)
+
+// errEmailTokenValueAlreadyExists is an error that indicates that a given token literal
+// already exists in the database. This shouldn't ever actually happen as tokens are randomly
+// generated with rand.Text(), but it's easy to check for.
+var errEmailTokenValueAlreadyExists = errors.New("email token value already exists in DB")
+
+// errEmailTokenAlreadyExists is an error that indicated that a given User already has an EmailToken
+// present in the database. This is done as part of a validation to prevent us from creating duplicate
+// email tokens and ensuring that we clean up email tokens when re-sending a verification email
+var errEmailTokenAlreadyExists = errors.New("conflicting email token already exists for user")
+
+// EmailToken is a random token that is sent via email to a particular User in order to verify
+// that they own the EmailAddress that they set on their User
+type EmailToken struct {
+	ID     database.RecordId `json:"id"`      // store token in DB
+	Token  string            `json:"token"`   // random token value
+	UserId database.UserId   `json:"user_id"` // User ID that this token pertains to
+}
+
+func newEmailTokenForUser(userId database.UserId) *EmailToken {
+	return &EmailToken{
+		UserId: userId,
+		Token:  rand.Text(),
+	}
+}
+
+// CreateEmailTokenForUser creates an EmailToken for an existing User. If the User already
+// has an EmailToken in the DB, we will delete it and create a new one.
+func CreateEmailTokenForUser(ctx context.Context, db database.Provider, u database.UserId) (*EmailToken, error) {
+	whereFunc := func(ctx context.Context, v *EmailToken) bool { return v.UserId == u }
+	tokens, err := database.GetAllWhere[*EmailToken](ctx, db, whereFunc)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(tokens) != 0 {
+		_, _, err = database.DeleteOneById(ctx, db, &EmailToken{}, tokens[0].ID)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	token := newEmailTokenForUser(u)
+	return database.CreateOne(ctx, db, token)
+}
+
+// UniquenessEquivalent ensures that there is only a single EmailToken
+// for any given UserId.
+func (e *EmailToken) UniquenessEquivalent(other *EmailToken) error {
+	if e.UserId == other.UserId {
+		return errEmailTokenAlreadyExists
+	} else if e.Token == other.Token {
+		return errEmailTokenAlreadyExists
+	}
+	return nil
+}
+
+func (e *EmailToken) Type() string {
+	return "email_verification_token"
+}
+
+func (e *EmailToken) GetId() database.RecordId {
+	return e.ID
+}
+
+func (e *EmailToken) SetId(id database.RecordId) {
+	e.ID = id
+}
+
+func (e *EmailToken) EditableBy(ctx context.Context, db database.Provider) []database.UserId {
+	return []database.UserId{e.UserId}
+}
+
+func (e *EmailToken) AccessibleTo(ctx context.Context, db database.Provider) []database.UserId {
+	return []database.UserId{e.UserId}
+}
+
+func (e *EmailToken) SetOwner(userId database.UserId) {
+	e.UserId = userId
+}
+
+func (e *EmailToken) GetOwner() database.UserId {
+	return e.UserId
+}
+
+func (e *EmailToken) NewRecord() database.CrudRecord {
+	return &EmailToken{}
+}
+
+// StaticallyValid validates that this EmailToken has a non-empty
+// Token value and that the UserId set is non-empty
+func (e *EmailToken) StaticallyValid() error {
+	if e.Token == "" {
+		return errors.New("token is empty")
+	} else if e.UserId == database.InvalidUserId {
+		return errors.New("invalid user id")
+	}
+	return nil
+}
+
+// DynamicallyValid validates that this EmailToken corresponds to an actually
+// existing User in the database.
+func (e *EmailToken) DynamicallyValid(ctx context.Context, db database.Provider) error {
+	return database.ExistsById[*User](ctx, db, &User{}, e.UserId.RecordId())
+}

--- a/model/email_token_test.go
+++ b/model/email_token_test.go
@@ -1,0 +1,211 @@
+package model
+
+import (
+	"context"
+	"testing"
+
+	"intraclub/database"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewEmailTokenForUser_GeneratesToken(t *testing.T) {
+	userId := database.UserId(database.NewRecordId())
+	token := newEmailTokenForUser(userId)
+
+	require.NotNil(t, token)
+	assert.NotEmpty(t, token.Token)
+	assert.Equal(t, userId, token.UserId)
+}
+
+func TestCreateEmailTokenForUser_CreatesToken(t *testing.T) {
+	ctx := context.Background()
+	db := database.NewUnitTestDBProvider()
+
+	user := newStoredUser(t, db)
+	token, err := CreateEmailTokenForUser(ctx, db, user.ID)
+	require.NoError(t, err)
+	require.NotNil(t, token)
+	assert.NotEmpty(t, token.Token)
+	assert.Equal(t, user.ID, token.UserId)
+}
+
+func TestCreateEmailTokenForUser_DeletesExistingToken(t *testing.T) {
+	ctx := context.Background()
+	db := database.NewUnitTestDBProvider()
+
+	user := newStoredUser(t, db)
+
+	token1, err := CreateEmailTokenForUser(ctx, db, user.ID)
+	require.NoError(t, err)
+
+	token2, err := CreateEmailTokenForUser(ctx, db, user.ID)
+	require.NoError(t, err)
+
+	require.NotEqual(t, token1.Token, token2.Token)
+
+	tokens, err := database.GetAllWhere[*EmailToken](ctx, db, func(ctx context.Context, v *EmailToken) bool {
+		return v.UserId == user.ID
+	})
+	require.NoError(t, err)
+	assert.Len(t, tokens, 1)
+	assert.Equal(t, token2.Token, tokens[0].Token)
+}
+
+func TestCreateEmailTokenForUser_NoExistingToken(t *testing.T) {
+	ctx := context.Background()
+	db := database.NewUnitTestDBProvider()
+
+	user := newStoredUser(t, db)
+
+	tokens, err := database.GetAllWhere[*EmailToken](ctx, db, func(ctx context.Context, v *EmailToken) bool {
+		return v.UserId == user.ID
+	})
+	require.NoError(t, err)
+	assert.Len(t, tokens, 0)
+
+	_, err = CreateEmailTokenForUser(ctx, db, user.ID)
+	require.NoError(t, err)
+
+	tokens, err = database.GetAllWhere[*EmailToken](ctx, db, func(ctx context.Context, v *EmailToken) bool {
+		return v.UserId == user.ID
+	})
+	require.NoError(t, err)
+	assert.Len(t, tokens, 1)
+}
+
+func TestEmailTokenUniquenessEquivalent_MatchingUserId(t *testing.T) {
+	userId := database.UserId(database.NewRecordId())
+	token1 := &EmailToken{UserId: userId, Token: "abc123"}
+	token2 := &EmailToken{UserId: userId, Token: "def456"}
+
+	err := token1.UniquenessEquivalent(token2)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, errEmailTokenAlreadyExists)
+}
+
+func TestEmailTokenUniquenessEquivalent_DifferentUserId(t *testing.T) {
+	token1 := &EmailToken{UserId: database.UserId(database.NewRecordId()), Token: "abc123"}
+	token2 := &EmailToken{UserId: database.UserId(database.NewRecordId()), Token: "def456"}
+
+	err := token1.UniquenessEquivalent(token2)
+	assert.NoError(t, err)
+}
+
+func TestEmailTokenUniquenessEquivalent_SameTokenDifferentUser(t *testing.T) {
+	token1 := &EmailToken{UserId: database.UserId(database.NewRecordId()), Token: "shared-token"}
+	token2 := &EmailToken{UserId: database.UserId(database.NewRecordId()), Token: "shared-token"}
+
+	err := token1.UniquenessEquivalent(token2)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, errEmailTokenAlreadyExists)
+}
+
+func TestEmailTokenStaticallyValid_Valid(t *testing.T) {
+	token := &EmailToken{Token: "valid-token", UserId: database.UserId(database.NewRecordId())}
+
+	err := token.StaticallyValid()
+	assert.NoError(t, err)
+}
+
+func TestEmailTokenStaticallyValid_EmptyToken(t *testing.T) {
+	token := &EmailToken{Token: "", UserId: database.UserId(database.NewRecordId())}
+
+	err := token.StaticallyValid()
+	assert.Error(t, err)
+	assert.Equal(t, "token is empty", err.Error())
+}
+
+func TestEmailTokenStaticallyValid_InvalidUserId(t *testing.T) {
+	token := &EmailToken{Token: "valid-token", UserId: database.InvalidUserId}
+
+	err := token.StaticallyValid()
+	assert.Error(t, err)
+	assert.Equal(t, "invalid user id", err.Error())
+}
+
+func TestEmailTokenStaticallyValid_EmptyBoth(t *testing.T) {
+	token := &EmailToken{Token: "", UserId: database.InvalidUserId}
+
+	err := token.StaticallyValid()
+	assert.Error(t, err)
+	assert.Equal(t, "token is empty", err.Error())
+}
+
+func TestEmailTokenDynamicallyValid_ValidUser(t *testing.T) {
+	ctx := context.Background()
+	db := database.NewUnitTestDBProvider()
+
+	user := newStoredUser(t, db)
+	token := &EmailToken{Token: "valid-token", UserId: user.ID}
+
+	err := token.DynamicallyValid(ctx, db)
+	assert.NoError(t, err)
+}
+
+func TestEmailTokenDynamicallyValid_InvalidUser(t *testing.T) {
+	ctx := context.Background()
+	db := database.NewUnitTestDBProvider()
+
+	token := &EmailToken{Token: "valid-token", UserId: database.UserId(database.NewRecordId())}
+
+	err := token.DynamicallyValid(ctx, db)
+	assert.Error(t, err)
+}
+
+func TestEmailTokenType(t *testing.T) {
+	token := &EmailToken{}
+	assert.Equal(t, "email_verification_token", token.Type())
+}
+
+func TestEmailTokenGetIdAndSetId(t *testing.T) {
+	token := &EmailToken{}
+	assert.Equal(t, database.RecordId(0), token.GetId())
+
+	newId := database.NewRecordId()
+	token.SetId(newId)
+	assert.Equal(t, newId, token.GetId())
+}
+
+func TestEmailTokenGetOwnerAndSetOwner(t *testing.T) {
+	userId := database.UserId(database.NewRecordId())
+	token := &EmailToken{}
+
+	token.SetOwner(userId)
+	assert.Equal(t, userId, token.GetOwner())
+}
+
+func TestEmailTokenEditableBy(t *testing.T) {
+	ctx := context.Background()
+	db := database.NewUnitTestDBProvider()
+
+	userId := database.UserId(database.NewRecordId())
+	token := &EmailToken{UserId: userId}
+
+	editableBy := token.EditableBy(ctx, db)
+	assert.Len(t, editableBy, 1)
+	assert.Equal(t, userId, editableBy[0])
+}
+
+func TestEmailTokenAccessibleTo(t *testing.T) {
+	ctx := context.Background()
+	db := database.NewUnitTestDBProvider()
+
+	userId := database.UserId(database.NewRecordId())
+	token := &EmailToken{UserId: userId}
+
+	accessibleTo := token.AccessibleTo(ctx, db)
+	assert.Len(t, accessibleTo, 1)
+	assert.Equal(t, userId, accessibleTo[0])
+}
+
+func TestEmailTokenNewRecord(t *testing.T) {
+	token := &EmailToken{}
+	record := token.NewRecord()
+
+	require.NotNil(t, record)
+	emailToken, ok := record.(*EmailToken)
+	assert.True(t, ok)
+	assert.NotNil(t, emailToken)
+}

--- a/model/user.go
+++ b/model/user.go
@@ -14,21 +14,19 @@ type User struct {
 	LastName    string          `json:"last_name"`
 	PhoneNumber PhoneNumber     `json:"phone_number"`
 	Email       EmailAddress    `json:"email"`
+	Verified    bool            `json:"verified"`
 }
 
 func (u *User) GetOwner() database.UserId {
-	// TODO implement me
-	panic("implement me")
+	return u.ID
 }
 
 func (u *User) UniquenessEquivalent(other *User) error {
 	if u.Email == other.Email {
 		return fmt.Errorf("user with email address %s already exists", u.Email)
-	}
-	if u.FirstName == other.FirstName && u.LastName == other.LastName {
+	} else if u.FirstName == other.FirstName && u.LastName == other.LastName {
 		return fmt.Errorf("user with name %s %s already exists", u.FirstName, u.LastName)
-	}
-	if u.PhoneNumber != "" && u.PhoneNumber == other.PhoneNumber {
+	} else if u.PhoneNumber != "" && u.PhoneNumber == other.PhoneNumber {
 		return fmt.Errorf("user with phone number %s already exists", u.PhoneNumber)
 	}
 	return nil

--- a/model/user_test.go
+++ b/model/user_test.go
@@ -91,3 +91,73 @@ func TestDuplicateUserPhoneNumber(t *testing.T) {
 	}
 	fmt.Println(err)
 }
+
+func TestUniquenessEquivalent_MatchingEmail(t *testing.T) {
+	user1 := &User{Email: "test@example.com", FirstName: "John", LastName: "Doe", PhoneNumber: "123-456-7890"}
+	user2 := &User{Email: "test@example.com", FirstName: "Jane", LastName: "Smith", PhoneNumber: "098-765-4321"}
+
+	err := user1.UniquenessEquivalent(user2)
+	if err == nil {
+		t.Fatal("expected error for matching email")
+	}
+}
+
+func TestUniquenessEquivalent_DifferentEmail(t *testing.T) {
+	user1 := &User{Email: "john@example.com", FirstName: "John", LastName: "Doe", PhoneNumber: "123-456-7890"}
+	user2 := &User{Email: "jane@example.com", FirstName: "Jane", LastName: "Smith", PhoneNumber: "098-765-4321"}
+
+	err := user1.UniquenessEquivalent(user2)
+	if err != nil {
+		t.Fatalf("expected no error for different email/name/phone, got: %v", err)
+	}
+}
+
+func TestUniquenessEquivalent_MatchingName(t *testing.T) {
+	user1 := &User{Email: "john@example.com", FirstName: "John", LastName: "Doe", PhoneNumber: "123-456-7890"}
+	user2 := &User{Email: "jane@example.com", FirstName: "John", LastName: "Doe", PhoneNumber: "098-765-4321"}
+
+	err := user1.UniquenessEquivalent(user2)
+	if err == nil {
+		t.Fatal("expected error for matching first and last name")
+	}
+}
+
+func TestUniquenessEquivalent_FirstNameOnlyMatch(t *testing.T) {
+	user1 := &User{Email: "john@example.com", FirstName: "John", LastName: "Doe", PhoneNumber: "123-456-7890"}
+	user2 := &User{Email: "johnsmith@example.com", FirstName: "John", LastName: "Smith", PhoneNumber: "098-765-4321"}
+
+	err := user1.UniquenessEquivalent(user2)
+	if err != nil {
+		t.Fatalf("expected no error for matching first name only, got: %v", err)
+	}
+}
+
+func TestUniquenessEquivalent_LastNameOnlyMatch(t *testing.T) {
+	user1 := &User{Email: "john@example.com", FirstName: "John", LastName: "Doe", PhoneNumber: "123-456-7890"}
+	user2 := &User{Email: "janedoe@example.com", FirstName: "Jane", LastName: "Doe", PhoneNumber: "098-765-4321"}
+
+	err := user1.UniquenessEquivalent(user2)
+	if err != nil {
+		t.Fatalf("expected no error for matching last name only, got: %v", err)
+	}
+}
+
+func TestUniquenessEquivalent_MatchingPhoneNumber(t *testing.T) {
+	user1 := &User{Email: "john@example.com", FirstName: "John", LastName: "Doe", PhoneNumber: "123-456-7890"}
+	user2 := &User{Email: "jane@example.com", FirstName: "Jane", LastName: "Smith", PhoneNumber: "123-456-7890"}
+
+	err := user1.UniquenessEquivalent(user2)
+	if err == nil {
+		t.Fatal("expected error for matching phone number")
+	}
+}
+
+func TestUniquenessEquivalent_EmptyFields(t *testing.T) {
+	user1 := &User{Email: "", FirstName: "", LastName: "", PhoneNumber: ""}
+	user2 := &User{Email: "", FirstName: "", LastName: "", PhoneNumber: ""}
+
+	err := user1.UniquenessEquivalent(user2)
+	if err == nil {
+		t.Fatal("expected error for matching empty fields")
+	}
+}

--- a/route/user/common.go
+++ b/route/user/common.go
@@ -1,0 +1,23 @@
+package user
+
+import (
+	"context"
+
+	"intraclub/database"
+	"intraclub/model"
+)
+
+var BaseRoute = "/user"
+
+func DoesMatchingUserExist(ctx context.Context, db database.Provider, user *model.User) (bool, *model.User, error) {
+	users, err := database.GetAll[*model.User](ctx, db)
+	if err != nil {
+		return false, nil, err
+	}
+	for _, u := range users {
+		if u.UniquenessEquivalent(user) == nil {
+			return true, u, nil
+		}
+	}
+	return false, nil, nil
+}

--- a/route/user/self_registration.go
+++ b/route/user/self_registration.go
@@ -1,4 +1,4 @@
-package route
+package user
 
 import (
 	"errors"
@@ -9,13 +9,11 @@ import (
 	"intraclub/model"
 )
 
-var UserBaseRoute = "/user"
-
 // SelfRegister allows a user to self-register to the system
 type SelfRegister struct{}
 
 func (c SelfRegister) Path() (api.HttpMethod, string) {
-	return api.HttpMethodPost, UserBaseRoute
+	return api.HttpMethodPost, BaseRoute
 }
 
 func (c SelfRegister) RequestBody() (*model.User, bool) {

--- a/route/user/verify_email.go
+++ b/route/user/verify_email.go
@@ -1,0 +1,12 @@
+package user
+
+import (
+	"intraclub/model"
+)
+
+type verifyEmailRequest struct {
+	EmailAddress model.EmailAddress `json:"email"`
+	Token        string             `json:"token"`
+}
+
+type VerifyEmail struct{}

--- a/route/user/who_am_i.go
+++ b/route/user/who_am_i.go
@@ -1,4 +1,4 @@
-package route
+package user
 
 import (
 	"errors"


### PR DESCRIPTION
# Add email token type + reorganize some stuff into routes/user

This branch introduces email verification token support and reorganizes user-related routes into a `route/user` subpackage.

## Changes

### New: Email Token Model (`model/email_token.go`)
- Added `EmailToken` struct with random token generation via `crypto/rand`
- `CreateEmailTokenForUser` — creates a token for a user, deleting any existing token first to prevent duplicates
- Implements full `database.CrudRecord` interface (`GetId`, `SetId`, `EditableBy`, `AccessibleTo`, `SetOwner`, `GetOwner`, `NewRecord`)
- `StaticallyValid` — validates non-empty token and valid user ID
- `DynamicallyValid` — validates the token's user exists in the database
- `UniquenessEquivalent` — prevents duplicate tokens for the same user or duplicate token values
- `Type()` returns `"email_verification_token"`

### New: Verify Email Route (`route/user/verify_email.go`)
- Added `VerifyEmail` handler struct and `verifyEmailRequest` body (email + token)
- Scaffolded for email verification endpoint

### New: User Route Common (`route/user/common.go`)
- Added `BaseRoute = "/user"` constant
- Added `DoesMatchingUserExist` helper that iterates all users and checks `UniquenessEquivalent`

### Refactor: User Routes Reorganized into `route/user/`
- `route/user.go` → `route/user/self_registration.go` (renamed, package changed from `route` to `user`)
- `route/who_am_i.go` → `route/user/who_am_i.go` (renamed, package changed from `route` to `user`)
- Updated `main.go` to import `intraclub/route/user` and use the relocated handlers

### Updated: User Model (`model/user.go`)
- Added `Verified` (bool) field to `User` struct
- Implemented `GetOwner()` for `User` (returns `u.ID`)
- Cleaned up `UniquenessEquivalent` — converted chained `if` blocks to `else if`, removing redundant braces

### New: User Model Tests (`model/user_test.go`)
- `TestUniquenessEquivalent_MatchingEmail`
- `TestUniquenessEquivalent_DifferentEmail`
- `TestUniquenessEquivalent_MatchingName`
- `TestUniquenessEquivalent_FirstNameOnlyMatch`
- `TestUniquenessEquivalent_LastNameOnlyMatch`
- `TestUniquenessEquivalent_MatchingPhoneNumber`
- `TestUniquenessEquivalent_EmptyFields`

### Updated: Main (`main.go`)
- Registered `user.SelfRegister{}` and `user.WhoAmI{}` handlers under relocated route families