### PR TITLE
refactor(model): normalize Team.RatingsMap into TeamRating join table

### DIFF
--- a/model/draft.go
+++ b/model/draft.go
@@ -657,8 +657,16 @@ func (d *Draft) AssignDraftedPlayersToTeams(ctx context.Context, db database.Pro
 				if err != nil {
 					return err
 				}
-				// also add to ratings map
-				team.RatingsMap[result.User.ID] = result.Rating
+				// assign this player's rating to the team as a TeamRating record
+				teamRating := &TeamRating{
+					TeamId:   team.ID,
+					UserId:   result.User.ID,
+					RatingId: result.Rating,
+				}
+				_, err = database.CreateOne(ctx, db, teamRating)
+				if err != nil {
+					return err
+				}
 			}
 		}
 

--- a/model/draft_test.go
+++ b/model/draft_test.go
@@ -426,6 +426,42 @@ func TestTeamAssignmentAfterDraft(t *testing.T) {
 	}
 }
 
+func TestTeamRatingCreatedOnAssignDraftedPlayersToTeams(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	draft := doRandomDraft(t, db, 100, 4)
+
+	err := draft.AssignDraftedPlayersToTeams(context.Background(), db)
+	require.NoError(t, err)
+
+	captains, _ := draft.GetCaptains(context.Background(), db)
+	captainIds := make(map[database.UserId]bool)
+	for _, a := range captains {
+		captainIds[a.CaptainId] = true
+	}
+
+	totalRatings := 0
+	for _, assignment := range captains {
+		team, err := database.GetExistingRecordById(context.Background(), db, &Team{}, assignment.TeamId.RecordId())
+		require.NoError(t, err)
+
+		// every drafted (non-captain) player on the team should have a TeamRating row
+		members, err := team.GetMembers(context.Background(), db)
+		require.NoError(t, err)
+		for _, member := range members {
+			if captainIds[member] {
+				// captains draft themselves but are already members, so no rating is assigned
+				continue
+			}
+			rating, err := team.GetRating(context.Background(), db, member)
+			require.NoError(t, err, "expected a rating for every drafted team member")
+			assert.NotEqual(t, RatingId(0), rating)
+			totalRatings++
+		}
+	}
+	// all 96 drafted non-captain players (100 total minus 4 captains) should have a rating
+	assert.Equal(t, 96, totalRatings)
+}
+
 func TestDoubleInitializeDraft(t *testing.T) {
 	db := database.NewUnitTestDBProvider()
 	draft := newRandomDraft(t, db, 100, 4)

--- a/model/lineup_pairing.go
+++ b/model/lineup_pairing.go
@@ -122,6 +122,11 @@ func (l *LineupPairing) GetFormat(ctx context.Context, db database.Provider) (*F
 	return lineup.GetFormat(ctx, db)
 }
 
+// ValidatePlayerRatings verifies that both players in the pairing have the
+// rating expected by their format line. Previously the inline `RatingsMap`
+// silently returned a zero rating for players without an assignment; now a
+// player with no TeamRating is treated as an error, since such a player is
+// not valid for lineup validation.
 func (l *LineupPairing) ValidatePlayerRatings(ctx context.Context, db database.Provider) error {
 	format, err := l.GetFormat(ctx, db)
 	if err != nil {
@@ -131,20 +136,22 @@ func (l *LineupPairing) ValidatePlayerRatings(ctx context.Context, db database.P
 	if err != nil {
 		return err
 	}
-	return l._validatePlayerRatings(format, team)
-}
-
-func (l *LineupPairing) _validatePlayerRatings(format *Format, team *Team) error {
 	line := format.Lines[l.FormatLineIndex]
 
-	rating1 := team.RatingsMap[l.Player1]
+	rating1, err := team.GetRating(ctx, db, l.Player1)
+	if err != nil {
+		return err
+	}
 	if rating1 != line.Player1Rating {
-		return fmt.Errorf("player 1 has rating %s, expected %s for line index %d for format", line.Player1Rating, rating1, l.FormatLineIndex)
+		return fmt.Errorf("player 1 has rating %s, expected %s for line index %d for format", rating1, line.Player1Rating, l.FormatLineIndex)
 	}
 
-	rating2 := team.RatingsMap[l.Player2]
+	rating2, err := team.GetRating(ctx, db, l.Player2)
+	if err != nil {
+		return err
+	}
 	if rating2 != line.Player2Rating {
-		return fmt.Errorf("player 2 has rating %s, expected %s for line index %d for format", line.Player2Rating, rating2, l.FormatLineIndex)
+		return fmt.Errorf("player 2 has rating %s, expected %s for line index %d for format", rating2, line.Player2Rating, l.FormatLineIndex)
 	}
 	return nil
 }

--- a/model/team.go
+++ b/model/team.go
@@ -135,15 +135,94 @@ func (a *TeamAssignment) NewRecord() database.CrudRecord {
 	return new(TeamAssignment)
 }
 
+// TeamRating is a join table record that assigns a RatingId to a UserId
+// on a particular Team. This replaces the former denormalized
+// `Team.RatingsMap` inline map (user -> rating), enabling the relationship
+// to be queried/indexed individually and stored in its own collection/table.
+//
+// API/JSON shape decision: `Team.RatingsMap` (the `ratings_map` JSON field)
+// has been removed from `Team`. Team records are not currently exposed via a
+// REST CRUD route (see main.go), so removing the field is not a breaking wire
+// change; in-process reads can reassemble the relationship rows into the old
+// map shape via `Team.GetRatingsMap`. `TeamRating` is stored in its own
+// collection (`team_rating`) with FKs to team/user/rating and a natural unique
+// constraint on (TeamId, UserId). When the #36 SQLite provider lands, this
+// becomes a `team_ratings` table with a migration/backfill.
+type TeamRating struct {
+	ID       database.RecordId `json:"id"`
+	TeamId   TeamId            `json:"team_id"`
+	UserId   database.UserId   `json:"user_id"`
+	RatingId RatingId          `json:"rating_id"`
+}
+
+func (r *TeamRating) GetOwner() database.UserId {
+	return database.InvalidUserId
+}
+
+func (r *TeamRating) SetOwner(userId database.UserId) {}
+
+func (r *TeamRating) Type() string {
+	return "team_rating"
+}
+
+func (r *TeamRating) GetId() database.RecordId {
+	return r.ID
+}
+
+func (r *TeamRating) SetId(id database.RecordId) {
+	r.ID = id
+}
+
+func (r *TeamRating) StaticallyValid() error {
+	return nil
+}
+
+func (r *TeamRating) DynamicallyValid(ctx context.Context, db database.Provider) error {
+	if err := database.ExistsById(ctx, db, &Team{}, r.TeamId.RecordId()); err != nil {
+		return err
+	}
+
+	if err := database.ExistsById(ctx, db, &User{}, r.UserId.RecordId()); err != nil {
+		return err
+	}
+
+	_, err := database.GetExistingRecordById(ctx, db, &Rating{}, r.RatingId.RecordId())
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *TeamRating) AccessibleTo(ctx context.Context, db database.Provider) []database.UserId {
+	return database.AccessibleToEveryone
+}
+
+func (r *TeamRating) EditableBy(ctx context.Context, db database.Provider) []database.UserId {
+	return []database.UserId{database.SysAdminUserId}
+}
+
+func (r *TeamRating) NewRecord() database.CrudRecord {
+	return new(TeamRating)
+}
+
+// UniquenessEquivalent enforces the natural unique constraint on (TeamId, UserId):
+// a user may only have one assigned rating per team.
+func (r *TeamRating) UniquenessEquivalent(other *TeamRating) error {
+	if r.TeamId == other.TeamId && r.UserId == other.UserId {
+		return fmt.Errorf("user %s already has a rating assigned on team %s", r.UserId, r.TeamId)
+	}
+	return nil
+}
+
 type Team struct {
-	ID          TeamId                       `json:"id"`
-	Name        string                       `json:"name"`
-	Color       TeamColor                    `json:"color"`
-	RatingsMap  map[database.UserId]RatingId `json:"ratings_map"`
-	tempCaptain database.UserId              `json:"-"`
-	CreatedAt   time.Time                    `json:"created_at"`
-	UpdatedAt   time.Time                    `json:"updated_at"`
-	DeletedAt   *time.Time                   `json:"deleted_at"`
+	ID          TeamId          `json:"id"`
+	Name        string          `json:"name"`
+	Color       TeamColor       `json:"color"`
+	tempCaptain database.UserId `json:"-"`
+	CreatedAt   time.Time       `json:"created_at"`
+	UpdatedAt   time.Time       `json:"updated_at"`
+	DeletedAt   *time.Time      `json:"deleted_at"`
 }
 
 func (t *Team) GetOwner() database.UserId {
@@ -158,9 +237,7 @@ func (t *Team) SetOwner(userId database.UserId) {
 }
 
 func NewTeam() *Team {
-	return &Team{
-		RatingsMap: make(map[database.UserId]RatingId),
-	}
+	return &Team{}
 }
 
 func NewDefaultTeam(captain database.UserId, name string) *Team {
@@ -179,6 +256,43 @@ func (t *Team) getAssignments(ctx context.Context, db database.Provider) ([]*Tea
 		return a.TeamId == t.ID
 	}
 	return database.GetAllWhere[*TeamAssignment](ctx, db, filter)
+}
+
+// getRatings returns all TeamRating relationship rows for this team.
+func (t *Team) getRatings(ctx context.Context, db database.Provider) ([]*TeamRating, error) {
+	filter := func(_ context.Context, r *TeamRating) bool {
+		return r.TeamId == t.ID
+	}
+	return database.GetAllWhere[*TeamRating](ctx, db, filter)
+}
+
+// GetRating returns the RatingId assigned to the given UserId on this team,
+// or an error if no rating assignment exists for that user.
+func (t *Team) GetRating(ctx context.Context, db database.Provider, userId database.UserId) (RatingId, error) {
+	ratings, err := t.getRatings(ctx, db)
+	if err != nil {
+		return 0, err
+	}
+	for _, r := range ratings {
+		if r.UserId == userId {
+			return r.RatingId, nil
+		}
+	}
+	return 0, fmt.Errorf("no rating assigned for user %s on team %s", userId, t.ID)
+}
+
+// GetRatingsMap reassembles the relationship rows into a user->rating map.
+// This preserves the former Team.RatingsMap shape for in-process reads.
+func (t *Team) GetRatingsMap(ctx context.Context, db database.Provider) (map[database.UserId]RatingId, error) {
+	ratings, err := t.getRatings(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+	result := make(map[database.UserId]RatingId, len(ratings))
+	for _, r := range ratings {
+		result[r.UserId] = r.RatingId
+	}
+	return result, nil
 }
 
 func (t *Team) GetCaptain(ctx context.Context, db database.Provider) (database.UserId, error) {

--- a/model/team_test.go
+++ b/model/team_test.go
@@ -5,6 +5,9 @@ import (
 	"testing"
 
 	"intraclub/database"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func newStoredTeam(t *testing.T, db database.Provider, captain database.UserId) *Team {
@@ -27,4 +30,266 @@ func newStoredTeam(t *testing.T, db database.Provider, captain database.UserId) 
 	}
 
 	return v
+}
+
+func TestTeamRatingRoundTrip(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	team := newStoredTeam(t, db, newStoredUser(t, db).ID)
+	member := newStoredUser(t, db)
+	rating := newStoredRating(t, db)
+
+	tr := &TeamRating{
+		TeamId:   team.ID,
+		UserId:   member.ID,
+		RatingId: rating.ID,
+	}
+	created, err := database.CreateOne(context.Background(), db, tr)
+	require.NoError(t, err)
+
+	got, exists, err := database.GetOneById(context.Background(), db, &TeamRating{}, created.GetId())
+	require.NoError(t, err)
+	require.True(t, exists)
+	assert.Equal(t, team.ID, got.TeamId)
+	assert.Equal(t, member.ID, got.UserId)
+	assert.Equal(t, rating.ID, got.RatingId)
+}
+
+func TestTeamRatingUniquenessConstraint(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	team := newStoredTeam(t, db, newStoredUser(t, db).ID)
+	member := newStoredUser(t, db)
+
+	rating1 := newStoredRating(t, db)
+	rating2 := newStoredRating(t, db)
+
+	tr1 := &TeamRating{TeamId: team.ID, UserId: member.ID, RatingId: rating1.ID}
+	_, err := database.CreateOne(context.Background(), db, tr1)
+	require.NoError(t, err)
+
+	// a second TeamRating for the same (team, user) must be rejected
+	tr2 := &TeamRating{TeamId: team.ID, UserId: member.ID, RatingId: rating2.ID}
+	_, err = database.CreateOne(context.Background(), db, tr2)
+	assert.Error(t, err)
+}
+
+func TestTeamRatingDynamicallyValid(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	team := newStoredTeam(t, db, newStoredUser(t, db).ID)
+	member := newStoredUser(t, db)
+	rating := newStoredRating(t, db)
+
+	// invalid team ID
+	badTeam := &TeamRating{
+		TeamId:   TeamId(database.InvalidRecordId),
+		UserId:   member.ID,
+		RatingId: rating.ID,
+	}
+	assert.Error(t, badTeam.DynamicallyValid(context.Background(), db))
+
+	// invalid user ID
+	badUser := &TeamRating{
+		TeamId:   team.ID,
+		UserId:   database.InvalidUserId,
+		RatingId: rating.ID,
+	}
+	assert.Error(t, badUser.DynamicallyValid(context.Background(), db))
+
+	// invalid rating ID
+	badRating := &TeamRating{
+		TeamId:   team.ID,
+		UserId:   member.ID,
+		RatingId: RatingId(database.InvalidRecordId),
+	}
+	assert.Error(t, badRating.DynamicallyValid(context.Background(), db))
+}
+
+func TestTeamGetRatingAndGetRatingsMap(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	team := newStoredTeam(t, db, newStoredUser(t, db).ID)
+	member := newStoredUser(t, db)
+	rating := newStoredRating(t, db)
+
+	tr := &TeamRating{TeamId: team.ID, UserId: member.ID, RatingId: rating.ID}
+	_, err := database.CreateOne(context.Background(), db, tr)
+	require.NoError(t, err)
+
+	got, err := team.GetRating(context.Background(), db, member.ID)
+	require.NoError(t, err)
+	assert.Equal(t, rating.ID, got)
+
+	// unknown user should error
+	_, err = team.GetRating(context.Background(), db, newStoredUser(t, db).ID)
+	assert.Error(t, err)
+
+	ratingsMap, err := team.GetRatingsMap(context.Background(), db)
+	require.NoError(t, err)
+	assert.Equal(t, map[database.UserId]RatingId{member.ID: rating.ID}, ratingsMap)
+}
+
+func TestTeamGetRatingsMultipleMembers(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	team := newStoredTeam(t, db, newStoredUser(t, db).ID)
+
+	member1 := newStoredUser(t, db)
+	member2 := newStoredUser(t, db)
+	rating1 := newStoredRating(t, db)
+	rating2 := newStoredRating(t, db)
+
+	_, err := database.CreateOne(context.Background(), db, &TeamRating{TeamId: team.ID, UserId: member1.ID, RatingId: rating1.ID})
+	require.NoError(t, err)
+	_, err = database.CreateOne(context.Background(), db, &TeamRating{TeamId: team.ID, UserId: member2.ID, RatingId: rating2.ID})
+	require.NoError(t, err)
+
+	ratingsMap, err := team.GetRatingsMap(context.Background(), db)
+	require.NoError(t, err)
+	assert.Equal(t, map[database.UserId]RatingId{
+		member1.ID: rating1.ID,
+		member2.ID: rating2.ID,
+	}, ratingsMap)
+
+	// each member resolves to their own rating
+	got1, err := team.GetRating(context.Background(), db, member1.ID)
+	require.NoError(t, err)
+	assert.Equal(t, rating1.ID, got1)
+	got2, err := team.GetRating(context.Background(), db, member2.ID)
+	require.NoError(t, err)
+	assert.Equal(t, rating2.ID, got2)
+}
+
+func TestTeamGetRatingsMapEmpty(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	team := newStoredTeam(t, db, newStoredUser(t, db).ID)
+
+	ratingsMap, err := team.GetRatingsMap(context.Background(), db)
+	require.NoError(t, err)
+	assert.Empty(t, ratingsMap)
+}
+
+func TestTeamRatingQueryByTeam(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	team := newStoredTeam(t, db, newStoredUser(t, db).ID)
+	otherTeam := newStoredTeam(t, db, newStoredUser(t, db).ID)
+	member := newStoredUser(t, db)
+	otherMember := newStoredUser(t, db)
+	rating := newStoredRating(t, db)
+
+	_, err := database.CreateOne(context.Background(), db, &TeamRating{TeamId: team.ID, UserId: member.ID, RatingId: rating.ID})
+	require.NoError(t, err)
+	// a record for a different team should not appear in this team's query
+	_, err = database.CreateOne(context.Background(), db, &TeamRating{TeamId: otherTeam.ID, UserId: otherMember.ID, RatingId: rating.ID})
+	require.NoError(t, err)
+
+	rows, err := database.GetAllWhere[*TeamRating](context.Background(), db, func(_ context.Context, r *TeamRating) bool {
+		return r.TeamId == team.ID
+	})
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, member.ID, rows[0].UserId)
+}
+
+func TestTeamRatingUniquenessEquivalentDirect(t *testing.T) {
+	teamId1 := TeamId(database.NewRecordId())
+	teamId2 := TeamId(database.NewRecordId())
+	user1 := database.UserId(database.NewRecordId())
+
+	base := &TeamRating{TeamId: teamId1, UserId: user1}
+
+	// same team + same user -> error
+	assert.Error(t, base.UniquenessEquivalent(&TeamRating{TeamId: teamId1, UserId: user1}))
+
+	// same user, different team -> allowed
+	assert.NoError(t, base.UniquenessEquivalent(&TeamRating{TeamId: teamId2, UserId: user1}))
+
+	// same team, different user -> allowed
+	assert.NoError(t, base.UniquenessEquivalent(&TeamRating{TeamId: teamId1, UserId: database.UserId(database.NewRecordId())}))
+
+	// different team + different user -> allowed
+	assert.NoError(t, base.UniquenessEquivalent(&TeamRating{TeamId: teamId2, UserId: database.UserId(database.NewRecordId())}))
+}
+
+func TestTeamRatingDynamicallyValidSuccess(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	team := newStoredTeam(t, db, newStoredUser(t, db).ID)
+	member := newStoredUser(t, db)
+	rating := newStoredRating(t, db)
+
+	tr := &TeamRating{TeamId: team.ID, UserId: member.ID, RatingId: rating.ID}
+	require.NoError(t, tr.DynamicallyValid(context.Background(), db))
+
+	_, err := database.CreateOne(context.Background(), db, tr)
+	require.NoError(t, err)
+}
+
+func TestTeamRatingUpdate(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	team := newStoredTeam(t, db, newStoredUser(t, db).ID)
+	member := newStoredUser(t, db)
+	rating1 := newStoredRating(t, db)
+	rating2 := newStoredRating(t, db)
+
+	tr := &TeamRating{TeamId: team.ID, UserId: member.ID, RatingId: rating1.ID}
+	created, err := database.CreateOne(context.Background(), db, tr)
+	require.NoError(t, err)
+
+	// reassigning the rating for the same (team, user) is a legal update
+	created.RatingId = rating2.ID
+	require.NoError(t, database.UpdateOne(context.Background(), db, created))
+
+	got, err := team.GetRating(context.Background(), db, member.ID)
+	require.NoError(t, err)
+	assert.Equal(t, rating2.ID, got)
+}
+
+func TestTeamRatingUpdateToDuplicateRejected(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	team := newStoredTeam(t, db, newStoredUser(t, db).ID)
+	member1 := newStoredUser(t, db)
+	member2 := newStoredUser(t, db)
+	rating := newStoredRating(t, db)
+
+	tr1 := &TeamRating{TeamId: team.ID, UserId: member1.ID, RatingId: rating.ID}
+	_, err := database.CreateOne(context.Background(), db, tr1)
+	require.NoError(t, err)
+	tr2 := &TeamRating{TeamId: team.ID, UserId: member2.ID, RatingId: rating.ID}
+	created2, err := database.CreateOne(context.Background(), db, tr2)
+	require.NoError(t, err)
+
+	// moving member2 onto member1's (team, user) must be rejected
+	created2.UserId = member1.ID
+	assert.Error(t, database.UpdateOne(context.Background(), db, created2))
+}
+
+func TestTeamRatingAccessControl(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	tr := &TeamRating{}
+
+	// ratings are owner-less, accessible to everyone, editable only by sysadmin
+	assert.Equal(t, database.InvalidUserId, tr.GetOwner())
+	assert.Equal(t, database.AccessibleToEveryone, tr.AccessibleTo(context.Background(), db))
+	assert.Equal(t, []database.UserId{database.SysAdminUserId}, tr.EditableBy(context.Background(), db))
+
+	// SetOwner is a no-op and does not change the owner
+	tr.SetOwner(newStoredUser(t, db).ID)
+	assert.Equal(t, database.InvalidUserId, tr.GetOwner())
+}
+
+func TestTeamRatingCrudRecordInterface(t *testing.T) {
+	tr := &TeamRating{}
+
+	assert.Equal(t, "team_rating", tr.Type())
+	assert.NoError(t, tr.StaticallyValid())
+	assert.Equal(t, database.RecordId(0), tr.GetId())
+
+	// SetId/GetId round-trips
+	tr.SetId(database.NewRecordId())
+	assert.Equal(t, tr.ID, tr.GetId())
+
+	// NewRecord returns a fresh empty record of the same type
+	blank := tr.NewRecord()
+	blankTr, ok := blank.(*TeamRating)
+	require.True(t, ok)
+	assert.Equal(t, database.RecordId(0), blankTr.GetId())
+	assert.Equal(t, TeamId(0), blankTr.TeamId)
+	assert.Equal(t, database.UserId(0), blankTr.UserId)
+	assert.Equal(t, RatingId(0), blankTr.RatingId)
 }


### PR DESCRIPTION
Closes #40

## Summary
Normalizes the inline `Team.RatingsMap` (user → rating) into a dedicated `TeamRating` assign-x-to-y record, mirroring the existing `FormatRating`/`DraftFormat` pattern.

## Changes
- **`model/team.go`**: added `TeamRating{ TeamId, UserId, RatingId }` with `Type()`/`NewRecord()`/`GetId()`/`SetId()`, static + dynamic validation (FK checks against team/user/rating), access control, and a natural unique constraint on `(TeamId, UserId)`. Removed `Team.RatingsMap` and its `NewTeam()` init. Added read helpers `Team.GetRating` / `Team.GetRatingsMap`.
- **`model/draft.go`**: `AssignDraftedPlayersToTeams` now creates `TeamRating` records instead of mutating the inline map.
- **`model/lineup_pairing.go`**: `ValidatePlayerRatings` reads ratings via `team.GetRating(...)` instead of the inline map. Note: a player with no rating now errors instead of silently reading `0`.
- **Tests**: round-trip, uniqueness (create + update), dynamic validation (success + failure), query-by-team, multiple members, access control, and interface compliance for `TeamRating`; plus a draft test verifying ratings are persisted for all drafted players.

## API/JSON shape decision
`ratings_map` was removed from `Team`. `Team` records aren't currently exposed via a REST CRUD route (`main.go` registers only User/Facility/ScoringStructure/Rating/Format), so this is not a breaking wire change. In-process reads can reassemble the old map shape via `Team.GetRatingsMap`.

## Migration note
The `team_ratings` table + backfill are deferred to the #36 SQLite migration framework, which does not exist yet.