### PR TITLE
chore: add Makefile targets for Go and Playwright test suites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ intraclub
 *.key
 .idea
 .claude
+.reasonix
+reasonix.toml

--- a/Makefile
+++ b/Makefile
@@ -54,9 +54,8 @@ linuxpackage: linux
 
 tests:
 	$(info Running golang unit tests)
-	@go test ./lib
-	@go test ./controllers
-	@go test ./common
+	@go test ./...
+	@go vet ./...
 
 gocommon:
 	$(info Synchronizing go-common code)
@@ -74,6 +73,14 @@ docker:
 dockertest:
 	$(info Building docker test image with name: $(TEST_DOCKER_NAME))
 	@docker build -t $(TEST_DOCKER_NAME) -f Dockerfile.test .
+
+e2e:
+	$(info Running Playwright e2e tests (headless, from ./ui))
+	@cd ui && npm run test:e2e
+
+e2e-ui:
+	$(info Running Playwright e2e tests in UI mode (from ./ui))
+	@cd ui && npm run test:e2e:ui
 
 clean:
 	@rm -f $(BINARY_NAME)


### PR DESCRIPTION
## Summary

Fixes the stale `tests` Makefile target and adds Playwright e2e targets.

- **`tests`** — was running `go test` against `./lib`, `./controllers`, `./common`, which don't exist in this repo (stale from an old project template) and always errored. Now runs `go test ./...` (covers `api`, `database`, `mailer`, `model`, `route`, `route/user`) plus `go vet ./...`.
- **`e2e`** — headless Playwright run from `./ui` (`npm run test:e2e`).
- **`e2e-ui`** — Playwright interactive UI mode (`npm run test:e2e:ui`).

Also ignores `.reasonix` and `reasonix.toml`.

## Verification

- `make -n tests e2e e2e-ui` dry-runs cleanly.
- `go test ./...` passes for all packages.
- The e2e target itself was not run here (it boots a full Go + Vite webserver and needs Playwright browsers installed).