### PR TITLE
refactor(model): normalize Draft.RatingCutoffs into DraftRatingCutoff

### DIFF
--- a/model/draft.go
+++ b/model/draft.go
@@ -76,10 +76,17 @@ type Draft struct {
 	Name              string            `json:"name"`                // descriptive name for the draft, e.g. "2025 Men's Intraclub". this will become the default name of the Season post-draft
 	Owner             database.UserId   `json:"owner"`               // This will be the commissioner of the league
 	Format            FormatId          `json:"format"`              // Format in which the Season associated with this draft will be played
-	RatingCutoffs     map[RatingId]int  `json:"rating_cutoffs"`      // map from rating ID to the last selection index matching that ID
 	CompletedAt       time.Time         `json:"completed_at"`        // timestamp when the draft was completed
 	DraftOrderPattern DraftOrderPattern `json:"draft_order_pattern"` // draft order pattern, e.g. snake, straight-up, etc.
 }
+
+// API/JSON shape decision: the former inline `rating_cutoffs` field
+// (`map[RatingId]int`) has been removed from `Draft` and normalized into the
+// `DraftRatingCutoff` join table (draft_rating_cutoff collection). Draft
+// records are not currently exposed via a REST CRUD route (see main.go), so
+// removing the field is not a breaking wire change; in-process reads can
+// reassemble the relationship rows into the old map shape via
+// `Draft.GetRatingCutoffs`.
 
 func (d *Draft) SetOwner(userId database.UserId) {
 	d.Owner = userId
@@ -122,12 +129,16 @@ func (d *Draft) DynamicallyValid(ctx context.Context, db database.Provider) erro
 		return err
 	}
 
-	if d.RatingCutoffs != nil {
-		// if the ratings cutoff are set, validate them, i.e.
-		// we have an increasing rating cutoff for each possible
-		// rating in the format, and that the last rating does not
-		// have a cutoff assigned to it
-		err = d.ValidateRatingsCutoff(format.PossibleRatings)
+	// if the rating cutoffs are set, validate them, i.e.
+	// we have an increasing rating cutoff for each possible
+	// rating in the format, and that the last rating does not
+	// have a cutoff assigned to it
+	ratingCutoffs, err := d.GetRatingCutoffs(ctx, db)
+	if err != nil {
+		return err
+	}
+	if len(ratingCutoffs) > 0 {
+		err = d.ValidateRatingsCutoff(format.PossibleRatings, ratingCutoffs)
 		if err != nil {
 			return err
 		}
@@ -389,7 +400,10 @@ func (d *Draft) Select(ctx context.Context, player database.UserId, db database.
 
 	// Get the rating for this pick
 	format, _ := database.GetExistingRecordById(getDraftContext(), db, &Format{}, d.Format.RecordId())
-	rating := d.GetRatingForPick(format.PossibleRatings, len(picks))
+	rating, err := d.GetRatingForPick(getDraftContext(), db, format.PossibleRatings, len(picks))
+	if err != nil {
+		return err
+	}
 
 	// Create the pick record
 	draftPick := &DraftPick{
@@ -400,7 +414,7 @@ func (d *Draft) Select(ctx context.Context, player database.UserId, db database.
 		Pick:    pick,
 		Rating:  rating,
 	}
-	_, err := database.CreateOne(ctx, db, draftPick)
+	_, err = database.CreateOne(ctx, db, draftPick)
 	return err
 }
 
@@ -468,27 +482,68 @@ func (d *Draft) GetDraftSelectionsByCaptainId(ctx context.Context, db database.P
 	return d.getDraftSelectionsByTeamIndex(getDraftContext(), db, teamIndex)
 }
 
+// getRatingCutoffRows returns all DraftRatingCutoff relationship rows assigned
+// to this draft.
+func (d *Draft) getRatingCutoffRows(ctx context.Context, db database.Provider) ([]*DraftRatingCutoff, error) {
+	filter := func(_ context.Context, drc *DraftRatingCutoff) bool {
+		return drc.DraftId == d.ID
+	}
+	return database.GetAllWhere[*DraftRatingCutoff](ctx, db, filter)
+}
+
+// GetRatingCutoffs reassembles the relationship rows into the former inline map
+// shape (rating -> cutoff index) for in-process reads.
+func (d *Draft) GetRatingCutoffs(ctx context.Context, db database.Provider) (map[RatingId]int, error) {
+	rows, err := d.getRatingCutoffRows(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+	result := make(map[RatingId]int, len(rows))
+	for _, row := range rows {
+		result[row.RatingId] = row.CutoffIndex
+	}
+	return result, nil
+}
+
+// AssignRatingCutoff creates the relationship row that assigns the given cutoff
+// index to the given rating for this Draft.
+func (d *Draft) AssignRatingCutoff(ctx context.Context, db database.Provider, rating RatingId, cutoff int) (*DraftRatingCutoff, error) {
+	row := &DraftRatingCutoff{
+		DraftId:     d.ID,
+		RatingId:    rating,
+		CutoffIndex: cutoff,
+	}
+	return database.CreateOne(ctx, db, row)
+}
+
 // GetRatingForPick returns the rating assigned to a pick based on the draft's rating cutoffs.
 // The rating is determined by comparing the pick number against the stored cutoffs.
-func (d *Draft) GetRatingForPick(ratings []RatingId, pick int) RatingId {
+func (d *Draft) GetRatingForPick(ctx context.Context, db database.Provider, ratings []RatingId, pick int) (RatingId, error) {
+	cutoffs, err := d.GetRatingCutoffs(ctx, db)
+	if err != nil {
+		return RatingId(0), err
+	}
+
 	// check if this pick is below one of the cutoffs
 	for _, rating := range ratings[:len(ratings)-1] {
-		cutoff := d.RatingCutoffs[rating]
+		cutoff := cutoffs[rating]
 		if pick <= cutoff {
-			return rating
+			return rating, nil
 		}
 	}
 	// if not, this pick is assigned the lowest rating
-	return ratings[len(ratings)-1]
+	return ratings[len(ratings)-1], nil
 }
 
-func (d *Draft) ValidateRatingsCutoff(ratings []RatingId) error {
+// ValidateRatingsCutoff validates the draft's rating cutoffs (queried from the
+// DraftRatingCutoff relationship table) against the format's possible ratings.
+func (d *Draft) ValidateRatingsCutoff(ratings []RatingId, cutoffs map[RatingId]int) error {
 	allButOneRatings := ratings[:len(ratings)-1]
 	lastRating := ratings[len(ratings)-1]
 
 	cutoffBefore := -1
 	for _, rating := range allButOneRatings {
-		v, ok := d.RatingCutoffs[rating]
+		v, ok := cutoffs[rating]
 		if !ok {
 			return fmt.Errorf("rating cutoff for rating %s not found", rating)
 		}
@@ -503,7 +558,7 @@ func (d *Draft) ValidateRatingsCutoff(ratings []RatingId) error {
 		cutoffBefore = v
 	}
 
-	_, ok := d.RatingCutoffs[lastRating]
+	_, ok := cutoffs[lastRating]
 	if ok {
 		return fmt.Errorf("lowest rating %s must not have a rating cutoff", lastRating)
 	}

--- a/model/draft_rating_cutoff.go
+++ b/model/draft_rating_cutoff.go
@@ -1,0 +1,75 @@
+package model
+
+import (
+	"context"
+	"fmt"
+
+	"intraclub/database"
+)
+
+// DraftRatingCutoff is a join table record that assigns a rating to a cutoff
+// index (the last selection index matching that rating) for a particular Draft.
+// This replaces the former denormalized `Draft.RatingCutoffs` inline map
+// (rating -> cutoff index), enabling the relationship to be queried/indexed
+// individually and stored in its own collection/table.
+//
+// It is stored in its own collection (`draft_rating_cutoff`) with FKs to draft
+// and rating, and a natural unique constraint on (DraftId, RatingId). When the
+// #36 SQLite provider lands, this becomes a `draft_rating_cutoffs` table with a
+// migration/backfill.
+type DraftRatingCutoff struct {
+	ID          database.RecordId `json:"id"`
+	DraftId     DraftId           `json:"draft_id"`
+	RatingId    RatingId          `json:"rating_id"`
+	CutoffIndex int               `json:"cutoff_index"`
+}
+
+func (d *DraftRatingCutoff) GetOwner() database.UserId {
+	return database.InvalidUserId
+}
+
+func (d *DraftRatingCutoff) SetOwner(userId database.UserId) {}
+
+func (d *DraftRatingCutoff) Type() string {
+	return "draft_rating_cutoff"
+}
+
+func (d *DraftRatingCutoff) GetId() database.RecordId {
+	return d.ID
+}
+
+func (d *DraftRatingCutoff) SetId(id database.RecordId) {
+	d.ID = id
+}
+
+func (d *DraftRatingCutoff) StaticallyValid() error {
+	return nil
+}
+
+func (d *DraftRatingCutoff) DynamicallyValid(ctx context.Context, db database.Provider) error {
+	if err := database.ExistsById(ctx, db, &Draft{}, d.DraftId.RecordId()); err != nil {
+		return err
+	}
+	return database.ExistsById(ctx, db, &Rating{}, d.RatingId.RecordId())
+}
+
+func (d *DraftRatingCutoff) AccessibleTo(ctx context.Context, db database.Provider) []database.UserId {
+	return database.AccessibleToEveryone
+}
+
+func (d *DraftRatingCutoff) EditableBy(ctx context.Context, db database.Provider) []database.UserId {
+	return []database.UserId{database.SysAdminUserId}
+}
+
+func (d *DraftRatingCutoff) NewRecord() database.CrudRecord {
+	return new(DraftRatingCutoff)
+}
+
+// UniquenessEquivalent enforces the natural unique constraint on
+// (DraftId, RatingId): a rating may only be assigned one cutoff per draft.
+func (d *DraftRatingCutoff) UniquenessEquivalent(other *DraftRatingCutoff) error {
+	if d.DraftId == other.DraftId && d.RatingId == other.RatingId {
+		return fmt.Errorf("draft %s already has a rating cutoff assigned for rating %s", d.DraftId, d.RatingId)
+	}
+	return nil
+}

--- a/model/draft_test.go
+++ b/model/draft_test.go
@@ -263,29 +263,42 @@ func TestGetRatingForSelection(t *testing.T) {
 	db := database.NewUnitTestDBProvider()
 	format := newDefaultFormat(t, db)
 	draft := newRandomDraft(t, db, 100, 4)
-	draft.RatingCutoffs = map[RatingId]int{
-		format.PossibleRatings[0]: 20,
-		format.PossibleRatings[1]: 40,
-		format.PossibleRatings[2]: 70,
+
+	// assign rating cutoffs via the relationship table
+	cutoffs := []struct {
+		rating RatingId
+		cutoff int
+	}{
+		{format.PossibleRatings[0], 20},
+		{format.PossibleRatings[1], 40},
+		{format.PossibleRatings[2], 70},
+	}
+	for _, c := range cutoffs {
+		_, err := draft.AssignRatingCutoff(context.Background(), db, c.rating, c.cutoff)
+		require.NoError(t, err)
 	}
 
 	for i := 0; i <= 20; i++ {
-		rating := draft.GetRatingForPick(format.PossibleRatings, i)
+		rating, err := draft.GetRatingForPick(context.Background(), db, format.PossibleRatings, i)
+		require.NoError(t, err)
 		assert.Equal(t, format.PossibleRatings[0], rating)
 	}
 
 	for i := 21; i <= 40; i++ {
-		rating := draft.GetRatingForPick(format.PossibleRatings, i)
+		rating, err := draft.GetRatingForPick(context.Background(), db, format.PossibleRatings, i)
+		require.NoError(t, err)
 		assert.Equal(t, format.PossibleRatings[1], rating)
 	}
 
 	for i := 41; i <= 70; i++ {
-		rating := draft.GetRatingForPick(format.PossibleRatings, i)
+		rating, err := draft.GetRatingForPick(context.Background(), db, format.PossibleRatings, i)
+		require.NoError(t, err)
 		assert.Equal(t, format.PossibleRatings[2], rating)
 	}
 
 	for i := 71; i <= 100; i++ {
-		rating := draft.GetRatingForPick(format.PossibleRatings, i)
+		rating, err := draft.GetRatingForPick(context.Background(), db, format.PossibleRatings, i)
+		require.NoError(t, err)
 		assert.Equal(t, format.PossibleRatings[3], rating)
 	}
 }
@@ -294,56 +307,64 @@ func TestRatingWithCutoffBelowPrevious(t *testing.T) {
 	db := database.NewUnitTestDBProvider()
 	format := newDefaultFormat(t, db)
 	draft := newRandomDraft(t, db, 100, 4)
-	draft.RatingCutoffs = map[RatingId]int{
+	assignRatingCutoffs(t, db, draft, format, map[RatingId]int{
 		format.PossibleRatings[0]: 20,
 		format.PossibleRatings[1]: 10,
 		format.PossibleRatings[2]: 70,
-	}
+	})
 
-	assert.Error(t, draft.ValidateRatingsCutoff(format.PossibleRatings), "Expected draft to be invalid")
-	fmt.Println(draft.ValidateRatingsCutoff(format.PossibleRatings))
+	assert.Error(t, draft.DynamicallyValid(context.Background(), db), "Expected draft to be invalid")
+	fmt.Println(draft.DynamicallyValid(context.Background(), db))
 }
 
 func TestRatingCutoffIsZero(t *testing.T) {
 	db := database.NewUnitTestDBProvider()
 	format := newDefaultFormat(t, db)
 	draft := newRandomDraft(t, db, 100, 4)
-	draft.RatingCutoffs = map[RatingId]int{
+	assignRatingCutoffs(t, db, draft, format, map[RatingId]int{
 		format.PossibleRatings[0]: 0,
 		format.PossibleRatings[1]: 10,
 		format.PossibleRatings[2]: 70,
-	}
+	})
 
-	assert.Error(t, draft.ValidateRatingsCutoff(format.PossibleRatings), "Expected draft to be invalid")
-	fmt.Println(draft.ValidateRatingsCutoff(format.PossibleRatings))
+	assert.Error(t, draft.DynamicallyValid(context.Background(), db), "Expected draft to be invalid")
+	fmt.Println(draft.DynamicallyValid(context.Background(), db))
 }
 
 func TestRatingCutoffIsMissing(t *testing.T) {
 	db := database.NewUnitTestDBProvider()
 	format := newDefaultFormat(t, db)
 	draft := newRandomDraft(t, db, 100, 4)
-	draft.RatingCutoffs = map[RatingId]int{
+	assignRatingCutoffs(t, db, draft, format, map[RatingId]int{
 		format.PossibleRatings[0]: 5,
 		format.PossibleRatings[1]: 10,
-	}
+	})
 
-	assert.Error(t, draft.ValidateRatingsCutoff(format.PossibleRatings), "Expected draft to be invalid")
-	fmt.Println(draft.ValidateRatingsCutoff(format.PossibleRatings))
+	assert.Error(t, draft.DynamicallyValid(context.Background(), db), "Expected draft to be invalid")
+	fmt.Println(draft.DynamicallyValid(context.Background(), db))
 }
 
 func TestRatingCutoffForLastRatingIdIsPresent(t *testing.T) {
 	db := database.NewUnitTestDBProvider()
 	format := newDefaultFormat(t, db)
 	draft := newRandomDraft(t, db, 100, 4)
-	draft.RatingCutoffs = map[RatingId]int{
+	assignRatingCutoffs(t, db, draft, format, map[RatingId]int{
 		format.PossibleRatings[0]: 5,
 		format.PossibleRatings[1]: 10,
 		format.PossibleRatings[2]: 70,
 		format.PossibleRatings[3]: 80,
-	}
+	})
 
 	assert.Error(t, draft.DynamicallyValid(context.Background(), db), "Expected draft to be invalid")
 	fmt.Println(draft.DynamicallyValid(context.Background(), db))
+}
+
+// assignRatingCutoffs persists the given cutoff map as DraftRatingCutoff rows.
+func assignRatingCutoffs(t *testing.T, db database.Provider, draft *Draft, format *Format, cutoffs map[RatingId]int) {
+	for rating, cutoff := range cutoffs {
+		_, err := draft.AssignRatingCutoff(context.Background(), db, rating, cutoff)
+		require.NoError(t, err)
+	}
 }
 
 func TestTeamCaptainAssignmentHasIncorrectCaptainId(t *testing.T) {
@@ -607,4 +628,88 @@ func TestDraftFormatInvalidFormatId(t *testing.T) {
 	}
 	assert.Error(t, df.DynamicallyValid(context.Background(), db), "Expected invalid format ID to fail validation")
 	fmt.Println(df.DynamicallyValid(context.Background(), db))
+}
+
+func TestDraftRatingCutoffRoundTrip(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	draft := newDefaultStoredDraft(t, db)
+	rating := newStoredRating(t, db)
+
+	row := &DraftRatingCutoff{
+		DraftId:     draft.ID,
+		RatingId:    rating.ID,
+		CutoffIndex: 25,
+	}
+	created, err := database.CreateOne(context.Background(), db, row)
+	require.NoError(t, err)
+
+	got, exists, err := database.GetOneById(context.Background(), db, &DraftRatingCutoff{}, created.GetId())
+	require.NoError(t, err)
+	require.True(t, exists)
+	assert.Equal(t, draft.ID, got.DraftId)
+	assert.Equal(t, rating.ID, got.RatingId)
+	assert.Equal(t, 25, got.CutoffIndex)
+}
+
+func TestDraftRatingCutoffUniquenessConstraint(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	draft := newDefaultStoredDraft(t, db)
+	rating := newStoredRating(t, db)
+
+	row1 := &DraftRatingCutoff{
+		DraftId:     draft.ID,
+		RatingId:    rating.ID,
+		CutoffIndex: 10,
+	}
+	_, err := database.CreateOne(context.Background(), db, row1)
+	require.NoError(t, err)
+
+	// a second cutoff for the same (draft, rating) must be rejected
+	row2 := &DraftRatingCutoff{
+		DraftId:     draft.ID,
+		RatingId:    rating.ID,
+		CutoffIndex: 20,
+	}
+	_, err = database.CreateOne(context.Background(), db, row2)
+	assert.Error(t, err)
+}
+
+func TestDraftRatingCutoffDynamicallyValid(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	draft := newDefaultStoredDraft(t, db)
+	rating := newStoredRating(t, db)
+
+	// invalid draft ID
+	badDraft := &DraftRatingCutoff{
+		DraftId:     DraftId(database.InvalidRecordId),
+		RatingId:    rating.ID,
+		CutoffIndex: 10,
+	}
+	assert.Error(t, badDraft.DynamicallyValid(context.Background(), db))
+
+	// invalid rating ID
+	badRating := &DraftRatingCutoff{
+		DraftId:     draft.ID,
+		RatingId:    RatingId(database.InvalidRecordId),
+		CutoffIndex: 10,
+	}
+	assert.Error(t, badRating.DynamicallyValid(context.Background(), db))
+}
+
+func TestDraftAssignAndGetRatingCutoffs(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	draft := newDefaultStoredDraft(t, db)
+	rating1 := newStoredRating(t, db)
+	rating2 := newStoredRating(t, db)
+
+	_, err := draft.AssignRatingCutoff(context.Background(), db, rating1.ID, 20)
+	require.NoError(t, err)
+	_, err = draft.AssignRatingCutoff(context.Background(), db, rating2.ID, 40)
+	require.NoError(t, err)
+
+	cutoffs, err := draft.GetRatingCutoffs(context.Background(), db)
+	require.NoError(t, err)
+	assert.Len(t, cutoffs, 2)
+	assert.Equal(t, 20, cutoffs[rating1.ID])
+	assert.Equal(t, 40, cutoffs[rating2.ID])
 }


### PR DESCRIPTION
## Summary

Part of the umbrella normalization work in #37. Normalizes the inline `Draft.RatingCutoffs` map into a dedicated `DraftRatingCutoff` assign-x-to-y record, following the established `TeamRating`/`FormatRating` join-table pattern.

## Changes

- **`model/draft_rating_cutoff.go`** (new): `DraftRatingCutoff{ DraftId, RatingId, CutoffIndex }` with `Type()`, `NewRecord()`, `GetId()`/`SetId()`, static + dynamic validation (FK to `draft` + `rating`), access control, and a natural unique constraint on `(DraftId, RatingId)`.
- **`model/draft.go`**: removed the inline `Draft.RatingCutoffs` map; added `GetRatingCutoffs` (reassembles the old map shape), `AssignRatingCutoff` (write site), and `getRatingCutoffRows`; updated `GetRatingForPick`, `ValidateRatingsCutoff`, and `DynamicallyValid` to query the relationship table.
- **`model/draft_test.go`**: rewrote the cutoff tests to use `DraftRatingCutoff` records and added round-trip / query / uniqueness / validation tests.

## API shape decision

`Draft` has no REST CRUD route (see `main.go`), so removing the inline `rating_cutoffs` field is **not a breaking wire change**. In-process reads reassemble the relationship rows into the old map shape via `Draft.GetRatingCutoffs`.

## Migration

No migration framework exists yet (#36); the future `draft_rating_cutoffs` table + backfill is documented in the new file's doc comment.

Closes #41