### PR TITLE
feat(db): wire provider selection via flag/env + thread-safe memory provider

### DIFF
--- a/database/provider_factory.go
+++ b/database/provider_factory.go
@@ -1,0 +1,56 @@
+package database
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// ProviderKind identifies a supported database.Provider implementation
+// that the running server can be wired to at startup.
+type ProviderKind string
+
+const (
+	// ProviderMemory is an in-memory, map-backed provider. It is used by the
+	// unit/contract tests and is a valid option for ephemeral local runs.
+	ProviderMemory ProviderKind = "memory"
+
+	// ProviderSqlite is the file-backed SQLite provider. Construction and
+	// connection setup are implemented in issue #53; until then selecting it
+	// returns an explicit "not yet implemented" error rather than failing
+	// silently at startup.
+	ProviderSqlite ProviderKind = "sqlite"
+)
+
+// ProviderConfig holds the settings needed to construct and open a Provider.
+type ProviderConfig struct {
+	Kind ProviderKind
+	// Path is the SQLite database file path. Ignored for in-memory providers.
+	Path string
+}
+
+// ErrUnknownProvider is returned by NewProvider when the requested
+// ProviderKind is not a known provider.
+var ErrUnknownProvider = errors.New("unknown database provider")
+
+// ErrSqliteNotImplemented is returned by NewProvider when the SQLite provider
+// is selected before it has been implemented (issue #53).
+var ErrSqliteNotImplemented = errors.New("sqlite database provider is not implemented")
+
+// NewProvider constructs, opens, and (for persistent providers) runs any
+// pending migrations on the requested Provider, returning the ready-to-use
+// Provider. The Provider interface has no Connect/Disconnect, so connection
+// setup and migration live here, on the concrete type, rather than in the
+// interface.
+func NewProvider(ctx context.Context, cfg ProviderConfig) (Provider, error) {
+	switch cfg.Kind {
+	case ProviderMemory:
+		return NewUnitTestDBProvider(), nil
+	case ProviderSqlite:
+		// TODO(#53): construct + open the SQLite provider here and run
+		// pending migrations (issue #52) before returning it.
+		return nil, fmt.Errorf("%w (see issue #53): %q", ErrSqliteNotImplemented, ProviderSqlite)
+	default:
+		return nil, fmt.Errorf("%w: %q (expected %q or %q)", ErrUnknownProvider, cfg.Kind, ProviderMemory, ProviderSqlite)
+	}
+}

--- a/database/provider_factory_test.go
+++ b/database/provider_factory_test.go
@@ -1,0 +1,42 @@
+package database
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestNewProviderMemory(t *testing.T) {
+	db, err := NewProvider(context.Background(), ProviderConfig{Kind: ProviderMemory})
+	if err != nil {
+		t.Fatalf("NewProvider(memory) returned error: %v", err)
+	}
+	if db == nil {
+		t.Fatal("NewProvider(memory) returned nil provider")
+	}
+	if _, ok := db.(*UnitTestDbProvider); !ok {
+		t.Fatalf("NewProvider(memory) returned %T, want *UnitTestDbProvider", db)
+	}
+}
+
+func TestNewProviderSqliteNotImplemented(t *testing.T) {
+	// NOTE: this branch is implemented in issue #53; this test should be
+	// updated to assert a working provider once the SQLite provider lands.
+	_, err := NewProvider(context.Background(), ProviderConfig{Kind: ProviderSqlite, Path: ":memory:"})
+	if err == nil {
+		t.Fatal("NewProvider(sqlite) returned nil error, want not-implemented error")
+	}
+	if !errors.Is(err, ErrSqliteNotImplemented) {
+		t.Fatalf("NewProvider(sqlite) error = %v, want ErrSqliteNotImplemented", err)
+	}
+}
+
+func TestNewProviderUnknownKind(t *testing.T) {
+	_, err := NewProvider(context.Background(), ProviderConfig{Kind: ProviderKind("bogus")})
+	if err == nil {
+		t.Fatal("NewProvider(unknown) returned nil error, want error")
+	}
+	if !errors.Is(err, ErrUnknownProvider) {
+		t.Fatalf("NewProvider(unknown) error = %v, want ErrUnknownProvider", err)
+	}
+}

--- a/database/unit_test_db_provider.go
+++ b/database/unit_test_db_provider.go
@@ -3,11 +3,18 @@ package database
 import (
 	"context"
 	"fmt"
+	"sync"
 )
 
 type RecordCache map[RecordId]CrudRecord // Map from a RecordId to the CrudRecord with that ID
+
+// UnitTestDbProvider is an in-memory, map-backed database.Provider. It is used
+// by the test suite and as the ephemeral "memory" provider for the running
+// server. All access is guarded by a mutex so concurrent gin handlers do not
+// race on the underlying maps (a pre-#53 stopgap; SQLite replaces it).
 type UnitTestDbProvider struct {
 	Caches map[string]RecordCache // map from CrudRecord.Type to a RecordCache
+	mu     sync.Mutex
 }
 
 func NewUnitTestDBProvider() *UnitTestDbProvider {
@@ -16,6 +23,8 @@ func NewUnitTestDBProvider() *UnitTestDbProvider {
 	}
 }
 
+// getOrCreateRecordCache returns the RecordCache for the given record type,
+// creating it if necessary. The caller must hold u.mu.
 func (u *UnitTestDbProvider) getOrCreateRecordCache(recordType CrudRecord) RecordCache {
 	v, ok := u.Caches[recordType.Type()]
 	if ok {
@@ -25,9 +34,17 @@ func (u *UnitTestDbProvider) getOrCreateRecordCache(recordType CrudRecord) Recor
 	return u.Caches[recordType.Type()]
 }
 
-func (u *UnitTestDbProvider) GetOne(ctx context.Context, record CrudRecord) (CrudRecord, bool, error) {
+// getOne is the unlocked implementation of GetOne. The caller must hold u.mu.
+func (u *UnitTestDbProvider) getOne(record CrudRecord) (CrudRecord, bool) {
 	cache := u.getOrCreateRecordCache(record)
 	v, ok := cache[record.GetId()]
+	return v, ok
+}
+
+func (u *UnitTestDbProvider) GetOne(ctx context.Context, record CrudRecord) (CrudRecord, bool, error) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	v, ok := u.getOne(record)
 	return v, ok, nil
 }
 
@@ -36,7 +53,8 @@ func (u *UnitTestDbProvider) GetAll(ctx context.Context, recordType CrudRecord) 
 }
 
 func (u *UnitTestDbProvider) GetAllWhere(ctx context.Context, recordType CrudRecord, where WhereFunc) ([]CrudRecord, error) {
-
+	u.mu.Lock()
+	defer u.mu.Unlock()
 	output := make([]CrudRecord, 0)
 	cache := u.getOrCreateRecordCache(recordType)
 	for _, record := range cache {
@@ -44,11 +62,13 @@ func (u *UnitTestDbProvider) GetAllWhere(ctx context.Context, recordType CrudRec
 			output = append(output, record)
 		}
 	}
-	// u.Dump()
 	return output, nil
 }
 
 func (u *UnitTestDbProvider) Create(ctx context.Context, record CrudRecord) (CrudRecord, error) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+
 	// get the RecordCache for this type, creating it if necessary
 	cache := u.getOrCreateRecordCache(record)
 
@@ -57,7 +77,7 @@ func (u *UnitTestDbProvider) Create(ctx context.Context, record CrudRecord) (Cru
 		record.SetId(NewRecordId())
 	}
 
-	// check that a record doesn't already exist with the given RecordIs
+	// check that a record doesn't already exist with the given RecordId
 	_, exists := cache[record.GetId()]
 	if exists {
 		return nil, fmt.Errorf("A %s record with ID %s already exists", record.Type(), record.GetId())
@@ -69,7 +89,9 @@ func (u *UnitTestDbProvider) Create(ctx context.Context, record CrudRecord) (Cru
 }
 
 func (u *UnitTestDbProvider) Update(ctx context.Context, record CrudRecord) error {
-	_, exists, _ := u.GetOne(ctx, record)
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	_, exists := u.getOne(record)
 	if !exists {
 		return fmt.Errorf("%s with ID  %s does not exist", record.Type(), record.GetId())
 	}
@@ -79,7 +101,9 @@ func (u *UnitTestDbProvider) Update(ctx context.Context, record CrudRecord) erro
 }
 
 func (u *UnitTestDbProvider) Delete(ctx context.Context, record CrudRecord) error {
-	_, exists, _ := u.GetOne(ctx, record)
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	_, exists := u.getOne(record)
 	if !exists {
 		return nil
 	}
@@ -89,6 +113,8 @@ func (u *UnitTestDbProvider) Delete(ctx context.Context, record CrudRecord) erro
 }
 
 func (u *UnitTestDbProvider) Dump() {
+	u.mu.Lock()
+	defer u.mu.Unlock()
 	for tableName, cache := range u.Caches {
 		for id, record := range cache {
 			fmt.Printf("%s %s\n", tableName, id)

--- a/main.go
+++ b/main.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"log"
 	"net"
+	"os"
 
 	"intraclub/api"
 	"intraclub/database"
@@ -19,11 +21,14 @@ func main() {
 	database.SysAdminCheck = model.IsUserSystemAdministrator
 	api.UserType = &model.User{}
 
-	// set up the default database provider
-	db := database.NewUnitTestDBProvider()
-
 	// parse command-line flags
-	addr := parseFlags()
+	cfg := parseFlags()
+
+	// construct, open, and migrate the requested database provider
+	db, err := database.NewProvider(context.Background(), cfg.providerConfig())
+	if err != nil {
+		log.Fatalf("failed to initialize database provider: %v", err)
+	}
 
 	// seed data for development mode
 	if model.UseDevTokenMode {
@@ -31,7 +36,7 @@ func main() {
 	}
 
 	// generate or load JWT key pair
-	err := api.GenerateJwtKeyPairIfNotExists()
+	err = api.GenerateJwtKeyPairIfNotExists()
 	if err != nil {
 		panic(err)
 	}
@@ -80,15 +85,36 @@ func main() {
 
 	rg.GET("/draft_order_patterns", model.GetDraftOrderPatterns)
 
-	err = r.Run(addr)
+	err = r.Run(cfg.addr)
 	if err != nil {
 		panic(err)
 	}
 }
 
-func parseFlags() string {
+// serverConfig holds the settings parsed from command-line flags and
+// environment variables that configure the running server.
+type serverConfig struct {
+	addr   string
+	dbKind database.ProviderKind
+	dbPath string
+}
+
+// providerConfig converts the server's parsed database settings into the
+// database.ProviderConfig consumed by database.NewProvider.
+func (c serverConfig) providerConfig() database.ProviderConfig {
+	return database.ProviderConfig{Kind: c.dbKind, Path: c.dbPath}
+}
+
+func parseFlags() serverConfig {
 	useDevTokenMode := flag.Bool("dev-token", false, "Use development token mode")
 	addr := flag.String("addr", "127.0.0.1:8080", "Address to listen on, e.g. 127.0.0.1:8080")
+
+	// defaultDBKind is the provider used at startup. It is set to the
+	// in-memory provider until the SQLite provider (issue #53) lands; the
+	// default flips to database.ProviderSqlite once that provider is wired.
+	defaultDBKind := database.ProviderMemory
+	dbKind := flag.String("db", string(defaultDBKind), "Database provider (memory | sqlite)")
+	dbPath := flag.String("db-path", "", "Path to the SQLite database file; falls back to INTRACLUB_DB_PATH env")
 	flag.Parse()
 
 	if useDevTokenMode != nil && *useDevTokenMode == true {
@@ -100,7 +126,21 @@ func parseFlags() string {
 		log.Fatalf("--dev-token mode is DEV MODE ONLY and bypasses authentication; it may only be used when the server is bound to a loopback address (127.0.0.1 / localhost), but got %q", *addr)
 	}
 
-	return *addr
+	// resolve the database path from the flag or the environment variable
+	return serverConfig{
+		addr:   *addr,
+		dbKind: database.ProviderKind(*dbKind),
+		dbPath: resolveDBPath(*dbPath),
+	}
+}
+
+// resolveDBPath returns the SQLite database file path, preferring the
+// explicit --db-path flag and falling back to the INTRACLUB_DB_PATH env var.
+func resolveDBPath(flagPath string) string {
+	if flagPath != "" {
+		return flagPath
+	}
+	return os.Getenv("INTRACLUB_DB_PATH")
 }
 
 // isLoopbackAddress reports whether addr's host is a loopback interface

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,42 @@
 package main
 
-import "testing"
+import (
+	"os"
+	"testing"
+)
+
+func TestResolveDBPath(t *testing.T) {
+	// ensure env var is clean regardless of caller environment
+	prev, hadPrev := os.LookupEnv("INTRACLUB_DB_PATH")
+	t.Cleanup(func() {
+		if hadPrev {
+			os.Setenv("INTRACLUB_DB_PATH", prev)
+		} else {
+			os.Unsetenv("INTRACLUB_DB_PATH")
+		}
+	})
+
+	t.Run("flag wins over env", func(t *testing.T) {
+		os.Setenv("INTRACLUB_DB_PATH", "/from/env/data.db")
+		if got := resolveDBPath("/from/flag/data.db"); got != "/from/flag/data.db" {
+			t.Errorf("resolveDBPath = %q, want flag path", got)
+		}
+	})
+
+	t.Run("falls back to env when flag empty", func(t *testing.T) {
+		os.Setenv("INTRACLUB_DB_PATH", "/from/env/data.db")
+		if got := resolveDBPath(""); got != "/from/env/data.db" {
+			t.Errorf("resolveDBPath = %q, want env path", got)
+		}
+	})
+
+	t.Run("empty when neither set", func(t *testing.T) {
+		os.Unsetenv("INTRACLUB_DB_PATH")
+		if got := resolveDBPath(""); got != "" {
+			t.Errorf("resolveDBPath = %q, want empty", got)
+		}
+	})
+}
 
 func TestIsLoopbackAddress(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
Closes #51 · Part of #36 (SQLite database provider)

## What
Wires provider selection into the running server so the hard-coded `NewUnitTestDBProvider()` goes away and a provider can be chosen at startup.

- Adds `database.NewProvider(ctx, cfg)` factory with `ProviderKind` (`memory` | `sqlite`), `ProviderConfig`, and sentinel errors (`ErrUnknownProvider`, `ErrSqliteNotImplemented`).
- Adds `--db` / `--db-path` flags plus `INTRACLUB_DB_PATH` env fallback in `main.go`; provider init failures now `log.Fatalf` before serving.
- Makes the in-memory provider mutex-guarded (concurrent gin handlers were previously able to race on the maps).
- Tests: provider factory + flag/env precedence (`resolveDBPath`).

## Notes
- Default provider is `memory`, not `sqlite` — the SQLite provider doesn't exist yet (#53), so defaulting to `sqlite` now would fail at startup. The default flips to `database.ProviderSqlite` on the one line in `parseFlags` when #53 lands.

## Verification
- `go build ./...`, `go vet ./...`, `go test ./...` all green
- `go test -race ./database/ .` clean
