### PR TITLE
add user unit tests

### DIFF
--- a/model/user_test.go
+++ b/model/user_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"intraclub/database"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func randomEmail() EmailAddress {
@@ -160,4 +162,164 @@ func TestUniquenessEquivalent_EmptyFields(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for matching empty fields")
 	}
+}
+
+func TestUserGetOwner(t *testing.T) {
+	userId := database.UserId(database.NewRecordId())
+	user := &User{ID: userId}
+
+	assert.Equal(t, userId, user.GetOwner())
+}
+
+func TestUserSetOwner(t *testing.T) {
+	user := &User{ID: database.UserId(123)}
+	userId := database.UserId(456)
+
+	user.SetOwner(userId)
+
+	assert.Equal(t, database.UserId(123), user.GetOwner())
+}
+
+func TestUserSetOwner_DoesNotChangeId(t *testing.T) {
+	originalId := database.UserId(789)
+	user := &User{ID: originalId}
+
+	user.SetOwner(database.UserId(456))
+	user.SetOwner(database.UserId(999))
+
+	assert.Equal(t, originalId, user.GetOwner())
+}
+
+func TestUserEditableBy(t *testing.T) {
+	ctx := context.Background()
+	db := database.NewUnitTestDBProvider()
+
+	userId := database.UserId(database.NewRecordId())
+	user := &User{ID: userId}
+
+	editableBy := user.EditableBy(ctx, db)
+	require.Len(t, editableBy, 2)
+	assert.Equal(t, userId, editableBy[0])
+	assert.Equal(t, database.SysAdminUserId, editableBy[1])
+}
+
+func TestUserAccessibleTo(t *testing.T) {
+	ctx := context.Background()
+	db := database.NewUnitTestDBProvider()
+
+	user := &User{}
+
+	accessibleTo := user.AccessibleTo(ctx, db)
+	require.Len(t, accessibleTo, 1)
+	assert.Equal(t, database.EveryoneUserId, accessibleTo[0])
+}
+
+func TestUserNewRecord(t *testing.T) {
+	user := &User{}
+	record := user.NewRecord()
+
+	require.NotNil(t, record)
+	newUser, ok := record.(*User)
+	assert.True(t, ok)
+	assert.NotNil(t, newUser)
+}
+
+func TestUserTrimValues(t *testing.T) {
+	user := &User{
+		FirstName:   "  John  ",
+		LastName:    "  Doe  ",
+		Email:       "  JOHN@Example.COM  ",
+		PhoneNumber: "1234567890",
+	}
+
+	user.TrimValues()
+
+	assert.Equal(t, "John", user.FirstName)
+	assert.Equal(t, "Doe", user.LastName)
+	assert.Equal(t, EmailAddress("john@example.com"), user.Email)
+	assert.Equal(t, PhoneNumber("123-456-7890"), user.PhoneNumber)
+}
+
+func TestUserTrimValues_EmptyPhoneNumber(t *testing.T) {
+	user := &User{
+		FirstName:   "John",
+		LastName:    "Doe",
+		Email:       "john@example.com",
+		PhoneNumber: "",
+	}
+
+	user.TrimValues()
+
+	assert.Equal(t, PhoneNumber(""), user.PhoneNumber)
+}
+
+func TestUserStaticallyValid_Valid(t *testing.T) {
+	user := &User{
+		FirstName:   "John",
+		LastName:    "Doe",
+		Email:       "john@example.com",
+		PhoneNumber: "123-456-7890",
+	}
+
+	err := user.StaticallyValid()
+	assert.NoError(t, err)
+}
+
+func TestUserStaticallyValid_EmptyFirstName(t *testing.T) {
+	user := &User{
+		FirstName:   "",
+		LastName:    "Doe",
+		Email:       "john@example.com",
+		PhoneNumber: "123-456-7890",
+	}
+
+	err := user.StaticallyValid()
+	assert.Error(t, err)
+	assert.Equal(t, "first name must not be empty", err.Error())
+}
+
+func TestUserStaticallyValid_EmptyLastName(t *testing.T) {
+	user := &User{
+		FirstName:   "John",
+		LastName:    "",
+		Email:       "john@example.com",
+		PhoneNumber: "123-456-7890",
+	}
+
+	err := user.StaticallyValid()
+	assert.Error(t, err)
+	assert.Equal(t, "last name must not be empty", err.Error())
+}
+
+func TestUserStaticallyValid_InvalidEmail(t *testing.T) {
+	user := &User{
+		FirstName:   "John",
+		LastName:    "Doe",
+		Email:       "invalid-email",
+		PhoneNumber: "123-456-7890",
+	}
+
+	err := user.StaticallyValid()
+	assert.Error(t, err)
+}
+
+func TestUserStaticallyValid_InvalidPhoneNumber(t *testing.T) {
+	user := &User{
+		FirstName:   "John",
+		LastName:    "Doe",
+		Email:       "john@example.com",
+		PhoneNumber: "123456789012345",
+	}
+
+	err := user.StaticallyValid()
+	assert.Error(t, err)
+}
+
+func TestUserDynamicallyValid(t *testing.T) {
+	ctx := context.Background()
+	db := database.NewUnitTestDBProvider()
+
+	user := &User{}
+	err := user.DynamicallyValid(ctx, db)
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
# Add Test Coverage for `model/user.go`

## Summary

This branch brings `model/user.go` to 100% executable statement coverage by adding unit tests for the methods that previously had no test coverage. Only one file is changed: `model/user_test.go`.

## What was missing

Prior to this branch, `model/user.go` had the following methods at 0% coverage (in addition to partial coverage of `StaticallyValid`):

- `GetOwner`
- `SetOwner`
- `EditableBy`
- `AccessibleTo`
- `NewRecord`
- `TrimValues`
- `StaticallyValid` (only the email-validation error path was exercised)

## Changes

`model/user_test.go` — 14 new test functions, all using the project's `testify` (`assert` / `require`) conventions:

### CrudRecord interface methods

- `TestUserGetOwner` — verifies `GetOwner` returns the user's own `UserId`.
- `TestUserSetOwner` — verifies `SetOwner` is a no-op (user records are self-owned).
- `TestUserSetOwner_DoesNotChangeId` — verifies repeated `SetOwner` calls don't mutate the user's ID.
- `TestUserEditableBy` — verifies the user themselves and the sys admin are returned.
- `TestUserAccessibleTo` — verifies `EveryoneUserId` is the only entry.
- `TestUserNewRecord` — verifies the returned record is a new `*User`.

### `TrimValues`

- `TestUserTrimValues` — covers whitespace trimming on name fields, lowercasing/trimming on email, and dash-formatting on a non-empty phone number.
- `TestUserTrimValues_EmptyPhoneNumber` — covers the empty-phone branch (no dash formatting applied).

### `StaticallyValid`

- `TestUserStaticallyValid_Valid` — exercises the happy path.
- `TestUserStaticallyValid_EmptyFirstName` — covers the empty-first-name error.
- `TestUserStaticallyValid_EmptyLastName` — covers the empty-last-name error.
- `TestUserStaticallyValid_InvalidEmail` — covers the `EmailAddress.StaticallyValid` error path.
- `TestUserStaticallyValid_InvalidPhoneNumber` — covers the `PhoneNumber.StaticallyValid` error path.

### `DynamicallyValid`

- `TestUserDynamicallyValid` — exercises the no-op implementation (returns `nil`).

## Test imports

Adds the existing-project `testify` imports to `model/user_test.go`:

```go
"github.com/stretchr/testify/assert"
"github.com/stretchr/testify/require"
```

## Coverage result

After this branch, every executable statement in `model/user.go` is covered. (`SetOwner` is a no-op comment-only function, so it shows 0% by definition but is exercised by the call site tests.)

## Files changed

- `model/user_test.go` (+162 lines)