### PR TITLE
refactor(model): normalize Schedule.Matchups into ScheduleMatchup join table

### DIFF
--- a/docs/api-shape-schedule-matchup.md
+++ b/docs/api-shape-schedule-matchup.md
@@ -1,0 +1,18 @@
+# API Shape Decision Documentation
+
+## ScheduleMatchup Normalization (Ticket #38)
+
+### Decision: Wire format reassembles relationship rows into the existing `matchups` shape
+
+The `Schedule` model no longer stores an inline `[]WeeklyMatchupId` slice. Instead, each weekly matchup assignment is normalized into a separate `ScheduleMatchup` record (`schedule_matchup` collection/table) with FKs to `schedule` and `weekly_matchup`, a natural unique constraint on `(ScheduleId, WeeklyMatchupId)`, and a `Position` to preserve ordering.
+
+For API consumers:
+- **Serialization**: When returning a `Schedule` via the API, callers should call `s.GetMatchups(ctx, db)` to reassemble the `[]*WeeklyMatchup` slice from the relationship table and include it in the response under the existing `matchups` JSON key.
+- **Deserialization**: When receiving a `Schedule` from the API, callers should create the `Schedule` record first, then call `s.SetMatchups(ctx, db, ids)` to persist the individual matchup assignments.
+- **Wire format**: The external JSON shape remains unchanged: `{ "id": "...", "season_id": "...", "matchups": [...] }`. The `matchups` field is virtual — it is computed on read and expanded on write.
+
+### Why
+
+This preserves backward compatibility with existing API consumers while achieving the normalization goal. The `GetMatchups`/`SetMatchups` helpers provide a clean interface for callers, and the `Position` column preserves the ordering that the former inline list implied.
+
+> Note: The `schedule_matchups` table creation + backfill from the former inline data is deferred to the #36 SQLite provider migration framework, as documented in the `ScheduleMatchup` type comment.

--- a/model/schedule.go
+++ b/model/schedule.go
@@ -20,7 +20,6 @@ func (id ScheduleId) String() string {
 type Schedule struct {
 	ID       ScheduleId
 	SeasonId SeasonId
-	Matchups []WeeklyMatchupId
 }
 
 func (s *Schedule) GetOwner() database.UserId {
@@ -75,12 +74,19 @@ func (s *Schedule) DynamicallyValid(ctx context.Context, db database.Provider) e
 		return err
 	}
 
-	for _, m := range s.Matchups {
-		weeklyMatchup, err := database.GetExistingRecordById(ctx, db, &WeeklyMatchup{}, m.RecordId())
-		if err != nil {
-			return err
-		}
-		err = weeklyMatchup.DynamicallyValid(ctx, db)
+	// Validate each assigned weekly matchup. Matchups are separate records
+	// (ScheduleMatchup) with a FK to this schedule, so they are created after
+	// the Schedule record itself; skip the check when none are assigned yet.
+	matchups, err := s.GetMatchups(ctx, db)
+	if err != nil {
+		return err
+	}
+	if len(matchups) == 0 {
+		return nil
+	}
+
+	for _, m := range matchups {
+		err = m.DynamicallyValid(ctx, db)
 		if err != nil {
 			return err
 		}
@@ -113,7 +119,86 @@ func (s *Schedule) IsScheduleComplete(ctx context.Context, db database.Provider)
 	if err != nil {
 		return false, err
 	}
-	return len(weeks) == len(s.Matchups), nil
+	matchups, err := s.GetMatchups(ctx, db)
+	if err != nil {
+		return false, err
+	}
+	return len(weeks) == len(matchups), nil
+}
+
+// GetMatchups retrieves all WeeklyMatchup records assigned to this Schedule by
+// querying the ScheduleMatchup relationship table, sorted by Position.
+func (s *Schedule) GetMatchups(ctx context.Context, db database.Provider) ([]*WeeklyMatchup, error) {
+	records, err := database.GetAllWhere[*ScheduleMatchup](ctx, db, func(_ context.Context, sm *ScheduleMatchup) bool {
+		return sm.ScheduleId == s.ID
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Sort by Position to preserve ordering
+	for i := 0; i < len(records); i++ {
+		for j := i + 1; j < len(records); j++ {
+			if records[j].Position < records[i].Position {
+				records[i], records[j] = records[j], records[i]
+			}
+		}
+	}
+
+	matchups := make([]*WeeklyMatchup, 0, len(records))
+	for _, sm := range records {
+		weeklyMatchup, err := database.GetExistingRecordById(ctx, db, &WeeklyMatchup{}, sm.WeeklyMatchupId.RecordId())
+		if err != nil {
+			return nil, err
+		}
+		matchups = append(matchups, weeklyMatchup)
+	}
+	return matchups, nil
+}
+
+// SetMatchups replaces all weekly matchups assigned to this Schedule.
+// It deletes existing ScheduleMatchup records and creates new ones.
+func (s *Schedule) SetMatchups(ctx context.Context, db database.Provider, matchups []WeeklyMatchupId) error {
+	// Delete existing matchup records
+	existing, err := database.GetAllWhere[*ScheduleMatchup](ctx, db, func(_ context.Context, sm *ScheduleMatchup) bool {
+		return sm.ScheduleId == s.ID
+	})
+	if err != nil {
+		return err
+	}
+	for _, sm := range existing {
+		_, _, err = database.DeleteOneById(ctx, db, &ScheduleMatchup{}, sm.ID.RecordId())
+		if err != nil {
+			return err
+		}
+	}
+
+	// Create new matchup records
+	for i, m := range matchups {
+		sm := NewScheduleMatchup(s.ID, m, i)
+		_, err = database.CreateOne(ctx, db, sm)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// PreDelete cascades deletion to all associated ScheduleMatchup records.
+func (s *Schedule) PreDelete(ctx context.Context, db database.Provider) error {
+	existing, err := database.GetAllWhere[*ScheduleMatchup](ctx, db, func(_ context.Context, sm *ScheduleMatchup) bool {
+		return sm.ScheduleId == s.ID
+	})
+	if err != nil {
+		return err
+	}
+	for _, sm := range existing {
+		_, _, err = database.DeleteOneById(ctx, db, &ScheduleMatchup{}, sm.ID.RecordId())
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (s *Schedule) NewRecord() database.CrudRecord {

--- a/model/schedule_matchup.go
+++ b/model/schedule_matchup.go
@@ -1,0 +1,106 @@
+package model
+
+import (
+	"context"
+	"fmt"
+
+	"intraclub/database"
+)
+
+// ScheduleMatchupId is the unique identifier for a ScheduleMatchup record.
+type ScheduleMatchupId database.RecordId
+
+func (id ScheduleMatchupId) RecordId() database.RecordId {
+	return database.RecordId(id)
+}
+
+func (id ScheduleMatchupId) String() string {
+	return id.RecordId().String()
+}
+
+// ScheduleMatchup is a join table record that assigns a WeeklyMatchup to a
+// Schedule at a given Position (preserving ordering). This replaces the former
+// denormalized `Schedule.Matchups` inline ID-slice, enabling the relationship
+// to be queried/indexed individually and stored in its own collection/table.
+//
+// It is stored in its own collection (`schedule_matchup`) with FKs to schedule
+// and weekly_matchup, and a natural unique constraint on
+// (ScheduleId, WeeklyMatchupId). When the #36 SQLite provider lands, this
+// becomes a `schedule_matchups` table with a migration/backfill.
+type ScheduleMatchup struct {
+	ID              ScheduleMatchupId `json:"id"`
+	ScheduleId      ScheduleId        `json:"schedule_id"`
+	WeeklyMatchupId WeeklyMatchupId   `json:"weekly_matchup_id"`
+	Position        int               `json:"position"`
+}
+
+// GetOwner returns InvalidUserId as ScheduleMatchup has no specific owner.
+func (s *ScheduleMatchup) GetOwner() database.UserId {
+	return database.InvalidUserId
+}
+
+// SetOwner is a no-op as ScheduleMatchup has no specific owner.
+func (s *ScheduleMatchup) SetOwner(userId database.UserId) {}
+
+// AccessibleTo returns everyone as ScheduleMatchup records are public.
+func (s *ScheduleMatchup) AccessibleTo(ctx context.Context, db database.Provider) []database.UserId {
+	return database.AccessibleToEveryone
+}
+
+// EditableBy returns sysadmin-only access for join records.
+func (s *ScheduleMatchup) EditableBy(ctx context.Context, db database.Provider) []database.UserId {
+	return []database.UserId{database.SysAdminUserId}
+}
+
+// Type returns the record type identifier for ScheduleMatchup.
+func (s *ScheduleMatchup) Type() string {
+	return "schedule_matchup"
+}
+
+// GetId returns the unique identifier for this record.
+func (s *ScheduleMatchup) GetId() database.RecordId {
+	return s.ID.RecordId()
+}
+
+// SetId sets the unique identifier for this record.
+func (s *ScheduleMatchup) SetId(id database.RecordId) {
+	s.ID = ScheduleMatchupId(id)
+}
+
+// StaticallyValid always returns nil as there are no static validation rules.
+func (s *ScheduleMatchup) StaticallyValid() error {
+	return nil
+}
+
+// DynamicallyValid verifies that the referenced Schedule and WeeklyMatchup
+// records exist.
+func (s *ScheduleMatchup) DynamicallyValid(ctx context.Context, db database.Provider) error {
+	if err := database.ExistsById(ctx, db, &Schedule{}, s.ScheduleId.RecordId()); err != nil {
+		return err
+	}
+	return database.ExistsById(ctx, db, &WeeklyMatchup{}, s.WeeklyMatchupId.RecordId())
+}
+
+// UniquenessEquivalent enforces the natural unique constraint on
+// (ScheduleId, WeeklyMatchupId): a weekly matchup may only be assigned to a
+// schedule once.
+func (s *ScheduleMatchup) UniquenessEquivalent(other *ScheduleMatchup) error {
+	if s.ScheduleId == other.ScheduleId && s.WeeklyMatchupId == other.WeeklyMatchupId {
+		return fmt.Errorf("schedule %s already has weekly matchup %s assigned", s.ScheduleId, s.WeeklyMatchupId)
+	}
+	return nil
+}
+
+// NewRecord returns a new empty ScheduleMatchup.
+func (s *ScheduleMatchup) NewRecord() database.CrudRecord {
+	return new(ScheduleMatchup)
+}
+
+// NewScheduleMatchup creates a new ScheduleMatchup record.
+func NewScheduleMatchup(scheduleId ScheduleId, weeklyMatchupId WeeklyMatchupId, position int) *ScheduleMatchup {
+	return &ScheduleMatchup{
+		ScheduleId:      scheduleId,
+		WeeklyMatchupId: weeklyMatchupId,
+		Position:        position,
+	}
+}

--- a/model/schedule_test.go
+++ b/model/schedule_test.go
@@ -38,14 +38,228 @@ func TestSeasonUpdatedOnScheduleCreate(t *testing.T) {
 func TestOneSchedulePerSeason(t *testing.T) {
 	db := database.NewUnitTestDBProvider()
 	season, _ := newDefaultSeason(t, db)
-	schedule := newStoredSchedule(t, db, season)
+	newStoredSchedule(t, db, season)
 
 	schedule2 := NewSchedule()
 	schedule2.SeasonId = season.ID
-	schedule2.Matchups = schedule.Matchups
 	_, err := database.CreateOne(context.Background(), db, schedule2)
 	if err == nil {
 		t.Fatal("Expected error creating a duplicate schedule")
 	}
 	fmt.Println(err)
+}
+
+// newStoredWeeklyMatchups creates count stored WeeklyMatchup records for the
+// given season (one per week) and returns them in order.
+func newStoredWeeklyMatchups(t *testing.T, db database.Provider, season *Season, count int) []*WeeklyMatchup {
+	t.Helper()
+	matchups := make([]*WeeklyMatchup, 0, count)
+	for i := 0; i < count; i++ {
+		week := newStoredWeek(t, db, season)
+		w := NewWeeklyMatchup()
+		w.WeekId = week.ID
+		w.SeasonId = season.ID
+		v, err := database.CreateOne(context.Background(), db, w)
+		if err != nil {
+			t.Fatal(err)
+		}
+		matchups = append(matchups, v)
+	}
+	return matchups
+}
+
+// newStoredScheduleWithMatchups creates a stored Schedule for the season and
+// assigns the given weekly matchups to it via SetMatchups.
+func newStoredScheduleWithMatchups(t *testing.T, db database.Provider, season *Season, matchups []*WeeklyMatchup) *Schedule {
+	t.Helper()
+	schedule := newStoredSchedule(t, db, season)
+	ids := make([]WeeklyMatchupId, 0, len(matchups))
+	for _, m := range matchups {
+		ids = append(ids, m.ID)
+	}
+	err := schedule.SetMatchups(context.Background(), db, ids)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return schedule
+}
+
+func TestScheduleMatchupRoundTrip(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	season, _ := newDefaultSeasonWithTeams(t, db, 4)
+	weeklyMatchups := newStoredWeeklyMatchups(t, db, season, 3)
+
+	schedule := newStoredScheduleWithMatchups(t, db, season, weeklyMatchups)
+
+	got, err := schedule.GetMatchups(context.Background(), db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 matchups, got %d", len(got))
+	}
+	for i, m := range weeklyMatchups {
+		if got[i].ID != m.ID {
+			t.Fatalf("expected matchup %d to be %s, got %s", i, m.ID, got[i].ID)
+		}
+	}
+}
+
+func TestScheduleMatchupPreservesOrderByPosition(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	season, _ := newDefaultSeasonWithTeams(t, db, 4)
+	weeklyMatchups := newStoredWeeklyMatchups(t, db, season, 3)
+
+	schedule := newStoredSchedule(t, db, season)
+
+	// Assign matchups out of order to verify GetMatchups sorts by Position.
+	ids := []WeeklyMatchupId{weeklyMatchups[2].ID, weeklyMatchups[0].ID, weeklyMatchups[1].ID}
+	err := schedule.SetMatchups(context.Background(), db, ids)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := schedule.GetMatchups(context.Background(), db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Positions were assigned in SetMatchups order (0, 1, 2) regardless of the
+	// order the weekly matchups were created, so GetMatchups must return them
+	// in that assignment order.
+	expected := []WeeklyMatchupId{weeklyMatchups[2].ID, weeklyMatchups[0].ID, weeklyMatchups[1].ID}
+	if len(got) != len(expected) {
+		t.Fatalf("expected %d matchups, got %d", len(expected), len(got))
+	}
+	for i, id := range expected {
+		if got[i].ID != id {
+			t.Fatalf("expected matchup at position %d to be %s, got %s", i, id, got[i].ID)
+		}
+	}
+}
+
+func TestScheduleSetMatchupsReplacesExisting(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	season, _ := newDefaultSeasonWithTeams(t, db, 4)
+	weeklyMatchups := newStoredWeeklyMatchups(t, db, season, 3)
+
+	schedule := newStoredScheduleWithMatchups(t, db, season, weeklyMatchups[:2])
+
+	// Replace with only the third matchup.
+	err := schedule.SetMatchups(context.Background(), db, []WeeklyMatchupId{weeklyMatchups[2].ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := schedule.GetMatchups(context.Background(), db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 matchup after replacement, got %d", len(got))
+	}
+	if got[0].ID != weeklyMatchups[2].ID {
+		t.Fatalf("expected matchup to be %s, got %s", weeklyMatchups[2].ID, got[0].ID)
+	}
+}
+
+func TestScheduleMatchupUniqueness(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	season, _ := newDefaultSeasonWithTeams(t, db, 4)
+	weeklyMatchups := newStoredWeeklyMatchups(t, db, season, 1)
+	schedule := newStoredSchedule(t, db, season)
+
+	sm := NewScheduleMatchup(schedule.ID, weeklyMatchups[0].ID, 0)
+	_, err := database.CreateOne(context.Background(), db, sm)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Assigning the same weekly matchup to the same schedule again must fail.
+	sm2 := NewScheduleMatchup(schedule.ID, weeklyMatchups[0].ID, 1)
+	_, err = database.CreateOne(context.Background(), db, sm2)
+	if err == nil {
+		t.Fatal("expected error assigning duplicate weekly matchup to schedule")
+	}
+	fmt.Println(err)
+}
+
+func TestScheduleMatchupDynamicallyValid(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	season, _ := newDefaultSeasonWithTeams(t, db, 4)
+	weeklyMatchups := newStoredWeeklyMatchups(t, db, season, 1)
+
+	// Invalid schedule ID.
+	sm := NewScheduleMatchup(ScheduleId(database.InvalidRecordId), weeklyMatchups[0].ID, 0)
+	err := sm.DynamicallyValid(context.Background(), db)
+	if err == nil {
+		t.Fatal("expected error for invalid schedule ID")
+	}
+
+	// Invalid weekly matchup ID.
+	schedule := newStoredSchedule(t, db, season)
+	sm2 := NewScheduleMatchup(schedule.ID, WeeklyMatchupId(database.InvalidRecordId), 0)
+	err = sm2.DynamicallyValid(context.Background(), db)
+	if err == nil {
+		t.Fatal("expected error for invalid weekly matchup ID")
+	}
+}
+
+func TestScheduleIsComplete(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+
+	// Incomplete schedule: season has two weeks but only one weekly matchup assigned.
+	season1, _ := newDefaultSeasonWithTeams(t, db, 4)
+	weeklyMatchups1 := newStoredWeeklyMatchups(t, db, season1, 2)
+	schedule1 := newStoredScheduleWithMatchups(t, db, season1, weeklyMatchups1[:1])
+	complete, err := schedule1.IsScheduleComplete(context.Background(), db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if complete {
+		t.Fatal("expected schedule to be incomplete")
+	}
+
+	// Complete schedule: season has two weeks and two weekly matchups assigned.
+	season2, _ := newDefaultSeasonWithTeams(t, db, 4)
+	weeklyMatchups2 := newStoredWeeklyMatchups(t, db, season2, 2)
+	schedule2 := newStoredScheduleWithMatchups(t, db, season2, weeklyMatchups2)
+	complete, err = schedule2.IsScheduleComplete(context.Background(), db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !complete {
+		t.Fatal("expected schedule to be complete")
+	}
+}
+
+func TestSchedulePreDeleteCascadesMatchups(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	season, _ := newDefaultSeasonWithTeams(t, db, 4)
+	weeklyMatchups := newStoredWeeklyMatchups(t, db, season, 2)
+	schedule := newStoredScheduleWithMatchups(t, db, season, weeklyMatchups)
+
+	rows, err := database.GetAllWhere[*ScheduleMatchup](context.Background(), db, func(_ context.Context, sm *ScheduleMatchup) bool {
+		return sm.ScheduleId == schedule.ID
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 ScheduleMatchup rows before delete, got %d", len(rows))
+	}
+
+	_, _, err = database.DeleteOneById(context.Background(), db, &Schedule{}, schedule.ID.RecordId())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rows, err = database.GetAllWhere[*ScheduleMatchup](context.Background(), db, func(_ context.Context, sm *ScheduleMatchup) bool {
+		return sm.ScheduleId == schedule.ID
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("expected 0 ScheduleMatchup rows after delete, got %d", len(rows))
+	}
 }


### PR DESCRIPTION
Closes #38

Part of the umbrella normalization work in #37.

- Remove the inline `Schedule.Matchups []WeeklyMatchupId` slice.
- Add a dedicated `ScheduleMatchup` join record (`schedule_matchup` collection) with FKs to schedule/weekly_matchup, a natural unique constraint on (ScheduleId, WeeklyMatchupId), and a `Position` to preserve ordering — following the established SeasonTeam/FormatRating/WeeklyMatchupTeamMatchup pattern.
- Add `Schedule.GetMatchups` (reassembles matchups sorted by Position), `SetMatchups`, and `PreDelete` cascade.
- Update `DynamicallyValid` and `IsScheduleComplete` to query the relationship table.
- Document the API shape decision (wire format unchanged, reassembled on read / expanded on write) in `docs/api-shape-schedule-matchup.md`.
- Add round-trip/query/uniqueness/validation/ordering/cascade tests.

Note: the `schedule_matchups` table creation + backfill is deferred to the #36 SQLite provider migration framework (as documented in the ScheduleMatchup type comment).