### PR TITLE
chore(ui): start the Go backend alongside Vite for Playwright

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -54,13 +54,22 @@ npm run check
 
 Playwright is used for end-to-end (UI) automation. Tests live in the `e2e/` directory.
 
-First-time setup installs the Playwright browser binaries:
+Most UI tests need the Go API as well as the UI, so Playwright starts both servers itself:
+
+- the Vite dev server on `http://127.0.0.1:5173`
+- the Go backend on `http://127.0.0.1:8080`, built to `../tmp/intraclub-e2e` and run with
+  `--dev-token` so that dev data is seeded and login tokens are returned in API responses
+
+The dev server proxies `/api` to the backend (see `vite.config.ts`), so the app's relative
+`fetch('/api/...')` calls work unchanged under test.
+
+First-time setup requires Go on your `PATH` and the Playwright browser binaries:
 
 ```sh
 npx playwright install chromium
 ```
 
-Run the E2E tests (this starts the Vite dev server automatically):
+Run the E2E tests (this starts both servers automatically):
 
 ```sh
 npm run test:e2e

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -17,9 +17,23 @@ export default defineConfig({
 			use: { ...devices['Desktop Chrome'] }
 		}
 	],
-	webServer: {
-		command: 'npm run dev -- --host 127.0.0.1',
-		url: 'http://127.0.0.1:5173',
-		reuseExistingServer: !process.env.CI
-	}
+	webServer: [
+		{
+			// Build to tmp/ (gitignored, same convention as .air.toml) rather than using
+			// `go run`, which leaves the compiled child holding :8080 on teardown.
+			// --dev-token seeds dev data and returns login tokens in API responses.
+			command: 'go build -o ./tmp/intraclub-e2e . && ./tmp/intraclub-e2e --dev-token',
+			cwd: '..',
+			// Every route is mounted under /api, so `/` 404s and never reads as ready.
+			url: 'http://127.0.0.1:8080/api/score_counting_types',
+			reuseExistingServer: !process.env.CI,
+			timeout: 120_000
+		},
+		{
+			command: 'npm run dev -- --host 127.0.0.1',
+			url: 'http://127.0.0.1:5173',
+			reuseExistingServer: !process.env.CI,
+			timeout: 120_000
+		}
+	]
 });

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -2,5 +2,13 @@ import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-	plugins: [sveltekit()]
+	plugins: [sveltekit()],
+	server: {
+		proxy: {
+			'/api': {
+				target: 'http://127.0.0.1:8080',
+				changeOrigin: true
+			}
+		}
+	}
 });


### PR DESCRIPTION
## Context

Most UI e2e tests need the API as well as the UI, but Playwright only started the Vite dev server. This makes it manage both.

## Problems fixed

**The backend readiness probe could never succeed.** Every route is mounted under the `/api` group (`main.go:38`), so `/` returns a **404** — and Playwright only accepts 2xx/3xx/400/401/402/403 as "ready". A probe against the server root polls until timeout and aborts the run before a single test executes. The probe now targets `/api/score_counting_types` (`model/scoring_structure.go:84`), which is unauthenticated, touches no DB, and always returns 200.

**`go run` orphans its child.** `go run` compiles to a temp binary and execs it as a child; when Playwright tears the server down that child can survive and keep holding `:8080`, poisoning the next run. This was observed in practice — a go-build-cache binary reparented to systemd, still listening. The backend is now built to `tmp/` and executed directly, so Playwright kills one real process. `tmp/` is already gitignored and is where `.air.toml` puts its dev binary.

**No dev data.** The backend now runs with `--dev-token`, so `SeedDevData` populates the in-memory DB and `POST /api/one_time_password` returns the login token in the response body. Without it there are no users to log in as, and `Email.Send()` (`model/email.go:60`) is a no-op — so no test could ever obtain a token.

Vite proxies `/api` to the backend so the app's relative `fetch('/api/...')` calls in the login and auth-callback pages work unchanged under test.

## Verification

Ran cold with both ports confirmed free beforehand:

- `npm run test:e2e` → **1 passed (3.8s)**, both servers booting from cold
- Readiness URL → `HTTP/1.1 200 OK`
- `POST http://127.0.0.1:5173/api/one_time_password` for the seeded `jdarthur@gatech.edu` → **201 with a token in the body**, confirming in one call that the proxy forwards, `--dev-token` took effect, and the seed user exists
- Ports clear after the run with no orphaned backend

## Note for reviewers

Both entries keep `reuseExistingServer: !process.env.CI`, and the backend uses `NewUnitTestDBProvider` (in-memory, reseeded per boot). Locally a reused backend therefore carries state across runs, so a test that mutates seeded data could affect a later run. CI always gets a fresh process. Happy to force a clean local backend too if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)