### PR TITLE
refactor(model): normalize CommissionerProposal.Votes into CommissionerProposalVote

### DIFF
--- a/model/commissioner_proposal.go
+++ b/model/commissioner_proposal.go
@@ -13,13 +13,19 @@ import (
 // one-time (or perhaps permanent going-forward) rule change or other type of
 // administrative action during the season (such as adding a player to a team
 // after-the-fact or modifying a player's rating). This can be ratified either by
-// majority rule (50%+1), or by unanimous consent, based on the type of proposal
+// majority rule (50%+1), or by unanimous consent, based on the type of proposal.
+//
+// API/JSON shape decision: the former inline `votes` field
+// (`map[database.UserId]bool`) has been removed from `CommissionerProposal` and
+// normalized into the `CommissionerProposalVote` relationship table. A proposal
+// is not currently exposed via a REST CRUD route (see main.go), so removing the
+// field is not a breaking wire change; in-process reads can reassemble the
+// relationship rows into the old map shape via `CommissionerProposal.GetVotes`.
 type CommissionerProposal struct {
-	ID              database.RecordId        // unique ID for this proposal
-	Description     string                   // description of the change or action
-	SeasonId        SeasonId                 // season that this pertains to
-	Votes           map[database.UserId]bool // votes of all commissioners or team captains, true == vote in favor, false == vote against
-	MustBeUnanimous bool                     // true if this proposal must get unanimous consent to pass
+	ID              database.RecordId // unique ID for this proposal
+	Description     string            // description of the change or action
+	SeasonId        SeasonId          // season that this pertains to
+	MustBeUnanimous bool              // true if this proposal must get unanimous consent to pass
 }
 
 func (c *CommissionerProposal) GetOwner() database.UserId {
@@ -35,9 +41,7 @@ func (c *CommissionerProposal) PreUpdate(ctx context.Context, db database.Provid
 }
 
 func NewCommissionerProposal() *CommissionerProposal {
-	return &CommissionerProposal{
-		Votes: make(map[database.UserId]bool),
-	}
+	return &CommissionerProposal{}
 }
 
 func (c *CommissionerProposal) Type() string {
@@ -89,17 +93,21 @@ func (c *CommissionerProposal) DynamicallyValid(ctx context.Context, db database
 		return err
 	}
 
-	// validate that each voter is a valid captain or commissioner
-	for voter, _ := range c.Votes {
+	// validate that each recorded voter is a valid captain or commissioner
+	rows, err := c.getVoteRows(ctx, db)
+	if err != nil {
+		return err
+	}
+	for _, row := range rows {
 		found := false
-		for _, captain := range possibleVoters {
-			if voter == captain {
+		for _, possible := range possibleVoters {
+			if row.UserId == possible {
 				found = true
 				break
 			}
 		}
 		if !found {
-			return fmt.Errorf("voter %s not found in possible voters for commissioner proposal", voter)
+			return fmt.Errorf("voter %s not found in possible voters for commissioner proposal", row.UserId)
 		}
 	}
 	return nil
@@ -126,12 +134,68 @@ func (c *CommissionerProposal) GetAllVoterIds(ctx context.Context, db database.P
 	return append(output, teamCaptains...), nil
 }
 
-func (c *CommissionerProposal) Vote(ctx context.Context, db database.Provider, voterId database.UserId, vote bool) error {
-	// add vote to the map
-	c.Votes[voterId] = vote
+// getVoteRows returns all CommissionerProposalVote relationship rows assigned to
+// this proposal.
+func (c *CommissionerProposal) getVoteRows(ctx context.Context, db database.Provider) ([]*CommissionerProposalVote, error) {
+	filter := func(_ context.Context, v *CommissionerProposalVote) bool {
+		return v.ProposalId == c.ID
+	}
+	return database.GetAllWhere[*CommissionerProposalVote](ctx, db, filter)
+}
 
-	// update the record, returning an error if e.g. this UserId is not entitled to a vote here
-	return database.UpdateOne(ctx, db, c)
+// GetVotes reassembles the relationship rows into the former inline map shape
+// (user id -> vote) for in-process reads.
+func (c *CommissionerProposal) GetVotes(ctx context.Context, db database.Provider) (map[database.UserId]bool, error) {
+	rows, err := c.getVoteRows(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+	result := make(map[database.UserId]bool, len(rows))
+	for _, row := range rows {
+		result[row.UserId] = row.Vote
+	}
+	return result, nil
+}
+
+func (c *CommissionerProposal) Vote(ctx context.Context, db database.Provider, voterId database.UserId, vote bool) error {
+	// only an entitled voter (a commissioner or team captain in the Season) may
+	// cast a vote on this proposal
+	possibleVoters, err := c.GetAllVoterIds(ctx, db)
+	if err != nil {
+		return err
+	}
+	valid := false
+	for _, possible := range possibleVoters {
+		if voterId == possible {
+			valid = true
+			break
+		}
+	}
+	if !valid {
+		return fmt.Errorf("voter %s not found in possible voters for commissioner proposal", voterId)
+	}
+
+	// if this voter has already voted, update their existing relationship row
+	// rather than creating a duplicate (one vote per voter, enforced by the
+	// natural unique constraint on (ProposalId, UserId))
+	rows, err := c.getVoteRows(ctx, db)
+	if err != nil {
+		return err
+	}
+	for _, row := range rows {
+		if row.UserId == voterId {
+			row.Vote = vote
+			return database.UpdateOne(ctx, db, row)
+		}
+	}
+
+	row := &CommissionerProposalVote{
+		ProposalId: c.ID,
+		UserId:     voterId,
+		Vote:       vote,
+	}
+	_, err = database.CreateOne(ctx, db, row)
+	return err
 }
 
 func (c *CommissionerProposal) VotesToPassOrFail(voterIds []database.UserId) (votesToPass, votesToFail int) {
@@ -156,15 +220,19 @@ func (c *CommissionerProposal) Status(ctx context.Context, db database.Provider)
 		return false, false, err
 	}
 
-	// X votes to pass, Y votes to fail based on
+	// X votes to pass, Y votes to fail based on the proposal type
 	votesNeededToPass, votesNeededToFail := c.VotesToPassOrFail(voterIds)
+
+	rows, err := c.getVoteRows(ctx, db)
+	if err != nil {
+		return false, false, err
+	}
 
 	votesInFavor := 0
 	votesAgainst := 0
-	for _, vote := range c.Votes {
+	for _, row := range rows {
 		// tally all the existing votes
-
-		if vote == true {
+		if row.Vote {
 			votesInFavor += 1
 		} else {
 			votesAgainst += 1
@@ -186,4 +254,77 @@ func (c *CommissionerProposal) Status(ctx context.Context, db database.Provider)
 
 func (c *CommissionerProposal) NewRecord() database.CrudRecord {
 	return new(CommissionerProposal)
+}
+
+// CommissionerProposalVote is a relationship record that assigns a single vote
+// (for or against) from a User on a CommissionerProposal. This replaces the
+// former denormalized `CommissionerProposal.Votes` inline map, enabling each
+// vote to be queried/indexed individually and stored in its own collection.
+//
+// It is stored in its own collection (`commissioner_proposal_vote`) with FKs to
+// commissioner_proposal and user, and a natural unique constraint on
+// (ProposalId, UserId) guaranteeing one vote per voter. When the #36 SQLite
+// provider lands, this becomes a `commissioner_proposal_votes` table with a
+// migration/backfill.
+type CommissionerProposalVote struct {
+	ID         database.RecordId
+	ProposalId database.RecordId
+	UserId     database.UserId
+	Vote       bool
+}
+
+func (v *CommissionerProposalVote) GetOwner() database.UserId {
+	return database.InvalidUserId
+}
+
+func (v *CommissionerProposalVote) SetOwner(userId database.UserId) {}
+
+func (v *CommissionerProposalVote) Type() string {
+	return "commissioner_proposal_vote"
+}
+
+func (v *CommissionerProposalVote) GetId() database.RecordId {
+	return v.ID
+}
+
+func (v *CommissionerProposalVote) SetId(id database.RecordId) {
+	v.ID = id
+}
+
+func (v *CommissionerProposalVote) StaticallyValid() error {
+	return nil
+}
+
+func (v *CommissionerProposalVote) DynamicallyValid(ctx context.Context, db database.Provider) error {
+	if err := database.ExistsById(ctx, db, &CommissionerProposal{}, v.ProposalId); err != nil {
+		return err
+	}
+	return database.ExistsById(ctx, db, &User{}, v.UserId.RecordId())
+}
+
+// AccessibleTo exposes the vote only to those who can view the proposal itself
+// (the Season's commissioners and team captains).
+func (v *CommissionerProposalVote) AccessibleTo(ctx context.Context, db database.Provider) []database.UserId {
+	proposal, err := database.GetExistingRecordById(ctx, db, &CommissionerProposal{}, v.ProposalId)
+	if err != nil {
+		return nil
+	}
+	return proposal.AccessibleTo(ctx, db)
+}
+
+func (v *CommissionerProposalVote) EditableBy(ctx context.Context, db database.Provider) []database.UserId {
+	return []database.UserId{database.SysAdminUserId}
+}
+
+func (v *CommissionerProposalVote) NewRecord() database.CrudRecord {
+	return new(CommissionerProposalVote)
+}
+
+// UniquenessEquivalent enforces the natural unique constraint on
+// (ProposalId, UserId): a user may only cast one vote per proposal.
+func (v *CommissionerProposalVote) UniquenessEquivalent(other *CommissionerProposalVote) error {
+	if v.ProposalId == other.ProposalId && v.UserId == other.UserId {
+		return fmt.Errorf("voter %s already has a vote on commissioner proposal %s", v.UserId, v.ProposalId)
+	}
+	return nil
 }

--- a/model/commissioner_proposal_test.go
+++ b/model/commissioner_proposal_test.go
@@ -6,6 +6,9 @@ import (
 	"testing"
 
 	"intraclub/database"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func newStoredCommissionerProposalForSeason(t *testing.T, db database.Provider, season *Season, mustBeUnanimous bool) *CommissionerProposal {
@@ -200,7 +203,6 @@ func copyProposal(p *CommissionerProposal) *CommissionerProposal {
 		ID:              p.ID,
 		Description:     p.Description,
 		SeasonId:        p.SeasonId,
-		Votes:           p.Votes,
 		MustBeUnanimous: p.MustBeUnanimous,
 	}
 }
@@ -215,4 +217,102 @@ func TestCommissionerProposalUnanimousConstraintCannotBeUpdated(t *testing.T) {
 		t.Fatal("expected error when updating unanimous constraint")
 	}
 	fmt.Println(err)
+}
+
+func TestCommissionerProposalVoteRoundTrip(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	season, prop := newStoredCommissionerProposal(t, db, false)
+	commissioners, err := season.GetCommissioners(context.Background(), db)
+	require.NoError(t, err)
+
+	row := &CommissionerProposalVote{
+		ProposalId: prop.ID,
+		UserId:     commissioners[0],
+		Vote:       true,
+	}
+	created, err := database.CreateOne(context.Background(), db, row)
+	require.NoError(t, err)
+
+	got, exists, err := database.GetOneById(context.Background(), db, &CommissionerProposalVote{}, created.GetId())
+	require.NoError(t, err)
+	require.True(t, exists)
+	assert.Equal(t, prop.ID, got.ProposalId)
+	assert.Equal(t, commissioners[0], got.UserId)
+	assert.True(t, got.Vote)
+}
+
+func TestCommissionerProposalVoteUniquenessConstraint(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	season, prop := newStoredCommissionerProposal(t, db, false)
+	commissioners, err := season.GetCommissioners(context.Background(), db)
+	require.NoError(t, err)
+
+	row1 := &CommissionerProposalVote{ProposalId: prop.ID, UserId: commissioners[0], Vote: true}
+	_, err = database.CreateOne(context.Background(), db, row1)
+	require.NoError(t, err)
+
+	// a second vote for the same (proposal, user) must be rejected
+	row2 := &CommissionerProposalVote{ProposalId: prop.ID, UserId: commissioners[0], Vote: false}
+	_, err = database.CreateOne(context.Background(), db, row2)
+	assert.Error(t, err)
+}
+
+func TestCommissionerProposalVoteDynamicallyValid(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	season, prop := newStoredCommissionerProposal(t, db, false)
+	commissioners, err := season.GetCommissioners(context.Background(), db)
+	require.NoError(t, err)
+
+	valid := &CommissionerProposalVote{ProposalId: prop.ID, UserId: commissioners[0], Vote: true}
+	assert.NoError(t, valid.DynamicallyValid(context.Background(), db))
+
+	// invalid proposal ID
+	badProp := &CommissionerProposalVote{ProposalId: database.InvalidRecordId, UserId: commissioners[0], Vote: true}
+	assert.Error(t, badProp.DynamicallyValid(context.Background(), db))
+
+	// invalid user ID
+	badUser := &CommissionerProposalVote{ProposalId: prop.ID, UserId: database.InvalidUserId, Vote: true}
+	assert.Error(t, badUser.DynamicallyValid(context.Background(), db))
+}
+
+func TestCommissionerProposalVoteViaVoteMethod(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	season, prop := newStoredCommissionerProposal(t, db, false)
+	commissioners, err := season.GetCommissioners(context.Background(), db)
+	require.NoError(t, err)
+
+	err = prop.Vote(context.Background(), db, commissioners[0], true)
+	require.NoError(t, err)
+
+	votes, err := prop.GetVotes(context.Background(), db)
+	require.NoError(t, err)
+	assert.Len(t, votes, 1)
+	assert.True(t, votes[commissioners[0]])
+}
+
+func TestCommissionerProposalVoteCanChange(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	season, prop := newStoredCommissionerProposal(t, db, false)
+	commissioners, err := season.GetCommissioners(context.Background(), db)
+	require.NoError(t, err)
+
+	err = prop.Vote(context.Background(), db, commissioners[0], true)
+	require.NoError(t, err)
+	err = prop.Vote(context.Background(), db, commissioners[0], false)
+	require.NoError(t, err)
+
+	// the voter's existing relationship row is updated, not duplicated
+	votes, err := prop.GetVotes(context.Background(), db)
+	require.NoError(t, err)
+	assert.Len(t, votes, 1)
+	assert.False(t, votes[commissioners[0]])
+}
+
+func TestCommissionerProposalGetVotesEmpty(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	_, prop := newStoredCommissionerProposal(t, db, false)
+
+	votes, err := prop.GetVotes(context.Background(), db)
+	require.NoError(t, err)
+	assert.Len(t, votes, 0)
 }


### PR DESCRIPTION
## Summary

Implements **#42** from the umbrella normalization work in #37.

Normalizes the inline `CommissionerProposal.Votes` map (`map[UserId]bool`) into a dedicated `CommissionerProposalVote` relationship record/table, following the established `SeasonTeam`/`FormatRating`/`TeamMatchIndividualMatch` join-table pattern.

## What changed

- **`model/commissioner_proposal.go`**
  - Removed the inline `Votes` map and its initialization in `NewCommissionerProposal()`.
  - Added `CommissionerProposalVote` (`ProposalId`, `UserId`, `Vote bool`) with `Type()`, `NewRecord()`, `GetId()`/`SetId()`, validation, access control, and a natural unique constraint on `(ProposalId, UserId)` (one vote per voter).
  - `Vote()` now creates/updates a relationship row (re-voting updates the existing row, no duplicate).
  - `Status()` and `DynamicallyValid()` read/tally/validate via the new table.
  - Added `GetVotes()` to reassemble the old map shape for in-process reads.
  - Documented the API shape decision (no breaking wire change — proposal isn't exposed via REST) and migration/backfill intent for the #36 SQLite provider.

- **`model/commissioner_proposal_test.go`**
  - Removed the dropped `Votes` field from `copyProposal`.
  - Added round-trip, uniqueness, dynamic-validation, vote-via-method, re-vote, and empty-votes tests.

## Verification

- `go build ./...`, `go vet ./...`, `go test ./...` — all green.

Closes #42