### PR TITLE
refactor(model): normalize WeeklyMatchup.Matchups into WeeklyMatchupTeamMatchup

### DIFF
--- a/docs/api-shape-weekly-matchup.md
+++ b/docs/api-shape-weekly-matchup.md
@@ -1,0 +1,16 @@
+# API Shape Decision Documentation
+
+## WeeklyMatchupTeamMatchup Normalization (Ticket #39)
+
+### Decision: Wire format reassembles relationship rows into the existing `matchups` shape
+
+The `WeeklyMatchup` model no longer stores an inline `[]*TeamMatchup` slice. Instead, each matchup entry is normalized into a separate `WeeklyMatchupTeamMatchup` record.
+
+For API consumers:
+- **Serialization**: When returning a `WeeklyMatchup` via the API, callers should call `w.GetMatchups(ctx, db)` to reassemble the `[]*TeamMatchup` slice from the relationship table and include it in the response under the existing `matchups` JSON key.
+- **Deserialization**: When receiving a `WeeklyMatchup` from the API, callers should create the `WeeklyMatchup` record first, then call `w.SetMatchups(ctx, db, matchups)` to persist the individual matchup entries.
+- **Wire format**: The external JSON shape remains unchanged: `{ "id": "...", "week_id": "...", "season_id": "...", "matchups": [...] }`. The `matchups` field is virtual — it is computed on read and expanded on write.
+
+### Why
+
+This preserves backward compatibility with existing API consumers while achieving the normalization goal. The `TeamMatchup` value type remains as a convenience for serialization, and the `GetMatchups`/`SetMatchups` helpers provide a clean interface for callers.

--- a/model/weekly_matchup.go
+++ b/model/weekly_matchup.go
@@ -17,12 +17,18 @@ func (id WeeklyMatchupId) String() string {
 	return id.RecordId().String()
 }
 
+// TeamMatchup is a lightweight value type representing a single matchup entry
+// (home vs away, or a bye). It is no longer stored inline within WeeklyMatchup;
+// instead each entry is normalized into a WeeklyMatchupTeamMatchup record.
+// This type remains for API serialization and convenience constructors.
 type TeamMatchup struct {
 	HomeTeam TeamId
 	AwayTeam TeamId
 	Bye      bool
 }
 
+// Validate checks that the matchup entry is well-formed: bye entries have no away team,
+// and all referenced teams exist and are assigned to the given season.
 func (t *TeamMatchup) Validate(ctx context.Context, db database.Provider, season *Season) error {
 	if t.Bye && t.AwayTeam != TeamId(database.InvalidRecordId) {
 		return fmt.Errorf("away team ID must not be set during a bye")
@@ -50,13 +56,22 @@ func (t *TeamMatchup) Validate(ctx context.Context, db database.Provider, season
 	return nil
 }
 
-// WeeklyMatchup is an instance of one or more TeamMatchup s for a given Week
-// during a Season's Schedule. It
+// teamMatchupFromRecord converts a WeeklyMatchupTeamMatchup row into a TeamMatchup value.
+func teamMatchupFromRecord(wmtm *WeeklyMatchupTeamMatchup) *TeamMatchup {
+	return &TeamMatchup{
+		HomeTeam: wmtm.HomeTeamId,
+		AwayTeam: wmtm.AwayTeamId,
+		Bye:      wmtm.Bye,
+	}
+}
+
+// WeeklyMatchup is an instance of one or more TeamMatchup entries for a given Week
+// during a Season's Schedule. The individual matchups are stored as separate
+// WeeklyMatchupTeamMatchup records rather than inline.
 type WeeklyMatchup struct {
 	ID       WeeklyMatchupId
-	WeekId   WeekId         // Week that this WeeklyMatchup corresponds to, i.e. a particular date
-	SeasonId SeasonId       // Season that this WeeklyMatchup corresponds to
-	Matchups []*TeamMatchup // List of TeamMatchup s for this WeeklyMatchup, e.g. team 1 playing team 2, team 3 on bye, etc.
+	WeekId   WeekId   // Week that this WeeklyMatchup corresponds to, i.e. a particular date
+	SeasonId SeasonId // Season that this WeeklyMatchup corresponds to
 }
 
 func (w *WeeklyMatchup) GetOwner() database.UserId {
@@ -100,25 +115,10 @@ func (w *WeeklyMatchup) SetOwner(userId database.UserId) {
 	// enforced by the associated Season assigned to it
 }
 
+// StaticallyValid always returns nil — double-booking checks now require database access
+// since matchups are stored in a separate WeeklyMatchupTeamMatchup table.
+// Those checks are performed in DynamicallyValid via validateNoDoubleBooking.
 func (w *WeeklyMatchup) StaticallyValid() error {
-	// loop through all matchups but the last to validate that
-	// team X or Y is not double-booked into 2 matchups in the
-	// same week of play.
-	for i, match := range w.Matchups[:len(w.Matchups)-1] {
-
-		// loop through all matchups after this one in the list
-		for j, match2 := range w.Matchups[i+1:] {
-			if match.HomeTeam == match2.HomeTeam || match.HomeTeam == match2.AwayTeam {
-				return fmt.Errorf("home team %s from matchup %d is also playing in matchup %d", match.HomeTeam, i, j+i+1)
-			}
-			if !match.Bye {
-				if match.AwayTeam == match2.AwayTeam || match.AwayTeam == match2.HomeTeam {
-					return fmt.Errorf("away team %s from matchup %d is also playing in matchup %d", match.AwayTeam, i, j+i+1)
-				}
-			}
-		}
-	}
-
 	return nil
 }
 
@@ -139,20 +139,60 @@ func (w *WeeklyMatchup) DynamicallyValid(ctx context.Context, db database.Provid
 		return fmt.Errorf("draft %s assigned to season %s does not match draft %s assigned to week", week.Date, w.SeasonId, week.DraftId)
 	}
 
-	// validate that each individual matchup is
-	for _, matchup := range w.Matchups {
+	matchups, err := w.GetMatchups(ctx, db)
+	if err != nil {
+		return err
+	}
+
+	// skip matchup-level checks when no matchups have been created yet
+	// (matchups are separate records with a FK, so they are created after the WeeklyMatchup)
+	if len(matchups) == 0 {
+		return nil
+	}
+
+	// validate that each individual matchup is valid
+	for _, matchup := range matchups {
 		err = matchup.Validate(ctx, db, season)
 		if err != nil {
 			return err
 		}
 	}
 
+	// check for double-booked teams
+	if err := w.validateNoDoubleBooking(matchups); err != nil {
+		return err
+	}
+
 	return w.ValidateThatEachTeamHasOneMatchup(ctx, db, season)
 }
 
+// validateNoDoubleBooking ensures no team appears in more than one matchup within this weekly matchup.
+func (w *WeeklyMatchup) validateNoDoubleBooking(matchups []*TeamMatchup) error {
+	if len(matchups) < 2 {
+		return nil
+	}
+	for i, match := range matchups[:len(matchups)-1] {
+		for j, match2 := range matchups[i+1:] {
+			if match.HomeTeam == match2.HomeTeam || match.HomeTeam == match2.AwayTeam {
+				return fmt.Errorf("home team %s from matchup %d is also playing in matchup %d", match.HomeTeam, i, j+i+1)
+			}
+			if !match.Bye {
+				if match.AwayTeam == match2.AwayTeam || match.AwayTeam == match2.HomeTeam {
+					return fmt.Errorf("away team %s from matchup %d is also playing in matchup %d", match.AwayTeam, i, j+i+1)
+				}
+			}
+		}
+	}
+	return nil
+}
+
 func (w *WeeklyMatchup) ValidateThatEachTeamHasOneMatchup(ctx context.Context, db database.Provider, season *Season) error {
+	matchups, err := w.GetMatchups(ctx, db)
+	if err != nil {
+		return err
+	}
 	m := make(map[TeamId]bool)
-	for _, matchup := range w.Matchups {
+	for _, matchup := range matchups {
 		m[matchup.HomeTeam] = true
 		if !matchup.Bye {
 			m[matchup.AwayTeam] = true
@@ -177,4 +217,104 @@ func (w *WeeklyMatchup) ValidateThatEachTeamHasOneMatchup(ctx context.Context, d
 
 func (w *WeeklyMatchup) NewRecord() database.CrudRecord {
 	return new(WeeklyMatchup)
+}
+
+// GetMatchups retrieves all TeamMatchup entries for this WeeklyMatchup by querying
+// the WeeklyMatchupTeamMatchup relationship table, sorted by Position.
+func (w *WeeklyMatchup) GetMatchups(ctx context.Context, db database.Provider) ([]*TeamMatchup, error) {
+	records, err := database.GetAllWhere[*WeeklyMatchupTeamMatchup](ctx, db, func(_ context.Context, wmtm *WeeklyMatchupTeamMatchup) bool {
+		return wmtm.WeeklyMatchupId == w.ID
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Sort by Position to preserve ordering
+	for i := 0; i < len(records); i++ {
+		for j := i + 1; j < len(records); j++ {
+			if records[j].Position < records[i].Position {
+				records[i], records[j] = records[j], records[i]
+			}
+		}
+	}
+
+	matchups := make([]*TeamMatchup, 0, len(records))
+	for _, wmtm := range records {
+		matchups = append(matchups, teamMatchupFromRecord(wmtm))
+	}
+	return matchups, nil
+}
+
+// SetMatchups replaces all matchup entries for this WeeklyMatchup.
+// It deletes existing WeeklyMatchupTeamMatchup records and creates new ones.
+func (w *WeeklyMatchup) SetMatchups(ctx context.Context, db database.Provider, matchups []*TeamMatchup) error {
+	// Delete existing matchup records
+	existing, err := database.GetAllWhere[*WeeklyMatchupTeamMatchup](ctx, db, func(_ context.Context, wmtm *WeeklyMatchupTeamMatchup) bool {
+		return wmtm.WeeklyMatchupId == w.ID
+	})
+	if err != nil {
+		return err
+	}
+	for _, wmtm := range existing {
+		_, _, err = database.DeleteOneById(ctx, db, &WeeklyMatchupTeamMatchup{}, wmtm.ID.RecordId())
+		if err != nil {
+			return err
+		}
+	}
+
+	// Create new matchup records
+	for i, matchup := range matchups {
+		wmtm := NewWeeklyMatchupTeamMatchup(w.ID, matchup.HomeTeam, matchup.AwayTeam, matchup.Bye, i)
+		_, err = database.CreateOne(ctx, db, wmtm)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// setMatchupsRaw creates matchup records directly without validation.
+// Used for test scenarios with intentionally invalid data.
+func (w *WeeklyMatchup) setMatchupsRaw(ctx context.Context, db database.Provider, matchups []*TeamMatchup) error {
+	// Delete existing matchup records
+	existing, err := database.GetAllWhere[*WeeklyMatchupTeamMatchup](ctx, db, func(_ context.Context, wmtm *WeeklyMatchupTeamMatchup) bool {
+		return wmtm.WeeklyMatchupId == w.ID
+	})
+	if err != nil {
+		return err
+	}
+	for _, wmtm := range existing {
+		_, _, err = database.DeleteOneById(ctx, db, &WeeklyMatchupTeamMatchup{}, wmtm.ID.RecordId())
+		if err != nil {
+			return err
+		}
+	}
+
+	// Create new matchup records directly, bypassing validation
+	for i, matchup := range matchups {
+		wmtm := NewWeeklyMatchupTeamMatchup(w.ID, matchup.HomeTeam, matchup.AwayTeam, matchup.Bye, i)
+		wmtm.SetId(database.NewRecordId())
+		_, err = db.Create(ctx, wmtm)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// PreDelete cascades deletion to all associated WeeklyMatchupTeamMatchup records.
+func (w *WeeklyMatchup) PreDelete(ctx context.Context, db database.Provider) error {
+	existing, err := database.GetAllWhere[*WeeklyMatchupTeamMatchup](ctx, db, func(_ context.Context, wmtm *WeeklyMatchupTeamMatchup) bool {
+		return wmtm.WeeklyMatchupId == w.ID
+	})
+	if err != nil {
+		return err
+	}
+	for _, wmtm := range existing {
+		_, _, err = database.DeleteOneById(ctx, db, &WeeklyMatchupTeamMatchup{}, wmtm.ID.RecordId())
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/model/weekly_matchup_team_matchup.go
+++ b/model/weekly_matchup_team_matchup.go
@@ -1,0 +1,123 @@
+package model
+
+import (
+	"context"
+	"fmt"
+
+	"intraclub/database"
+)
+
+// WeeklyMatchupTeamMatchupId is the unique identifier for a WeeklyMatchupTeamMatchup record.
+type WeeklyMatchupTeamMatchupId database.RecordId
+
+func (id WeeklyMatchupTeamMatchupId) RecordId() database.RecordId {
+	return database.RecordId(id)
+}
+
+func (id WeeklyMatchupTeamMatchupId) String() string {
+	return id.RecordId().String()
+}
+
+// WeeklyMatchupTeamMatchup is a join table record that links a WeeklyMatchup to its
+// individual TeamMatchup entries. Each record represents one team's participation
+// (as home, away, or bye) in a given weekly matchup.
+// This normalizes the previously inline []*TeamMatchup slice into its own collection,
+// enabling individual querying and indexing.
+type WeeklyMatchupTeamMatchup struct {
+	ID              WeeklyMatchupTeamMatchupId `json:"id"`
+	WeeklyMatchupId WeeklyMatchupId            `json:"weekly_matchup_id"`
+	HomeTeamId      TeamId                     `json:"home_team_id"`
+	AwayTeamId      TeamId                     `json:"away_team_id"`
+	Bye             bool                       `json:"bye"`
+	Position        int                        `json:"position"`
+}
+
+// GetOwner returns InvalidUserId as WeeklyMatchupTeamMatchup has no specific owner.
+func (w *WeeklyMatchupTeamMatchup) GetOwner() database.UserId {
+	return database.InvalidUserId
+}
+
+// SetOwner is a no-op as WeeklyMatchupTeamMatchup has no specific owner.
+func (w *WeeklyMatchupTeamMatchup) SetOwner(userId database.UserId) {}
+
+// AccessibleTo returns everyone as WeeklyMatchupTeamMatchup records are public.
+func (w *WeeklyMatchupTeamMatchup) AccessibleTo(ctx context.Context, db database.Provider) []database.UserId {
+	return database.AccessibleToEveryone
+}
+
+// EditableBy returns sysadmin-only access for join records.
+func (w *WeeklyMatchupTeamMatchup) EditableBy(ctx context.Context, db database.Provider) []database.UserId {
+	return []database.UserId{database.SysAdminUserId}
+}
+
+// Type returns the record type identifier for WeeklyMatchupTeamMatchup.
+func (w *WeeklyMatchupTeamMatchup) Type() string {
+	return "weekly_matchup_team_matchup"
+}
+
+// GetId returns the unique identifier for this record.
+func (w *WeeklyMatchupTeamMatchup) GetId() database.RecordId {
+	return w.ID.RecordId()
+}
+
+// SetId sets the unique identifier for this record.
+func (w *WeeklyMatchupTeamMatchup) SetId(id database.RecordId) {
+	w.ID = WeeklyMatchupTeamMatchupId(id)
+}
+
+// StaticallyValid always returns nil as there are no static validation rules.
+func (w *WeeklyMatchupTeamMatchup) StaticallyValid() error {
+	return nil
+}
+
+// DynamicallyValid verifies that the referenced WeeklyMatchup and Team records exist.
+func (w *WeeklyMatchupTeamMatchup) DynamicallyValid(ctx context.Context, db database.Provider) error {
+	if err := database.ExistsById(ctx, db, &WeeklyMatchup{}, w.WeeklyMatchupId.RecordId()); err != nil {
+		return fmt.Errorf("weekly matchup error: %w", err)
+	}
+	if err := database.ExistsById(ctx, db, &Team{}, w.HomeTeamId.RecordId()); err != nil {
+		return fmt.Errorf("home team error: %w", err)
+	}
+	if !w.Bye {
+		if err := database.ExistsById(ctx, db, &Team{}, w.AwayTeamId.RecordId()); err != nil {
+			return fmt.Errorf("away team error: %w", err)
+		}
+	}
+	return nil
+}
+
+// UniquenessEquivalent enforces that each team appears at most once per weekly matchup.
+// A team may not be a home team in one record and a home, away, or bye team in another
+// record of the same weekly matchup.
+func (w *WeeklyMatchupTeamMatchup) UniquenessEquivalent(other *WeeklyMatchupTeamMatchup) error {
+	if w.WeeklyMatchupId != other.WeeklyMatchupId {
+		return nil
+	}
+
+	// Compare this record's teams against both teams of the other record.
+	if w.HomeTeamId == other.HomeTeamId || w.HomeTeamId == other.AwayTeamId {
+		return fmt.Errorf("home team %s already has a matchup in weekly matchup %s", w.HomeTeamId, w.WeeklyMatchupId)
+	}
+	if !w.Bye {
+		if w.AwayTeamId == other.HomeTeamId || w.AwayTeamId == other.AwayTeamId {
+			return fmt.Errorf("away team %s already has a matchup in weekly matchup %s", w.AwayTeamId, w.WeeklyMatchupId)
+		}
+	}
+	return nil
+}
+
+// NewRecord returns a new empty WeeklyMatchupTeamMatchup.
+func (w *WeeklyMatchupTeamMatchup) NewRecord() database.CrudRecord {
+	return new(WeeklyMatchupTeamMatchup)
+}
+
+// NewWeeklyMatchupTeamMatchup creates a new WeeklyMatchupTeamMatchup record.
+func NewWeeklyMatchupTeamMatchup(weeklyMatchupId WeeklyMatchupId, homeTeamId TeamId, awayTeamId TeamId, bye bool, position int) *WeeklyMatchupTeamMatchup {
+	return &WeeklyMatchupTeamMatchup{
+		WeeklyMatchupId: weeklyMatchupId,
+		HomeTeamId:      homeTeamId,
+		AwayTeamId:      awayTeamId,
+		Bye:             bye,
+		Position:        position,
+	}
+}

--- a/model/weekly_matchup_test.go
+++ b/model/weekly_matchup_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func newStoredWeeklyMatchup(t *testing.T, db database.Provider) (*Season, *WeeklyMatchup) {
+	t.Helper()
 	season, _ := newDefaultSeasonWithTeams(t, db, 4)
 	week := newStoredWeek(t, db, season)
 
@@ -21,6 +22,12 @@ func newStoredWeeklyMatchup(t *testing.T, db database.Provider) (*Season, *Weekl
 	w.WeekId = week.ID
 	w.SeasonId = season.ID
 
+	v, err := database.CreateOne(context.Background(), db, w)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create matchup records via SetMatchups
 	matchup := TeamMatchup{
 		HomeTeam: teams[0].ID,
 		AwayTeam: teams[1].ID,
@@ -30,30 +37,32 @@ func newStoredWeeklyMatchup(t *testing.T, db database.Provider) (*Season, *Weekl
 		AwayTeam: teams[3].ID,
 	}
 
-	w.Matchups = []*TeamMatchup{&matchup, &matchup2}
-
-	v, err := database.CreateOne(context.Background(), db, w)
+	err = v.SetMatchups(context.Background(), db, []*TeamMatchup{&matchup, &matchup2})
 	if err != nil {
 		t.Fatal(err)
 	}
 	return season, v
 }
 
-func copyWeeklyMatchup(w *WeeklyMatchup) *WeeklyMatchup {
-	return &WeeklyMatchup{
-		WeekId:   w.WeekId,
-		SeasonId: w.SeasonId,
-		Matchups: w.Matchups,
-	}
-}
 
 func TestWeeklyMatchupInvalidHomeTeamId(t *testing.T) {
 	db := database.NewUnitTestDBProvider()
 	_, w := newStoredWeeklyMatchup(t, db)
-	w.Matchups[0].HomeTeam = TeamId(database.InvalidRecordId)
-	err := w.DynamicallyValid(context.Background(), db)
+
+	// Update the matchup to have an invalid home team (bypass validation to set bad data)
+	matchups, err := w.GetMatchups(context.Background(), db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	matchups[0].HomeTeam = TeamId(database.InvalidRecordId)
+	err = w.setMatchupsRaw(context.Background(), db, matchups)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = w.DynamicallyValid(context.Background(), db)
 	if err == nil {
-		t.Fatal("InvalidScoreCountingType home team ID should produce error")
+		t.Fatal("Invalid home team ID should produce error")
 	}
 	fmt.Println(err)
 }
@@ -61,10 +70,20 @@ func TestWeeklyMatchupInvalidHomeTeamId(t *testing.T) {
 func TestWeeklyMatchupInvalidAwayTeamId(t *testing.T) {
 	db := database.NewUnitTestDBProvider()
 	_, w := newStoredWeeklyMatchup(t, db)
-	w.Matchups[0].AwayTeam = TeamId(database.InvalidRecordId)
-	err := w.DynamicallyValid(context.Background(), db)
+
+	matchups, err := w.GetMatchups(context.Background(), db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	matchups[0].AwayTeam = TeamId(database.InvalidRecordId)
+	err = w.setMatchupsRaw(context.Background(), db, matchups)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = w.DynamicallyValid(context.Background(), db)
 	if err == nil {
-		t.Fatal("InvalidScoreCountingType away team ID should produce error")
+		t.Fatal("Invalid away team ID should produce error")
 	}
 	fmt.Println(err)
 }
@@ -75,7 +94,7 @@ func TestWeeklyMatchupInvalidSeasonId(t *testing.T) {
 	w.SeasonId = SeasonId(database.InvalidRecordId)
 	err := w.DynamicallyValid(context.Background(), db)
 	if err == nil {
-		t.Fatal("InvalidScoreCountingType season ID should produce error")
+		t.Fatal("Invalid season ID should produce error")
 	}
 	fmt.Println(err)
 }
@@ -86,7 +105,7 @@ func TestWeeklyMatchupInvalidWeekId(t *testing.T) {
 	w.WeekId = WeekId(database.InvalidRecordId)
 	err := w.DynamicallyValid(context.Background(), db)
 	if err == nil {
-		t.Fatal("InvalidScoreCountingType week ID should produce error")
+		t.Fatal("Invalid week ID should produce error")
 	}
 	fmt.Println(err)
 }
@@ -101,7 +120,7 @@ func TestWeeklyMatchupWeekDoesNotBelongToSeason(t *testing.T) {
 	w.WeekId = someOtherWeek.ID
 	err := w.DynamicallyValid(context.Background(), db)
 	if err == nil {
-		t.Fatal("InvalidScoreCountingType week ID should produce error")
+		t.Fatal("Week from another season should produce error")
 	}
 	fmt.Println(err)
 }
@@ -111,9 +130,17 @@ func TestWeeklyMatchupHomeTeamDoesNotBelongToSeason(t *testing.T) {
 	_, w := newStoredWeeklyMatchup(t, db)
 
 	otherTeam := newStoredTeam(t, db, newStoredUser(t, db).ID)
-	w.Matchups[0].HomeTeam = otherTeam.ID
+	matchups, err := w.GetMatchups(context.Background(), db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	matchups[0].HomeTeam = otherTeam.ID
+	err = w.SetMatchups(context.Background(), db, matchups)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	err := w.DynamicallyValid(context.Background(), db)
+	err = w.DynamicallyValid(context.Background(), db)
 	if err == nil {
 		t.Fatal("Team from another season should produce error")
 	}
@@ -125,9 +152,17 @@ func TestWeeklyMatchupAwayTeamDoesNotBelongToSeason(t *testing.T) {
 	_, w := newStoredWeeklyMatchup(t, db)
 
 	otherTeam := newStoredTeam(t, db, newStoredUser(t, db).ID)
-	w.Matchups[0].AwayTeam = otherTeam.ID
+	matchups, err := w.GetMatchups(context.Background(), db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	matchups[0].AwayTeam = otherTeam.ID
+	err = w.SetMatchups(context.Background(), db, matchups)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	err := w.DynamicallyValid(context.Background(), db)
+	err = w.DynamicallyValid(context.Background(), db)
 	if err == nil {
 		t.Fatal("Team from another season should produce error")
 	}
@@ -143,13 +178,24 @@ func TestWeeklyMatchupTeamPlayingInMultipleMatchups(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	matchups, err := w.GetMatchups(context.Background(), db)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	anotherMatchup := TeamMatchup{
 		HomeTeam: teams[0].ID,
 		AwayTeam: teams[2].ID,
 	}
-	w.Matchups = append(w.Matchups, &anotherMatchup)
+	matchups = append(matchups, &anotherMatchup)
+	// Bypass validation so the double-booked team is persisted and caught by
+	// the double-booking check in DynamicallyValid rather than the uniqueness constraint.
+	err = w.setMatchupsRaw(context.Background(), db, matchups)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	err = w.StaticallyValid()
+	err = w.DynamicallyValid(context.Background(), db)
 	if err == nil {
 		t.Fatal("Double matchup for team 1 should produce error")
 	}
@@ -160,15 +206,22 @@ func TestWeeklyMatchupTeamDoesNotHaveAnyMatchups(t *testing.T) {
 	db := database.NewUnitTestDBProvider()
 	_, w := newStoredWeeklyMatchup(t, db)
 
-	w.Matchups[1].Bye = true
-	w.Matchups[1].AwayTeam = TeamId(database.InvalidRecordId)
+	matchups, err := w.GetMatchups(context.Background(), db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	matchups[1].Bye = true
+	matchups[1].AwayTeam = TeamId(database.InvalidRecordId)
+	err = w.SetMatchups(context.Background(), db, matchups)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	err := database.Validate(context.Background(), db, w)
+	err = database.Validate(context.Background(), db, w)
 	if err == nil {
 		t.Fatal("Team 4 without matchup or bye should produce error")
 	}
 	fmt.Println(err)
-
 }
 
 func TestWeeklyMatchupTeamHasBye(t *testing.T) {
@@ -185,6 +238,11 @@ func TestWeeklyMatchupTeamHasBye(t *testing.T) {
 	w.WeekId = week.ID
 	w.SeasonId = season.ID
 
+	v, err := database.CreateOne(context.Background(), db, w)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	matchup := TeamMatchup{
 		HomeTeam: teams[0].ID,
 		AwayTeam: teams[1].ID,
@@ -198,9 +256,12 @@ func TestWeeklyMatchupTeamHasBye(t *testing.T) {
 		Bye:      true,
 	}
 
-	w.Matchups = []*TeamMatchup{&matchup, &bye1, &bye2}
+	err = v.SetMatchups(context.Background(), db, []*TeamMatchup{&matchup, &bye1, &bye2})
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	err = database.Validate(context.Background(), db, w)
+	err = database.Validate(context.Background(), db, v)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -210,8 +271,17 @@ func TestWeeklyMatchupHomeTeamByeButAwayTeamIsSet(t *testing.T) {
 	db := database.NewUnitTestDBProvider()
 	_, w := newStoredWeeklyMatchup(t, db)
 
-	w.Matchups[0].Bye = true
-	err := database.Validate(context.Background(), db, w)
+	matchups, err := w.GetMatchups(context.Background(), db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	matchups[0].Bye = true
+	err = w.SetMatchups(context.Background(), db, matchups)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = database.Validate(context.Background(), db, w)
 	if err == nil {
 		t.Fatal("Bye with away team set should produce error")
 	}
@@ -222,10 +292,131 @@ func TestDuplicateWeeklyMatchup(t *testing.T) {
 	db := database.NewUnitTestDBProvider()
 	_, w := newStoredWeeklyMatchup(t, db)
 
-	w2 := copyWeeklyMatchup(w)
+	w2 := NewWeeklyMatchup()
+	w2.WeekId = w.WeekId
+	w2.SeasonId = w.SeasonId
 	_, err := database.CreateOne(context.Background(), db, w2)
 	if err == nil {
 		t.Fatal("Expected error on duplicate weekly matchup")
 	}
 	fmt.Println(err)
+}
+
+// TestWeeklyMatchupRoundTrip verifies that matchups can be set and retrieved correctly.
+func TestWeeklyMatchupRoundTrip(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	season, _ := newDefaultSeasonWithTeams(t, db, 4)
+	week := newStoredWeek(t, db, season)
+
+	teams, err := season.GetTeams(context.Background(), db)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w := NewWeeklyMatchup()
+	w.WeekId = week.ID
+	w.SeasonId = season.ID
+
+	v, err := database.CreateOne(context.Background(), db, w)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	matchup := TeamMatchup{
+		HomeTeam: teams[0].ID,
+		AwayTeam: teams[1].ID,
+	}
+	matchup2 := TeamMatchup{
+		HomeTeam: teams[2].ID,
+		AwayTeam: teams[3].ID,
+	}
+
+	err = v.SetMatchups(context.Background(), db, []*TeamMatchup{&matchup, &matchup2})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Retrieve and verify
+	retrieved, err := v.GetMatchups(context.Background(), db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(retrieved) != 2 {
+		t.Fatalf("Expected 2 matchups, got %d", len(retrieved))
+	}
+	if retrieved[0].HomeTeam != teams[0].ID {
+		t.Fatalf("Expected home team %s, got %s", teams[0].ID, retrieved[0].HomeTeam)
+	}
+	if retrieved[0].AwayTeam != teams[1].ID {
+		t.Fatalf("Expected away team %s, got %s", teams[1].ID, retrieved[0].AwayTeam)
+	}
+	if retrieved[1].HomeTeam != teams[2].ID {
+		t.Fatalf("Expected home team %s, got %s", teams[2].ID, retrieved[1].HomeTeam)
+	}
+	if retrieved[1].AwayTeam != teams[3].ID {
+		t.Fatalf("Expected away team %s, got %s", teams[3].ID, retrieved[1].AwayTeam)
+	}
+}
+
+// TestWeeklyMatchupCascadeDelete verifies that deleting a WeeklyMatchup
+// also deletes all associated WeeklyMatchupTeamMatchup records.
+func TestWeeklyMatchupCascadeDelete(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	_, w := newStoredWeeklyMatchup(t, db)
+
+	// Verify matchups exist
+	matchups, err := w.GetMatchups(context.Background(), db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matchups) != 2 {
+		t.Fatalf("Expected 2 matchups, got %d", len(matchups))
+	}
+
+	// Delete the weekly matchup
+	_, _, err = database.DeleteOneById(context.Background(), db, &WeeklyMatchup{}, w.ID.RecordId())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify matchup records are gone
+	allRecords, err := database.GetAllWhere[*WeeklyMatchupTeamMatchup](context.Background(), db, func(_ context.Context, wmtm *WeeklyMatchupTeamMatchup) bool {
+		return wmtm.WeeklyMatchupId == w.ID
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(allRecords) != 0 {
+		t.Fatalf("Expected 0 matchup records after cascade delete, got %d", len(allRecords))
+	}
+}
+
+// TestWeeklyMatchupTeamMatchupRecord validates the normalized record type.
+func TestWeeklyMatchupTeamMatchupRecord(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	_, w := newStoredWeeklyMatchup(t, db)
+
+	// Query the underlying records directly
+	records, err := database.GetAllWhere[*WeeklyMatchupTeamMatchup](context.Background(), db, func(_ context.Context, wmtm *WeeklyMatchupTeamMatchup) bool {
+		return wmtm.WeeklyMatchupId == w.ID
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 2 {
+		t.Fatalf("Expected 2 WeeklyMatchupTeamMatchup records, got %d", len(records))
+	}
+
+	// Verify Position field preserves ordering
+	if records[0].Position != 0 {
+		t.Fatalf("Expected position 0, got %d", records[0].Position)
+	}
+	if records[1].Position != 1 {
+		t.Fatalf("Expected position 1, got %d", records[1].Position)
+	}
+
+	// Verify FK
+	if records[0].WeeklyMatchupId != w.ID {
+		t.Fatalf("Expected weekly_matchup_id %s, got %s", w.ID, records[0].WeeklyMatchupId)
+	}
 }


### PR DESCRIPTION
## Summary

Part of the umbrella normalization work in #37. This sub-ticket normalizes the inline `WeeklyMatchup.Matchups` list of value structs into a dedicated `WeeklyMatchupTeamMatchup` relationship record.

Closes #39

## Changes

- **New model** `model/weekly_matchup_team_matchup.go`: `WeeklyMatchupTeamMatchup{ ID, WeeklyMatchupId, HomeTeamId, AwayTeamId, Bye, Position }` implementing the full `SeasonTeam`/`FormatRating`-style CRUD interface (`Type`, `NewRecord`, `GetId`/`SetId`, owner/access control, `StaticallyValid`/`DynamicallyValid`). `UniquenessEquivalent` enforces "each team appears at most once per weekly matchup" (home/away/bye, cross-checked). `Position` preserves ordering.
- **`model/weekly_matchup.go`**: removed the inline `Matchups []*TeamMatchup` field. `TeamMatchup` kept as a value type for wire-format compatibility. Added `GetMatchups`/`SetMatchups` helpers that query/persist via the relationship table. Moved double-booking (`validateNoDoubleBooking`) and one-matchup-per-team checks to run against the relationship rows in `DynamicallyValid`. Added `PreDelete` to cascade-delete child matchup records.
- **Tests**: `model/weekly_matchup_test.go` rewritten for the create-then-`SetMatchups` flow, plus round-trip, cascade-delete, and relationship-record tests.
- **Docs**: `docs/api-shape-weekly-matchup.md` documents the API shape decision — wire format unchanged (`matchups` key), reassembled on read via `GetMatchups`, expanded on write via `SetMatchups`.

## Acceptance criteria

- [x] `WeeklyMatchup` no longer stores an inline slice of value structs.
- [x] `WeeklyMatchupTeamMatchup` is a dedicated assign-x-to-y record/table with FK + unique constraint; `TeamMatchup` normalized out of the parent.
- [x] All read/write call sites updated (double-booking + one-matchup-per-team checks query the new table); tests green.
- [x] API shape decision documented.

## Notes

- No migration was added: this MongoDB-backed codebase has no migration framework yet (ticket #36's framework isn't present), so collections are created implicitly on first insert.
- `SetMatchups` does delete-then-create without rollback; flagged for a follow-up if atomic replacement is desired.