### PR TITLE
Set up Playwright for UI automation testing

### DIFF
--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -21,3 +21,9 @@ Thumbs.db
 # Vite
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+# Playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/ui/README.md
+++ b/ui/README.md
@@ -1,42 +1,126 @@
-# sv
+# UI
 
-Everything you need to build a Svelte project, powered by [`sv`](https://github.com/sveltejs/cli).
+This directory contains the SvelteKit frontend for the application. It is a Svelte 5 project powered by [`sv`](https://github.com/sveltejs/cli) and built with Vite.
 
-## Creating a project
+## Prerequisites
 
-If you're seeing this, you've probably already done this step. Congrats!
+- [Node.js](https://nodejs.org/) and npm installed
 
-```sh
-# create a new project
-npx sv create my-app
-```
+## Installation
 
-To recreate this project with the same configuration:
+From the `ui/` directory:
 
 ```sh
-# recreate this project
-npx sv@0.15.3 create --template minimal --types ts --no-install ui
+npm install
 ```
 
 ## Developing
 
-Once you've created a project and installed dependencies with `npm install` (or `pnpm install` or `yarn`), start a development server:
+Start the development server:
 
 ```sh
 npm run dev
+```
 
-# or start the server and open the app in a new browser tab
+Or start the server and open the app in a new browser tab:
+
+```sh
 npm run dev -- --open
 ```
 
 ## Building
 
-To create a production version of your app:
+Create a production version of the app:
 
 ```sh
 npm run build
 ```
 
-You can preview the production build with `npm run preview`.
+Preview the production build:
+
+```sh
+npm run preview
+```
+
+## Checking
+
+Run type checking and Svelte validation:
+
+```sh
+npm run check
+```
+
+## Testing
+
+Playwright is used for end-to-end (UI) automation. Tests live in the `e2e/` directory.
+
+First-time setup installs the Playwright browser binaries:
+
+```sh
+npx playwright install chromium
+```
+
+Run the E2E tests (this starts the Vite dev server automatically):
+
+```sh
+npm run test:e2e
+```
+
+Or open the interactive Playwright UI:
+
+```sh
+npm run test:e2e:ui
+```
 
 > To deploy your app, you may need to install an [adapter](https://svelte.dev/docs/kit/adapters) for your target environment.
+
+---
+
+## Backend prerequisites
+
+The UI talks to a Go/Gin backend that lives at the repository root (`/api/...` routes). Start it before exercising the UI.
+
+### 1. Start MongoDB
+
+The backend stores data in MongoDB, provided via Docker:
+
+```sh
+docker compose up -d
+```
+
+This starts `mongo-findash` and maps the container's MongoDB to port `27018` on your host.
+
+### 2. Prerequisites
+
+- [Go](https://go.dev/dl/) installed and available in your `PATH`
+- [Docker](https://docs.docker.com/engine/install/) (for MongoDB)
+
+### 3. Run the backend server
+
+From the repository **root** (not `ui/`):
+
+```sh
+# build a binary named `main` and run it
+make standard
+./main --dev-token
+```
+
+The `--dev-token` flag enables development token mode and seeds sample data, which is useful while developing the UI.
+
+Alternatively, run it directly with Go:
+
+```sh
+go run main.go --dev-token
+```
+
+The API server listens on `http://127.0.0.1:8080`.
+
+### 4. Run the UI
+
+Back in the `ui/` directory:
+
+```sh
+npm run dev
+```
+
+> Note: the UI fetches `/api/...` paths relative to its own origin, so you may need a dev proxy or to configure the API base URL to reach the backend on port `8080`.

--- a/ui/e2e/smoke.spec.ts
+++ b/ui/e2e/smoke.spec.ts
@@ -1,0 +1,8 @@
+import { expect, test } from '@playwright/test';
+
+test('homepage renders basic content', async ({ page }) => {
+	await page.goto('/');
+
+	await expect(page.getByRole('heading', { name: 'Welcome to SvelteKit' })).toBeVisible();
+	await expect(page.getByRole('link', { name: /svelte.dev\/docs\/kit/i })).toBeVisible();
+});

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -8,6 +8,7 @@
 			"name": "ui",
 			"version": "0.0.1",
 			"devDependencies": {
+				"@playwright/test": "^1.62.1",
 				"@sveltejs/adapter-auto": "^7.0.1",
 				"@sveltejs/kit": "^2.57.0",
 				"@sveltejs/vite-plugin-svelte": "^7.0.0",
@@ -129,6 +130,22 @@
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/Boshen"
+			}
+		},
+		"node_modules/@playwright/test": {
+			"version": "1.62.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+			"integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"playwright": "1.62.1"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=20"
 			}
 		},
 		"node_modules/@polka/url": {
@@ -1053,6 +1070,53 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/playwright": {
+			"version": "1.62.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+			"integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"playwright-core": "1.62.1"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"optionalDependencies": {
+				"fsevents": "2.3.2"
+			}
+		},
+		"node_modules/playwright-core": {
+			"version": "1.62.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+			"integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"playwright-core": "cli.js"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/playwright/node_modules/fsevents": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
 		},
 		"node_modules/postcss": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -9,9 +9,12 @@
 		"preview": "vite preview",
 		"prepare": "svelte-kit sync || echo ''",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
-		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
+		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
+		"test:e2e": "playwright test",
+		"test:e2e:ui": "playwright test --ui"
 	},
 	"devDependencies": {
+		"@playwright/test": "^1.62.1",
 		"@sveltejs/adapter-auto": "^7.0.1",
 		"@sveltejs/kit": "^2.57.0",
 		"@sveltejs/vite-plugin-svelte": "^7.0.0",

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+	testDir: './e2e',
+	fullyParallel: true,
+	forbidOnly: !!process.env.CI,
+	retries: process.env.CI ? 2 : 0,
+	workers: process.env.CI ? 1 : undefined,
+	reporter: 'html',
+	use: {
+		baseURL: 'http://127.0.0.1:5173',
+		trace: 'on-first-retry'
+	},
+	projects: [
+		{
+			name: 'chromium',
+			use: { ...devices['Desktop Chrome'] }
+		}
+	],
+	webServer: {
+		command: 'npm run dev -- --host 127.0.0.1',
+		url: 'http://127.0.0.1:5173',
+		reuseExistingServer: !process.env.CI
+	}
+});


### PR DESCRIPTION
## Summary

Adds [Playwright](https://playwright.dev/) for E2E/UI automation testing of the SvelteKit frontend, complementing the existing unit testing process.

Closes #30

## Changes

- Installed `@playwright/test` and Chromium browser binaries in `ui/`
- Added `ui/playwright.config.ts` with test directory, chromium project, and a `webServer` that auto-starts the Vite dev server (pinned to `127.0.0.1`)
- Added a hello-world smoke test (`ui/e2e/smoke.spec.ts`) asserting basic content renders
- Wired it into `package.json` via `test:e2e` and `test:e2e:ui` scripts
- Documented how to run the UI tests in `ui/README.md`
- Ignored Playwright test artifacts in `ui/.gitignore`

## Verification

`npm run test:e2e` passes.