### PR TITLE
self-reg: add more email content w/ token link

### DIFF
--- a/mailer/mailer.go
+++ b/mailer/mailer.go
@@ -28,6 +28,12 @@ import (
 	"github.com/emersion/go-msgauth/dkim"
 )
 
+// Default DKIM settings. These can be overridden per-config if needed.
+const (
+	DefaultDKIMSelector = "default"
+	DefaultDKIMKeyPath  = "/etc/intraclub/dkim.key"
+)
+
 // Config holds the settings needed to create a Mailer.
 type Config struct {
 	// FromDomain is the sending domain, e.g. "rcintra.club". It must match
@@ -41,10 +47,12 @@ type Config struct {
 
 	// DKIMSelector is the DNS selector used to look up the DKIM public key.
 	// A value of "default" resolves to default._domainkey.<FromDomain>.
+	// Defaults to DefaultDKIMSelector ("default") if empty.
 	DKIMSelector string
 
 	// DKIMKeyPath is the filesystem path to a PEM-encoded RSA or Ed25519
 	// private key. Both PKCS#1 and PKCS#8 formats are accepted.
+	// Defaults to DefaultDKIMKeyPath ("/etc/intraclub/dkim.key") if empty.
 	DKIMKeyPath string
 
 	// DialTimeout controls how long to wait when establishing the TCP
@@ -62,15 +70,21 @@ type Mailer struct {
 // New creates a Mailer from the given configuration. It validates required
 // fields and loads the DKIM private key from disk.
 func New(cfg Config) (*Mailer, error) {
-	if cfg.FromDomain == "" || cfg.Hostname == "" || cfg.DKIMSelector == "" {
-		return nil, errors.New("mailer: FromDomain, Hostname, DKIMSelector are required")
+	if cfg.FromDomain == "" || cfg.Hostname == "" {
+		return nil, errors.New("mailer: FromDomain, Hostname are required")
 	}
 	if cfg.DialTimeout == 0 {
 		cfg.DialTimeout = 30 * time.Second
 	}
+	if cfg.DKIMSelector == "" {
+		cfg.DKIMSelector = DefaultDKIMSelector
+	}
+	if cfg.DKIMKeyPath == "" {
+		cfg.DKIMKeyPath = DefaultDKIMKeyPath
+	}
 	signer, err := loadPrivateKey(cfg.DKIMKeyPath)
 	if err != nil {
-		return nil, fmt.Errorf("mailer: dkim key: %w", err)
+		return nil, fmt.Errorf("mailer: DKIM key loading error: %w", err)
 	}
 	return &Mailer{cfg: cfg, signer: signer}, nil
 }

--- a/route/user/self_registration.go
+++ b/route/user/self_registration.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 
 	"intraclub/api"
 	"intraclub/database"
@@ -15,7 +14,7 @@ import (
 
 // SelfRegister allows a user to self-register to the system
 type SelfRegister struct {
-	BaseURL string
+	Hostname string
 }
 
 func (c SelfRegister) Path() (api.HttpMethod, string) {
@@ -34,7 +33,7 @@ func (c SelfRegister) Handler(req api.Request[*model.User]) (any, int, error) {
 		return nil, http.StatusBadRequest, errors.New("token must not be passed into create user route")
 	}
 
-	user, err := selfRegister(req.Context, req.DatabaseProvider, req.Body, c.f)
+	user, err := selfRegister(req.Context, req.DatabaseProvider, req.Body, c.sendTokenEmail)
 
 	if err != nil {
 		// check for uniqueness constraint error
@@ -47,24 +46,21 @@ func (c SelfRegister) Handler(req api.Request[*model.User]) (any, int, error) {
 	return user, http.StatusCreated, nil
 }
 
-func (c SelfRegister) f(ctx context.Context, u *model.User, t *model.EmailToken) error {
+func (c SelfRegister) sendTokenEmail(ctx context.Context, u *model.User, t *model.EmailToken) error {
 	fmt.Println("send token to email:", u.Email)
 
-	appURL, err := url.Parse(c.BaseURL)
-	if err != nil {
-		return err
-	}
+	baseURL := "https://" + c.Hostname
 
 	cfg := mailer.Config{
-		FromDomain: appURL.Host,
-		Hostname:   "mail." + appURL.Host,
+		FromDomain: c.Hostname,
+		Hostname:   "mail." + c.Hostname,
 	}
 	m, err := mailer.New(cfg)
 	if err != nil {
 		return err
 	}
 
-	message := newEmailMessage(u.Email, t, c.BaseURL)
+	message := newEmailMessage(u.Email, t, baseURL)
 	return m.Send(ctx, message)
 }
 
@@ -83,7 +79,7 @@ func newEmailMessage(addr model.EmailAddress, t *model.EmailToken, baseURL strin
 <body>
   <div class="container">
     <h2>Verify Your Email</h2>
-    <p>Thank you for signing up! Please click the button below to verify your email address and activate your account.</p>
+    <p>Thank you for signing up to rcintra.club! Please click the button below to verify your email address and activate your account.</p>
     <p><a href="%s" class="button">Verify Email</a></p>
     <p>If the button doesn't work, copy and paste this link into your browser:</p>
     <p>%s</p>
@@ -95,7 +91,7 @@ func newEmailMessage(addr model.EmailAddress, t *model.EmailToken, baseURL strin
 	return mailer.Message{
 		From:    "noreply@rcintra.club",
 		To:      []string{string(addr)},
-		Subject: "Verify your account",
+		Subject: "Verify your Intraclub account",
 		Text:    body,
 	}
 }

--- a/route/user/self_registration.go
+++ b/route/user/self_registration.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"intraclub/api"
 	"intraclub/database"
@@ -13,7 +14,9 @@ import (
 )
 
 // SelfRegister allows a user to self-register to the system
-type SelfRegister struct{}
+type SelfRegister struct {
+	BaseURL string
+}
 
 func (c SelfRegister) Path() (api.HttpMethod, string) {
 	return api.HttpMethodPost, BaseRoute
@@ -47,27 +50,53 @@ func (c SelfRegister) Handler(req api.Request[*model.User]) (any, int, error) {
 func (c SelfRegister) f(ctx context.Context, u *model.User, t *model.EmailToken) error {
 	fmt.Println("send token to email:", u.Email)
 
+	appURL, err := url.Parse(c.BaseURL)
+	if err != nil {
+		return err
+	}
+
 	cfg := mailer.Config{
-		FromDomain:   "rcintra.club",
-		Hostname:     "mail.rcintra.club",
-		DKIMSelector: "default",
-		DKIMKeyPath:  "/etc/intraclub/dkim.key",
+		FromDomain: appURL.Host,
+		Hostname:   "mail." + appURL.Host,
 	}
 	m, err := mailer.New(cfg)
 	if err != nil {
 		return err
 	}
 
-	message := newEmailMessage(u.Email, t)
+	message := newEmailMessage(u.Email, t, c.BaseURL)
 	return m.Send(ctx, message)
 }
 
-func newEmailMessage(addr model.EmailAddress, t *model.EmailToken) mailer.Message {
+func newEmailMessage(addr model.EmailAddress, t *model.EmailToken, baseURL string) mailer.Message {
+	verifyURL := fmt.Sprintf("%s/verify?token=%s", baseURL, t.Token)
+	body := fmt.Sprintf(
+		`<!DOCTYPE html>
+<html>
+<head>
+<style>
+  body { font-family: Arial, sans-serif; background: #f4f4f4; padding: 40px; }
+  .container { max-width: 600px; margin: auto; background: #fff; padding: 30px; border-radius: 8px; }
+  .button { display: inline-block; padding: 14px 28px; background: #4CAF50; color: #fff; text-decoration: none; border-radius: 4px; }
+</style>
+</head>
+<body>
+  <div class="container">
+    <h2>Verify Your Email</h2>
+    <p>Thank you for signing up! Please click the button below to verify your email address and activate your account.</p>
+    <p><a href="%s" class="button">Verify Email</a></p>
+    <p>If the button doesn't work, copy and paste this link into your browser:</p>
+    <p>%s</p>
+  </div>
+</body>
+</html>`,
+		verifyURL, verifyURL,
+	)
 	return mailer.Message{
 		From:    "noreply@rcintra.club",
 		To:      []string{string(addr)},
 		Subject: "Verify your account",
-		Text:    "",
+		Text:    body,
 	}
 }
 


### PR DESCRIPTION
## Template a verification email for self-registration, move some hardcoded stuff to constants

- Add HTML email verification template with a styled "Verify Email" button and fallback link
- Introduce `SelfRegister.BaseURL` as the single source of truth for the app's base URL, deriving `FromDomain` and `Hostname` from it at runtime
- Add default DKIM settings (`DefaultDKIMSelector`, `DefaultDKIMKeyPath`) in the `mailer` package, applied automatically when config fields are unset

## Changes

**`mailer/mailer.go`**
- Added `DefaultDKIMSelector` and `DefaultDKIMKeyPath` package-level constants
- `New()` now fills in DKIM defaults when the corresponding config fields are empty
- Updated `Config` field docs to describe default behaviour
- Relaxed validation: only `FromDomain` and `Hostname` are now required

**`route/user/self_registration.go`**
- Added `BaseURL` field to `SelfRegister` struct
- `newEmailMessage` now generates an HTML body with a verification button linking to `<BaseURL>/verify?token=<token>`
- `c.f` parses `BaseURL` to derive `FromDomain` and `Hostname` for `mailer.Config`
- Removed hardcoded DKIM values from the mailer config (now use defaults)

## Notes

- The verify endpoint path (`/verify`) is stubbed and should be updated to match the actual route
- `SelfRegister` must be instantiated with `BaseURL` set (e.g. `user.SelfRegister{Hostname: "rcintra.club"}`)