### PR TITLE
feat(ui): add login and magic-link auth callback pages

### DIFF
--- a/ui/src/app.d.ts
+++ b/ui/src/app.d.ts
@@ -2,11 +2,13 @@
 // for information about these interfaces
 declare global {
 	namespace App {
-		// interface Error {}
-		// interface Locals {}
-		// interface PageData {}
-		// interface PageState {}
-		// interface Platform {}
+		interface Error {}
+		interface Locals {
+			userId?: string;
+		}
+		interface PageData {}
+		interface PageState {}
+		interface Platform {}
 	}
 }
 

--- a/ui/src/lib/auth.ts
+++ b/ui/src/lib/auth.ts
@@ -1,0 +1,27 @@
+const TOKEN_KEY = 'intraclub_jwt';
+
+export function getToken(): string | null {
+	if (typeof localStorage === 'undefined') return null;
+	return localStorage.getItem(TOKEN_KEY);
+}
+
+export function setToken(token: string): void {
+	localStorage.setItem(TOKEN_KEY, token);
+}
+
+export function clearToken(): void {
+	localStorage.removeItem(TOKEN_KEY);
+}
+
+export function isLoggedIn(): boolean {
+	return getToken() !== null;
+}
+
+export function authFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+	const token = getToken();
+	const headers = new Headers(init?.headers);
+	if (token) {
+		headers.set('X-INTRACLUB-TOKEN', token);
+	}
+	return fetch(input, { ...init, headers });
+}

--- a/ui/src/routes/auth/callback/+page.svelte
+++ b/ui/src/routes/auth/callback/+page.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+	import { setToken } from '$lib/auth';
+	import { page } from '$app/stores';
+	import { goto } from '$app/navigation';
+
+	let status = $state('exchanging');
+	let error = $state('');
+
+	async function exchangeToken(token: string) {
+		try {
+			const res = await fetch('/api/token', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ token })
+			});
+
+			if (!res.ok) {
+				const body = await res.json();
+				error = body.error ?? 'Token exchange failed';
+				status = 'error';
+				return;
+			}
+
+			const data = await res.json();
+			setToken(data.jwt);
+
+			if (data.return_to) {
+				await goto(data.return_to);
+			} else {
+				await goto('/');
+			}
+		} catch (e) {
+			error = e instanceof Error ? e.message : 'An unexpected error occurred';
+			status = 'error';
+		}
+	}
+
+	$effect(() => {
+		if (status !== 'exchanging') return;
+		const token = $page.url.searchParams.get('token');
+		if (!token) {
+			status = 'error';
+			error = 'No login token provided.';
+			return;
+		}
+		exchangeToken(token);
+	});
+</script>
+
+<svelte:head>
+	<title>Logging in...</title>
+</svelte:head>
+
+{#if status === 'exchanging'}
+	<p>Logging you in...</p>
+{:else if status === 'error'}
+	<h1>Login failed</h1>
+	<p>{error}</p>
+{/if}

--- a/ui/src/routes/login/+page.svelte
+++ b/ui/src/routes/login/+page.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+	import { setToken } from '$lib/auth';
+
+	let email = $state('');
+	let message = $state('');
+	let error = $state('');
+
+	async function handleSubmit(e: Event) {
+		e.preventDefault();
+		message = '';
+		error = '';
+
+		const res = await fetch('/api/one_time_password', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ email })
+		});
+
+		if (!res.ok) {
+			const body = await res.json();
+			error = body.error ?? 'Failed to send login link';
+			return;
+		}
+
+		message = 'Check your email for the login link.';
+	}
+</script>
+
+<svelte:head>
+	<title>Log in</title>
+</svelte:head>
+
+<h1>Log in</h1>
+
+<form onsubmit={handleSubmit}>
+	<label>
+		Email
+		<input type="email" bind:value={email} required />
+	</label>
+	<button type="submit">Send login link</button>
+</form>
+
+{#if message}
+	<p>{message}</p>
+{/if}
+
+{#if error}
+	<p>{error}</p>
+{/if}


### PR DESCRIPTION
## Summary

Adds the UI login flow so we can start on the dev-mode login ticket (https://github.com/jdarthur/intraclub/issues/32).

## Changes

- **`ui/src/routes/login/+page.svelte`** — email login page. POSTs the email to `POST /api/one_time_password` to request a one-time login token.
- **`ui/src/routes/auth/callback/+page.svelte`** — reads `?token=` from the URL, exchanges it via `POST /api/token` to get a JWT, stores it, and redirects to the `return_to` path (or `/`).
- **`ui/src/lib/auth.ts`** — auth helper: token get/set/clear, `isLoggedIn()`, and `authFetch()` that attaches the `X-INTRACLUB-TOKEN` header.
- **`ui/src/app.d.ts`** — expose an optional `userId` on `Locals`.

## Notes
- `CHANGES.md` is a stale leftover from the already-merged user-test-coverage work and is intentionally **not** included.
- The login page currently always shows "Check your email for the login link." Rendering the dev-mode magic link + the localhost guard are tracked separately in https://github.com/jdarthur/intraclub/issues/32.