### PR TITLE
feat: dev-mode login renders magic link in UI with loopback guard

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"flag"
 	"fmt"
+	"log"
+	"net"
 
 	"intraclub/api"
 	"intraclub/database"
@@ -21,7 +23,7 @@ func main() {
 	db := database.NewUnitTestDBProvider()
 
 	// parse command-line flags
-	parseFlags()
+	addr := parseFlags()
 
 	// seed data for development mode
 	if model.UseDevTokenMode {
@@ -78,18 +80,42 @@ func main() {
 
 	rg.GET("/draft_order_patterns", model.GetDraftOrderPatterns)
 
-	err = r.Run("127.0.0.1:8080")
+	err = r.Run(addr)
 	if err != nil {
 		panic(err)
 	}
 }
 
-func parseFlags() {
+func parseFlags() string {
 	useDevTokenMode := flag.Bool("dev-token", false, "Use development token mode")
+	addr := flag.String("addr", "127.0.0.1:8080", "Address to listen on, e.g. 127.0.0.1:8080")
 	flag.Parse()
 
 	if useDevTokenMode != nil && *useDevTokenMode == true {
 		model.UseDevTokenMode = true
 		fmt.Println("Using development token mode")
 	}
+
+	if model.UseDevTokenMode && !isLoopbackAddress(*addr) {
+		log.Fatalf("--dev-token mode is DEV MODE ONLY and bypasses authentication; it may only be used when the server is bound to a loopback address (127.0.0.1 / localhost), but got %q", *addr)
+	}
+
+	return *addr
+}
+
+// isLoopbackAddress reports whether addr's host is a loopback interface
+// (127.0.0.1 / localhost). This guards dev mode, which bypasses auth gating.
+func isLoopbackAddress(addr string) bool {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		// e.g. "localhost" or "127.0.0.1" with no port
+		host = addr
+	}
+
+	// an empty host binds all interfaces (e.g. ":8080"), which is not loopback
+	if host == "" {
+		return false
+	}
+
+	return host == "localhost" || net.ParseIP(host).IsLoopback()
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,28 @@
+package main
+
+import "testing"
+
+func TestIsLoopbackAddress(t *testing.T) {
+	tests := []struct {
+		name string
+		addr string
+		want bool
+	}{
+		{"default bind", "127.0.0.1:8080", true},
+		{"localhost host", "localhost:8080", true},
+		{"bare loopback IP no port", "127.0.0.1", true},
+		{"bare localhost no port", "localhost", true},
+		{"any-interface port", ":8080", false},
+		{"all interfaces", "0.0.0.0:8080", false},
+		{"wildcard", "0.0.0.0", false},
+		{"lan ip", "192.168.1.10:8080", false},
+		{"non-loopback hostname", "example.com:8080", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isLoopbackAddress(tt.addr); got != tt.want {
+				t.Errorf("isLoopbackAddress(%q) = %v, want %v", tt.addr, got, tt.want)
+			}
+		})
+	}
+}

--- a/model/start_login.go
+++ b/model/start_login.go
@@ -269,7 +269,9 @@ func (m *StartLoginTokenManager) OneTimePassword(c *gin.Context) {
 	}
 
 	if UseDevTokenMode {
-		c.JSON(http.StatusCreated, gin.H{"token": token})
+		// DEV MODE ONLY: return the magic-link token in the response body instead of
+		// emailing it. The UI renders this as a clickable link.
+		c.JSON(http.StatusCreated, gin.H{"token": token.Token})
 	} else {
 		c.JSON(http.StatusOK, gin.H{"status": "ok"})
 	}

--- a/ui/e2e/login.spec.ts
+++ b/ui/e2e/login.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test } from '@playwright/test';
+
+// The Go backend runs with --dev-token in the Playwright harness (see
+// playwright.config.ts), so POST /api/one_time_password returns the magic-link
+// token in the response body instead of emailing it.
+test('dev-mode login renders a magic link and completes the token→JWT exchange', async ({
+	page
+}) => {
+	await page.goto('/login');
+
+	// Wait for SvelteKit hydration to finish so the bound email input and the
+	// form's submit handler are live (filling before hydration resets the value).
+	await page.waitForLoadState('networkidle');
+
+	// Submit the email of the user seeded by SeedDevData (model/dev_data.go).
+	await page.getByLabel('Email').fill('jdarthur@gatech.edu');
+	await page.getByRole('button', { name: 'Send login link' }).click();
+
+	// Dev mode: the API returned a token, so the page shows the DEV MODE ONLY
+	// annotation and a clickable magic link instead of "check your email".
+	await expect(page.getByText(/DEV MODE ONLY/)).toBeVisible();
+
+	const link = page.getByRole('link', { name: 'Log in' });
+	await expect(link).toHaveAttribute('href', /^\/auth\/callback\?token=/);
+
+	// Clicking the link runs the existing token→JWT exchange and lands on "/".
+	await link.click();
+	await expect(page).toHaveURL('/');
+	await expect(page.getByRole('heading', { name: 'Welcome to SvelteKit' })).toBeVisible();
+
+	// The exchanged JWT should be persisted.
+	const jwt = await page.evaluate(() => localStorage.getItem('intraclub_jwt'));
+	expect(jwt).toBeTruthy();
+});

--- a/ui/src/routes/login/+page.svelte
+++ b/ui/src/routes/login/+page.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
-	import { setToken } from '$lib/auth';
-
 	let email = $state('');
 	let message = $state('');
 	let error = $state('');
+	let devLink = $state('');
 
 	async function handleSubmit(e: Event) {
 		e.preventDefault();
 		message = '';
 		error = '';
+		devLink = '';
 
 		const res = await fetch('/api/one_time_password', {
 			method: 'POST',
@@ -22,7 +22,15 @@
 			return;
 		}
 
-		message = 'Check your email for the login link.';
+		const body = await res.json();
+		if (body?.token) {
+			// DEV MODE ONLY: the API returned the magic-link token in the response
+			// instead of emailing it. Render it as a clickable link.
+			devLink = `/auth/callback?token=${encodeURIComponent(body.token)}`;
+			message = 'DEV MODE ONLY — no email was sent. Use the magic link below to log in.';
+		} else {
+			message = 'Check your email for the login link.';
+		}
 	}
 </script>
 
@@ -42,6 +50,12 @@
 
 {#if message}
 	<p>{message}</p>
+{/if}
+
+{#if devLink}
+	<p>
+		<a href={devLink}>Log in</a>
+	</p>
 {/if}
 
 {#if error}


### PR DESCRIPTION
## Summary
Resolves #32. Adds a **DEV MODE ONLY** login path so a local server bypasses email delivery.

### What changed
- **API** (`model/start_login.go`): when running with `--dev-token`, `POST /api/one_time_password` returns the magic-link token in the response body (`{"token": "<hex>"}`) instead of emailing it. Non-dev mode is unchanged.
- **Backend guard** (`main.go`): added an `--addr` flag (default `127.0.0.1:8080`) and refuse to start with `--dev-token` unless the server binds to a loopback address (`127.0.0.1` / `localhost`), since dev mode bypasses auth gating.
- **UI** (`ui/src/routes/login/+page.svelte`): when the API returns a token, the login page renders a clickable `/auth/callback?token=...` link annotated **DEV MODE ONLY**; clicking it flows through the existing token→JWT exchange. Otherwise it still says "Check your email".
- **Tests**: `main_test.go` (loopback-guard unit tests) and `ui/e2e/login.spec.ts` (Playwright e2e covering the dev-mode magic link through to the JWT exchange).

### Acceptance criteria
- [x] Dev-mode login page renders a clickable magic link from the token returned by `POST /api/one_time_password`
- [x] Clicking it navigates to `/auth/callback?token=...` and completes the token → JWT exchange
- [x] Dev-mode login is annotated **DEV MODE ONLY** in the UI
- [x] Dev-mode login is rejected unless the listening address is `127.0.0.1` / `localhost`
- [x] Non-dev-mode behavior unchanged (still emails)

### Verification
- `go build ./...`, `go vet ./...`, `go test ./...` all pass
- `npm run check` (svelte-check): 0 errors, 0 warnings
- Playwright e2e `login.spec.ts` + `smoke.spec.ts` pass

Closes #32