### PR TITLE
refactor(model): normalize TeamMatch.IndividualMatches into TeamMatchIndividualMatch

### DIFF
--- a/model/team_match.go
+++ b/model/team_match.go
@@ -1,6 +1,9 @@
 package model
 
 import (
+	"context"
+	"fmt"
+
 	"intraclub/database"
 )
 
@@ -14,35 +17,200 @@ func (id TeamMatchId) String() string {
 	return id.RecordId().String()
 }
 
+// TeamMatch represents a head-to-head match between a home and an away team
+// for a given week, using a specific lineup to determine the pairings played.
+//
+// API/JSON shape decision: the former inline `individual_matches` field
+// (`map[LineupPairingId]IndividualMatchId`) has been removed from `TeamMatch`
+// and normalized into the `TeamMatchIndividualMatch` join table. TeamMatch
+// records are not currently exposed via a REST CRUD route (see main.go), so
+// removing the field is not a breaking wire change; in-process reads can
+// reassemble the relationship rows into the old map shape via
+// `TeamMatch.GetIndividualMatches`.
 type TeamMatch struct {
-	ID                TeamMatchId
-	WeekId            WeekId
-	HomeTeam          TeamId
-	AwayTeam          TeamId
-	Lineup            LineupId
-	IndividualMatches map[LineupPairingId]IndividualMatchId
+	ID       TeamMatchId
+	WeekId   WeekId
+	HomeTeam TeamId
+	AwayTeam TeamId
+	Lineup   LineupId
 }
 
-// func (t *TeamMatch) ValidateMatchesVsLineup(db common.DatabaseProvider) error {
+func (t *TeamMatch) GetOwner() database.UserId {
+	return database.InvalidUserId
+}
+
+func (t *TeamMatch) SetOwner(userId database.UserId) {
+	// no owner field; access is governed by the participating teams
+}
+
+func (t *TeamMatch) Type() string {
+	return "team_match"
+}
+
+func (t *TeamMatch) GetId() database.RecordId {
+	return t.ID.RecordId()
+}
+
+func (t *TeamMatch) SetId(id database.RecordId) {
+	t.ID = TeamMatchId(id)
+}
+
+func (t *TeamMatch) StaticallyValid() error {
+	return nil
+}
+
+func (t *TeamMatch) DynamicallyValid(ctx context.Context, db database.Provider) error {
+	if err := database.ExistsById(ctx, db, &Week{}, t.WeekId.RecordId()); err != nil {
+		return err
+	}
+	if err := database.ExistsById(ctx, db, &Team{}, t.HomeTeam.RecordId()); err != nil {
+		return err
+	}
+	if err := database.ExistsById(ctx, db, &Team{}, t.AwayTeam.RecordId()); err != nil {
+		return err
+	}
+	return database.ExistsById(ctx, db, &Lineup{}, t.Lineup.RecordId())
+}
+
+func (t *TeamMatch) AccessibleTo(ctx context.Context, db database.Provider) []database.UserId {
+	return database.AccessibleToEveryone
+}
+
+func (t *TeamMatch) EditableBy(ctx context.Context, db database.Provider) []database.UserId {
+	return []database.UserId{database.SysAdminUserId}
+}
+
+func (t *TeamMatch) NewRecord() database.CrudRecord {
+	return new(TeamMatch)
+}
+
+// TeamMatchIndividualMatch is a join table record that assigns an
+// IndividualMatch to a LineupPairing for a particular TeamMatch. This replaces
+// the former denormalized `TeamMatch.IndividualMatches` inline map (lineup
+// pairing -> individual match), enabling the relationship to be queried/indexed
+// individually and stored in its own collection/table.
 //
-//	lineup, err := common.GetExistingRecordById(ctx, db, &Lineup{}, t.Lineup.RecordId())
-//	if err != nil {
-//		return err
-//	}
-//
-//	for lineupPairingId, individualMatchId := range t.IndividualMatches {
-//		lineupPairing, err := common.GetExistingRecordById(ctx, db, &LineupPairing{}, lineupPairingId.RecordId())
-//		if err != nil {
-//			return err
-//		}
-//
-//		individualMatch, err := common.GetExistingRecordById(ctx, db, &IndividualMatch{}, individualMatchId.RecordId())
-//		if err != nil {
-//			return err
-//		}
-//
-//		if individualMatch
-//
-//	}
-//
-// }
+// It is stored in its own collection (`team_match_individual_match`) with FKs
+// to team_match, lineup_pairing, and individual_match, and a natural unique
+// constraint on (TeamMatchId, LineupPairingId). When the #36 SQLite provider
+// lands, this becomes a `team_match_individual_matches` table with a
+// migration/backfill.
+type TeamMatchIndividualMatch struct {
+	ID                database.RecordId `json:"id"`
+	TeamMatchId       TeamMatchId       `json:"team_match_id"`
+	LineupPairingId   LineupPairingId   `json:"lineup_pairing_id"`
+	IndividualMatchId IndividualMatchId `json:"individual_match_id"`
+}
+
+func (m *TeamMatchIndividualMatch) GetOwner() database.UserId {
+	return database.InvalidUserId
+}
+
+func (m *TeamMatchIndividualMatch) SetOwner(userId database.UserId) {}
+
+func (m *TeamMatchIndividualMatch) Type() string {
+	return "team_match_individual_match"
+}
+
+func (m *TeamMatchIndividualMatch) GetId() database.RecordId {
+	return m.ID
+}
+
+func (m *TeamMatchIndividualMatch) SetId(id database.RecordId) {
+	m.ID = id
+}
+
+func (m *TeamMatchIndividualMatch) StaticallyValid() error {
+	return nil
+}
+
+func (m *TeamMatchIndividualMatch) DynamicallyValid(ctx context.Context, db database.Provider) error {
+	if err := database.ExistsById(ctx, db, &TeamMatch{}, m.TeamMatchId.RecordId()); err != nil {
+		return err
+	}
+	if err := database.ExistsById(ctx, db, &LineupPairing{}, m.LineupPairingId.RecordId()); err != nil {
+		return err
+	}
+	return database.ExistsById(ctx, db, &IndividualMatch{}, m.IndividualMatchId.RecordId())
+}
+
+func (m *TeamMatchIndividualMatch) AccessibleTo(ctx context.Context, db database.Provider) []database.UserId {
+	return database.AccessibleToEveryone
+}
+
+func (m *TeamMatchIndividualMatch) EditableBy(ctx context.Context, db database.Provider) []database.UserId {
+	return []database.UserId{database.SysAdminUserId}
+}
+
+func (m *TeamMatchIndividualMatch) NewRecord() database.CrudRecord {
+	return new(TeamMatchIndividualMatch)
+}
+
+// UniquenessEquivalent enforces the natural unique constraint on
+// (TeamMatchId, LineupPairingId): a lineup pairing may only be assigned one
+// individual match per team match.
+func (m *TeamMatchIndividualMatch) UniquenessEquivalent(other *TeamMatchIndividualMatch) error {
+	if m.TeamMatchId == other.TeamMatchId && m.LineupPairingId == other.LineupPairingId {
+		return fmt.Errorf("lineup pairing %s already has an individual match assigned on team match %s", m.LineupPairingId, m.TeamMatchId)
+	}
+	return nil
+}
+
+// getIndividualMatchRows returns all TeamMatchIndividualMatch relationship
+// rows assigned to this team match.
+func (t *TeamMatch) getIndividualMatchRows(ctx context.Context, db database.Provider) ([]*TeamMatchIndividualMatch, error) {
+	filter := func(_ context.Context, m *TeamMatchIndividualMatch) bool {
+		return m.TeamMatchId == t.ID
+	}
+	return database.GetAllWhere[*TeamMatchIndividualMatch](ctx, db, filter)
+}
+
+// GetIndividualMatches reassembles the relationship rows into the former
+// inline map shape (lineup pairing -> individual match) for in-process reads.
+func (t *TeamMatch) GetIndividualMatches(ctx context.Context, db database.Provider) (map[LineupPairingId]IndividualMatchId, error) {
+	rows, err := t.getIndividualMatchRows(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+	result := make(map[LineupPairingId]IndividualMatchId, len(rows))
+	for _, row := range rows {
+		result[row.LineupPairingId] = row.IndividualMatchId
+	}
+	return result, nil
+}
+
+// AssignIndividualMatch creates the relationship row that assigns the given
+// IndividualMatch to the given LineupPairing for this TeamMatch.
+func (t *TeamMatch) AssignIndividualMatch(ctx context.Context, db database.Provider, lineupPairingId LineupPairingId, individualMatchId IndividualMatchId) (*TeamMatchIndividualMatch, error) {
+	row := &TeamMatchIndividualMatch{
+		TeamMatchId:       t.ID,
+		LineupPairingId:   lineupPairingId,
+		IndividualMatchId: individualMatchId,
+	}
+	return database.CreateOne(ctx, db, row)
+}
+
+// ValidateMatchesVsLineup verifies that every individual match assigned to
+// this TeamMatch is tied to a lineup pairing that belongs to this team match's
+// lineup, and that each referenced individual match exists.
+func (t *TeamMatch) ValidateMatchesVsLineup(ctx context.Context, db database.Provider) error {
+	rows, err := t.getIndividualMatchRows(ctx, db)
+	if err != nil {
+		return err
+	}
+
+	for _, row := range rows {
+		pairing, err := database.GetExistingRecordById(ctx, db, &LineupPairing{}, row.LineupPairingId.RecordId())
+		if err != nil {
+			return err
+		}
+		if pairing.LineupId != t.Lineup {
+			return fmt.Errorf("lineup pairing %s is not part of lineup %s for team match %s", row.LineupPairingId, t.Lineup, t.ID)
+		}
+		if _, err := database.GetExistingRecordById(ctx, db, &IndividualMatch{}, row.IndividualMatchId.RecordId()); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/model/team_match_test.go
+++ b/model/team_match_test.go
@@ -1,0 +1,229 @@
+package model
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"intraclub/database"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newStoredTeamMatch builds the full chain required to persist a TeamMatch:
+// format -> draft -> two teams -> week -> lineup -> team match.
+func newStoredTeamMatch(t *testing.T, db database.Provider) *TeamMatch {
+	format := newDefaultStoredFormat(t, db)
+	commissioner := newStoredUser(t, db)
+
+	draft := NewDraft()
+	draft.Owner = commissioner.ID
+	draft.Format = format.ID
+	draftV, err := database.CreateOne(context.Background(), db, draft)
+	require.NoError(t, err)
+
+	team1 := newStoredTeam(t, db, newStoredUser(t, db).ID)
+	team2 := newStoredTeam(t, db, newStoredUser(t, db).ID)
+
+	week := NewWeek()
+	week.DraftId = draftV.ID
+	week.Date = time.Date(2020, 1, 1, 8, 0, 0, 0, time.UTC)
+	weekV, err := database.CreateOne(context.Background(), db, week)
+	require.NoError(t, err)
+
+	lineup := &Lineup{TeamId: team1.ID, WeekId: weekV.ID}
+	lineupV, err := database.CreateOne(context.Background(), db, lineup)
+	require.NoError(t, err)
+
+	tm := &TeamMatch{WeekId: weekV.ID, HomeTeam: team1.ID, AwayTeam: team2.ID, Lineup: lineupV.ID}
+	tmV, err := database.CreateOne(context.Background(), db, tm)
+	require.NoError(t, err)
+	return tmV
+}
+
+// newStoredLineupPairing builds a LineupPairing belonging to the given lineup,
+// with two freshly-created users added as members of the lineup's team.
+func newStoredLineupPairing(t *testing.T, db database.Provider, lineup *Lineup, team *Team) *LineupPairing {
+	player1 := newStoredUser(t, db)
+	player2 := newStoredUser(t, db)
+
+	for _, player := range []database.UserId{player1.ID, player2.ID} {
+		assignment := &TeamAssignment{
+			TeamId: team.ID,
+			UserId: player,
+			Role:   TeamRoleMember,
+		}
+		_, err := database.CreateOne(context.Background(), db, assignment)
+		require.NoError(t, err)
+	}
+
+	lp := &LineupPairing{
+		LineupId:        lineup.ID,
+		TeamId:          team.ID,
+		Player1:         player1.ID,
+		Player2:         player2.ID,
+		FormatLineIndex: 0,
+	}
+	v, err := database.CreateOne(context.Background(), db, lp)
+	require.NoError(t, err)
+	return v
+}
+
+// newStoredIndividualMatch builds a single, unpaired IndividualMatch.
+func newStoredIndividualMatch(t *testing.T, db database.Provider) *IndividualMatch {
+	scoring := newDefaultStoredScoringStructure(t, db)
+	match := NewMatch()
+	match.Structure = scoring.ID
+	match.Editors = []database.UserId{scoring.Owner}
+	v, err := database.CreateOne(context.Background(), db, match)
+	require.NoError(t, err)
+	return v
+}
+
+func TestTeamMatchIndividualMatchRoundTrip(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	teamMatch := newStoredTeamMatch(t, db)
+	lineup, err := database.GetExistingRecordById(context.Background(), db, &Lineup{}, teamMatch.Lineup.RecordId())
+	require.NoError(t, err)
+	homeTeam, err := database.GetExistingRecordById(context.Background(), db, &Team{}, teamMatch.HomeTeam.RecordId())
+	require.NoError(t, err)
+	pairing := newStoredLineupPairing(t, db, lineup, homeTeam)
+	match := newStoredIndividualMatch(t, db)
+
+	row := &TeamMatchIndividualMatch{
+		TeamMatchId:       teamMatch.ID,
+		LineupPairingId:   pairing.ID,
+		IndividualMatchId: match.ID,
+	}
+	created, err := database.CreateOne(context.Background(), db, row)
+	require.NoError(t, err)
+
+	got, exists, err := database.GetOneById(context.Background(), db, &TeamMatchIndividualMatch{}, created.GetId())
+	require.NoError(t, err)
+	require.True(t, exists)
+	assert.Equal(t, teamMatch.ID, got.TeamMatchId)
+	assert.Equal(t, pairing.ID, got.LineupPairingId)
+	assert.Equal(t, match.ID, got.IndividualMatchId)
+}
+
+func TestTeamMatchIndividualMatchUniquenessConstraint(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	teamMatch := newStoredTeamMatch(t, db)
+	lineup, err := database.GetExistingRecordById(context.Background(), db, &Lineup{}, teamMatch.Lineup.RecordId())
+	require.NoError(t, err)
+	homeTeam, err := database.GetExistingRecordById(context.Background(), db, &Team{}, teamMatch.HomeTeam.RecordId())
+	require.NoError(t, err)
+	pairing := newStoredLineupPairing(t, db, lineup, homeTeam)
+	match1 := newStoredIndividualMatch(t, db)
+	match2 := newStoredIndividualMatch(t, db)
+
+	row1 := &TeamMatchIndividualMatch{
+		TeamMatchId:       teamMatch.ID,
+		LineupPairingId:   pairing.ID,
+		IndividualMatchId: match1.ID,
+	}
+	_, err = database.CreateOne(context.Background(), db, row1)
+	require.NoError(t, err)
+
+	// a second assignment for the same (teamMatch, lineupPairing) must be rejected
+	row2 := &TeamMatchIndividualMatch{
+		TeamMatchId:       teamMatch.ID,
+		LineupPairingId:   pairing.ID,
+		IndividualMatchId: match2.ID,
+	}
+	_, err = database.CreateOne(context.Background(), db, row2)
+	assert.Error(t, err)
+}
+
+func TestTeamMatchIndividualMatchDynamicallyValid(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	teamMatch := newStoredTeamMatch(t, db)
+	lineup, err := database.GetExistingRecordById(context.Background(), db, &Lineup{}, teamMatch.Lineup.RecordId())
+	require.NoError(t, err)
+	homeTeam, err := database.GetExistingRecordById(context.Background(), db, &Team{}, teamMatch.HomeTeam.RecordId())
+	require.NoError(t, err)
+	pairing := newStoredLineupPairing(t, db, lineup, homeTeam)
+	match := newStoredIndividualMatch(t, db)
+
+	// invalid team match ID
+	badTeamMatch := &TeamMatchIndividualMatch{
+		TeamMatchId:       TeamMatchId(database.InvalidRecordId),
+		LineupPairingId:   pairing.ID,
+		IndividualMatchId: match.ID,
+	}
+	assert.Error(t, badTeamMatch.DynamicallyValid(context.Background(), db))
+
+	// invalid lineup pairing ID
+	badPairing := &TeamMatchIndividualMatch{
+		TeamMatchId:       teamMatch.ID,
+		LineupPairingId:   LineupPairingId(database.InvalidRecordId),
+		IndividualMatchId: match.ID,
+	}
+	assert.Error(t, badPairing.DynamicallyValid(context.Background(), db))
+
+	// invalid individual match ID
+	badMatch := &TeamMatchIndividualMatch{
+		TeamMatchId:       teamMatch.ID,
+		LineupPairingId:   pairing.ID,
+		IndividualMatchId: IndividualMatchId(database.InvalidRecordId),
+	}
+	assert.Error(t, badMatch.DynamicallyValid(context.Background(), db))
+}
+
+func TestTeamMatchAssignAndGetIndividualMatches(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	teamMatch := newStoredTeamMatch(t, db)
+	lineup, err := database.GetExistingRecordById(context.Background(), db, &Lineup{}, teamMatch.Lineup.RecordId())
+	require.NoError(t, err)
+	homeTeam, err := database.GetExistingRecordById(context.Background(), db, &Team{}, teamMatch.HomeTeam.RecordId())
+	require.NoError(t, err)
+	pairing1 := newStoredLineupPairing(t, db, lineup, homeTeam)
+	pairing2 := newStoredLineupPairing(t, db, lineup, homeTeam)
+	match1 := newStoredIndividualMatch(t, db)
+	match2 := newStoredIndividualMatch(t, db)
+
+	_, err = teamMatch.AssignIndividualMatch(context.Background(), db, pairing1.ID, match1.ID)
+	require.NoError(t, err)
+	_, err = teamMatch.AssignIndividualMatch(context.Background(), db, pairing2.ID, match2.ID)
+	require.NoError(t, err)
+
+	matches, err := teamMatch.GetIndividualMatches(context.Background(), db)
+	require.NoError(t, err)
+	assert.Len(t, matches, 2)
+	assert.Equal(t, match1.ID, matches[pairing1.ID])
+	assert.Equal(t, match2.ID, matches[pairing2.ID])
+}
+
+func TestTeamMatchValidateMatchesVsLineup(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	teamMatch := newStoredTeamMatch(t, db)
+	lineup, err := database.GetExistingRecordById(context.Background(), db, &Lineup{}, teamMatch.Lineup.RecordId())
+	require.NoError(t, err)
+	homeTeam, err := database.GetExistingRecordById(context.Background(), db, &Team{}, teamMatch.HomeTeam.RecordId())
+	require.NoError(t, err)
+	pairing := newStoredLineupPairing(t, db, lineup, homeTeam)
+	match := newStoredIndividualMatch(t, db)
+
+	// valid assignment within the team match's lineup passes
+	_, err = teamMatch.AssignIndividualMatch(context.Background(), db, pairing.ID, match.ID)
+	require.NoError(t, err)
+	require.NoError(t, teamMatch.ValidateMatchesVsLineup(context.Background(), db))
+
+	// a pairing belonging to a different lineup must fail
+	otherTeam := newStoredTeam(t, db, newStoredUser(t, db).ID)
+	otherWeek := NewWeek()
+	otherWeek.DraftId = newStoredDraft(t, db, newStoredUser(t, db).ID).ID
+	otherWeek.Date = time.Date(2020, 2, 1, 8, 0, 0, 0, time.UTC)
+	otherWeekV, err := database.CreateOne(context.Background(), db, otherWeek)
+	require.NoError(t, err)
+	otherLineup := &Lineup{TeamId: otherTeam.ID, WeekId: otherWeekV.ID}
+	otherLineupV, err := database.CreateOne(context.Background(), db, otherLineup)
+	require.NoError(t, err)
+	otherPairing := newStoredLineupPairing(t, db, otherLineupV, otherTeam)
+	otherMatch := newStoredIndividualMatch(t, db)
+
+	_, err = teamMatch.AssignIndividualMatch(context.Background(), db, otherPairing.ID, otherMatch.ID)
+	require.NoError(t, err)
+	assert.Error(t, teamMatch.ValidateMatchesVsLineup(context.Background(), db))
+}


### PR DESCRIPTION
## Summary

Implements ticket **#43** — the sub-ticket of the normalization umbrella **#37** covering `TeamMatch.IndividualMatches`.

Removes the denormalized inline `TeamMatch.IndividualMatches map[LineupPairingId]IndividualMatchId` and replaces it with a dedicated `TeamMatchIndividualMatch` join-table record, following the established `TeamRating`/`FormatRating` pattern.

## Changes

- **`model/team_match.go`**
  - Removed the inline `IndividualMatches` map.
  - Promoted `TeamMatch` to a full `CrudRecord` (Type / GetId / SetId / validation / access control / NewRecord) so the join table can reference it.
  - Added `TeamMatchIndividualMatch` (`{TeamMatchId, LineupPairingId, IndividualMatchId}`), stored in its own `team_match_individual_match` collection with FKs to team_match / lineup_pairing / individual_match and a natural unique constraint on `(TeamMatchId, LineupPairingId)`.
  - Added helpers: `GetIndividualMatches` (reassembles the old map shape for in-process reads), `AssignIndividualMatch` (creates relationship rows), and implemented the previously-stubbed `ValidateMatchesVsLineup` (verifies each assigned pairing belongs to the team match's lineup and that each referenced individual match exists).
  - Documented the API shape decision: the inline field is removed; since `TeamMatch` has no REST route, this is not a breaking wire change.
- **`model/team_match_test.go`** (new): round-trip, uniqueness-constraint, `DynamicallyValid`, `Assign`/`GetIndividualMatches`, and `ValidateMatchesVsLineup` tests, with helpers building the full chain.

## Acceptance criteria

- [x] `TeamMatch` no longer stores an inline relationship map.
- [x] `TeamMatchIndividualMatch` is a dedicated assign-x-to-y record/table with FK + unique constraint.
- [x] All read/write call sites updated (none existed — `TeamMatch` was previously dead code); tests green.
- [x] API shape decision documented.

## Verification

`go build ./...`, `go vet ./...`, and `go test ./...` all pass.

## Note

The migration/backfill item is deferred to the #36 migration framework, which does not yet exist; the collection is created lazily by MongoDB like every other model.

Closes #43