### PR TITLE
feat(db): SQLite schema + round-trip for seasons/teams & schedules (#56) (#57)

### DIFF
--- a/database/migrations/0005_create_seasons.sql
+++ b/database/migrations/0005_create_seasons.sql
@@ -1,0 +1,23 @@
+-- 0005_create_seasons.sql
+-- The season table, matching the Season record shape (model/season.go).
+-- Table name equals record.Type() ("season").
+--   id                 -> RecordId hex TEXT primary key
+--   name               -> TEXT
+--   facility           -> FacilityId hex TEXT (InvalidRecordId encodes as all-zero hex)
+--   start_time         -> TEXT (StartTime is a defined type over time.Time; RFC3339)
+--   draft_id           -> DraftId hex TEXT
+--   schedule_id        -> ScheduleId hex TEXT
+--   playoff_structure  -> PlayoffStructureId hex TEXT
+--   owner              -> UserId hex TEXT
+-- One season per draft: UNIQUE(draft_id) mirrors Season.UniquenessEquivalent.
+CREATE TABLE season (
+    id                TEXT PRIMARY KEY,  -- SeasonId hex string
+    name              TEXT NOT NULL,
+    facility          TEXT NOT NULL,     -- FacilityId hex string
+    start_time        TEXT NOT NULL,     -- StartTime (RFC3339)
+    draft_id          TEXT NOT NULL,     -- DraftId hex string
+    schedule_id       TEXT NOT NULL,     -- ScheduleId hex string
+    playoff_structure TEXT NOT NULL,     -- PlayoffStructureId hex string
+    owner             TEXT NOT NULL,     -- UserId hex string
+    UNIQUE (draft_id)
+);

--- a/database/migrations/0006_create_season_commissioners.sql
+++ b/database/migrations/0006_create_season_commissioners.sql
@@ -1,0 +1,16 @@
+-- 0006_create_season_commissioners.sql
+-- The season_commissioner join table, matching the SeasonCommissioner record
+-- shape (model/season_commissioner.go).
+-- Table name equals record.Type() ("season_commissioner").
+--   id         -> RecordId hex TEXT primary key
+--   season_id  -> SeasonId hex TEXT
+--   user_id    -> UserId hex TEXT
+--   created_at -> RFC3339 TEXT
+--   updated_at -> RFC3339 TEXT
+CREATE TABLE season_commissioner (
+    id         TEXT PRIMARY KEY,   -- RecordId hex string
+    season_id  TEXT NOT NULL,      -- SeasonId hex string
+    user_id    TEXT NOT NULL,      -- UserId hex string
+    created_at TEXT NOT NULL,      -- RFC3339
+    updated_at TEXT NOT NULL       -- RFC3339
+);

--- a/database/migrations/0007_create_season_late_additions.sql
+++ b/database/migrations/0007_create_season_late_additions.sql
@@ -1,0 +1,16 @@
+-- 0007_create_season_late_additions.sql
+-- The season_late_addition join table, matching the SeasonLateAddition record
+-- shape (model/season_late_addition.go).
+-- Table name equals record.Type() ("season_late_addition").
+--   id         -> RecordId hex TEXT primary key
+--   season_id  -> SeasonId hex TEXT
+--   user_id    -> UserId hex TEXT
+--   created_at -> RFC3339 TEXT
+--   updated_at -> RFC3339 TEXT
+CREATE TABLE season_late_addition (
+    id         TEXT PRIMARY KEY,   -- RecordId hex string
+    season_id  TEXT NOT NULL,      -- SeasonId hex string
+    user_id    TEXT NOT NULL,      -- UserId hex string
+    created_at TEXT NOT NULL,      -- RFC3339
+    updated_at TEXT NOT NULL       -- RFC3339
+);

--- a/database/migrations/0008_create_season_teams.sql
+++ b/database/migrations/0008_create_season_teams.sql
@@ -1,0 +1,16 @@
+-- 0008_create_season_teams.sql
+-- The season_team join table, matching the SeasonTeam record shape
+-- (model/season_team.go).
+-- Table name equals record.Type() ("season_team").
+--   id         -> RecordId hex TEXT primary key
+--   season_id  -> SeasonId hex TEXT
+--   team_id    -> TeamId hex TEXT
+--   created_at -> RFC3339 TEXT
+--   updated_at -> RFC3339 TEXT
+CREATE TABLE season_team (
+    id         TEXT PRIMARY KEY,   -- RecordId hex string
+    season_id  TEXT NOT NULL,      -- SeasonId hex string
+    team_id    TEXT NOT NULL,      -- TeamId hex string
+    created_at TEXT NOT NULL,      -- RFC3339
+    updated_at TEXT NOT NULL       -- RFC3339
+);

--- a/database/migrations/0009_create_teams.sql
+++ b/database/migrations/0009_create_teams.sql
@@ -1,0 +1,21 @@
+-- 0009_create_teams.sql
+-- The team table, matching the Team record shape (model/team.go).
+-- Table name equals record.Type() ("team").
+--   id           -> TeamId hex TEXT primary key
+--   name         -> TEXT
+--   color_name   -> TeamColor.Name (nested value-struct flattened; model/colors.go)
+--   color_hex    -> TeamColor.Hex
+--   created_at   -> RFC3339 TEXT
+--   updated_at   -> RFC3339 TEXT
+--   deleted_at   -> RFC3339 TEXT, nullable (*time.Time)
+-- Team.RatingsMap was normalized into the team_rating join table (0011); the
+-- inline map is not part of this table.
+CREATE TABLE team (
+    id          TEXT PRIMARY KEY,   -- TeamId hex string
+    name        TEXT NOT NULL,
+    color_name  TEXT NOT NULL,      -- TeamColor.Name
+    color_hex   TEXT NOT NULL,      -- TeamColor.Hex
+    created_at  TEXT NOT NULL,      -- RFC3339
+    updated_at  TEXT NOT NULL,      -- RFC3339
+    deleted_at  TEXT                -- RFC3339, nullable
+);

--- a/database/migrations/0010_create_team_assignments.sql
+++ b/database/migrations/0010_create_team_assignments.sql
@@ -1,0 +1,20 @@
+-- 0010_create_team_assignments.sql
+-- The team_assignment table, matching the TeamAssignment record shape
+-- (model/team.go).
+-- Table name equals record.Type() ("team_assignment").
+--   id         -> RecordId hex TEXT primary key
+--   team_id    -> TeamId hex TEXT
+--   user_id    -> UserId hex TEXT
+--   role       -> TeamRole string enum as TEXT
+--   created_at -> RFC3339 TEXT
+--   updated_at -> RFC3339 TEXT
+--   deleted_at -> RFC3339 TEXT, nullable (*time.Time)
+CREATE TABLE team_assignment (
+    id         TEXT PRIMARY KEY,   -- RecordId hex string
+    team_id    TEXT NOT NULL,      -- TeamId hex string
+    user_id    TEXT NOT NULL,      -- UserId hex string
+    role       TEXT NOT NULL,      -- TeamRole enum ("captain"|"co_captain"|"member")
+    created_at TEXT NOT NULL,      -- RFC3339
+    updated_at TEXT NOT NULL,      -- RFC3339
+    deleted_at TEXT                -- RFC3339, nullable
+);

--- a/database/migrations/0011_create_team_ratings.sql
+++ b/database/migrations/0011_create_team_ratings.sql
@@ -1,0 +1,18 @@
+-- 0011_create_team_ratings.sql
+-- The team_rating join table, matching the TeamRating record shape
+-- (model/team.go). This is the normalized replacement for the former inline
+-- Team.RatingsMap (user -> rating).
+-- Table name equals record.Type() ("team_rating").
+--   id        -> RecordId hex TEXT primary key
+--   team_id   -> TeamId hex TEXT
+--   user_id   -> UserId hex TEXT
+--   rating_id -> RatingId hex TEXT
+-- One rating per (team, user): UNIQUE(team_id, user_id) mirrors
+-- TeamRating.UniquenessEquivalent.
+CREATE TABLE team_rating (
+    id        TEXT PRIMARY KEY,   -- RecordId hex string
+    team_id   TEXT NOT NULL,      -- TeamId hex string
+    user_id   TEXT NOT NULL,      -- UserId hex string
+    rating_id TEXT NOT NULL,      -- RatingId hex string
+    UNIQUE (team_id, user_id)
+);

--- a/database/migrations/0012_create_schedules.sql
+++ b/database/migrations/0012_create_schedules.sql
@@ -1,0 +1,12 @@
+-- 0012_create_schedules.sql
+-- The schedule table, matching the Schedule record shape (model/schedule.go).
+-- Table name equals record.Type() ("schedule").
+--   id        -> ScheduleId hex TEXT primary key
+--   season_id -> SeasonId hex TEXT
+-- One schedule per season: UNIQUE(season_id) mirrors Schedule.UniquenessEquivalent.
+-- Schedule.Matchups ([]WeeklyMatchupId) is normalized into the schedule_matchup
+-- join table (0013), not stored inline.
+CREATE TABLE schedule (
+    id        TEXT PRIMARY KEY,   -- ScheduleId hex string
+    season_id TEXT NOT NULL       -- SeasonId hex string
+);

--- a/database/migrations/0013_create_schedule_matchups.sql
+++ b/database/migrations/0013_create_schedule_matchups.sql
@@ -1,0 +1,19 @@
+-- 0013_create_schedule_matchups.sql
+-- The schedule_matchup join table, matching the ScheduleMatchup record shape
+-- (model/schedule_matchup.go). This is the normalized replacement for the
+-- former inline Schedule.Matchups []WeeklyMatchupId slice, preserving ordering
+-- via the Position column.
+-- Table name equals record.Type() ("schedule_matchup").
+--   id                -> ScheduleMatchupId hex TEXT primary key
+--   schedule_id       -> ScheduleId hex TEXT
+--   weekly_matchup_id -> WeeklyMatchupId hex TEXT
+--   position          -> INTEGER
+-- A weekly matchup may only be assigned to a schedule once:
+-- UNIQUE(schedule_id, weekly_matchup_id) mirrors ScheduleMatchup.UniquenessEquivalent.
+CREATE TABLE schedule_matchup (
+    id                TEXT PRIMARY KEY,   -- ScheduleMatchupId hex string
+    schedule_id       TEXT NOT NULL,      -- ScheduleId hex string
+    weekly_matchup_id TEXT NOT NULL,      -- WeeklyMatchupId hex string
+    position          INTEGER NOT NULL,
+    UNIQUE (schedule_id, weekly_matchup_id)
+);

--- a/database/migrations/0014_create_weekly_matchups.sql
+++ b/database/migrations/0014_create_weekly_matchups.sql
@@ -1,0 +1,17 @@
+-- 0014_create_weekly_matchups.sql
+-- The weekly_matchup table, matching the WeeklyMatchup record shape
+-- (model/weekly_matchup.go).
+-- Table name equals record.Type() ("weekly_matchup").
+--   id        -> WeeklyMatchupId hex TEXT primary key
+--   week_id   -> WeekId hex TEXT
+--   season_id -> SeasonId hex TEXT
+-- One weekly matchup per (season, week): UNIQUE(season_id, week_id) mirrors
+-- WeeklyMatchup.UniquenessEquivalent.
+-- WeeklyMatchup.Matchups ([]*TeamMatchup) is normalized into the
+-- weekly_matchup_team_matchup join table (0015), not stored inline.
+CREATE TABLE weekly_matchup (
+    id        TEXT PRIMARY KEY,   -- WeeklyMatchupId hex string
+    week_id   TEXT NOT NULL,      -- WeekId hex string
+    season_id TEXT NOT NULL,      -- SeasonId hex string
+    UNIQUE (season_id, week_id)
+);

--- a/database/migrations/0015_create_weekly_matchup_team_matchups.sql
+++ b/database/migrations/0015_create_weekly_matchup_team_matchups.sql
@@ -1,0 +1,21 @@
+-- 0015_create_weekly_matchup_team_matchups.sql
+-- The weekly_matchup_team_matchup join table, matching the
+-- WeeklyMatchupTeamMatchup record shape (model/weekly_matchup_team_matchup.go).
+-- This is the normalized replacement for the former inline
+-- WeeklyMatchup.Matchups []*TeamMatchup slice, preserving ordering via the
+-- Position column.
+-- Table name equals record.Type() ("weekly_matchup_team_matchup").
+--   id                 -> WeeklyMatchupTeamMatchupId hex TEXT primary key
+--   weekly_matchup_id  -> WeeklyMatchupId hex TEXT
+--   home_team_id       -> TeamId hex TEXT
+--   away_team_id       -> TeamId hex TEXT
+--   bye                -> bool as INTEGER (0/1)
+--   position           -> INTEGER
+CREATE TABLE weekly_matchup_team_matchup (
+    id                TEXT PRIMARY KEY,   -- WeeklyMatchupTeamMatchupId hex string
+    weekly_matchup_id TEXT NOT NULL,      -- WeeklyMatchupId hex string
+    home_team_id      TEXT NOT NULL,      -- TeamId hex string
+    away_team_id      TEXT NOT NULL,      -- TeamId hex string
+    bye               INTEGER NOT NULL,   -- bool
+    position          INTEGER NOT NULL
+);

--- a/database/migrations/0016_create_weeks.sql
+++ b/database/migrations/0016_create_weeks.sql
@@ -1,0 +1,13 @@
+-- 0016_create_weeks.sql
+-- The week table, matching the Week record shape (model/week.go).
+-- Table name equals record.Type() ("week").
+--   id       -> WeekId hex TEXT primary key
+--   draft_id -> DraftId hex TEXT
+--   date     -> RFC3339 TEXT
+--   note     -> TEXT
+CREATE TABLE week (
+    id       TEXT PRIMARY KEY,   -- WeekId hex string
+    draft_id TEXT NOT NULL,      -- DraftId hex string
+    date     TEXT NOT NULL,      -- RFC3339
+    note     TEXT NOT NULL
+);

--- a/database/sqlite_db.go
+++ b/database/sqlite_db.go
@@ -236,24 +236,50 @@ func insertParts(record CrudRecord) ([]string, []any, error) {
 	if v.Kind() == reflect.Ptr {
 		v = v.Elem()
 	}
+
+	err := walkFields(v, "", func(colName string, field reflect.Value) error {
+		if colName == "id" {
+			return nil
+		}
+		val, err := encodeValue(field)
+		if err != nil {
+			return fmt.Errorf("column %q: %w", colName, err)
+		}
+		cols = append(cols, colName)
+		vals = append(vals, val)
+		return nil
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	return cols, vals, nil
+}
+
+// walkFields visits every scalar field of a struct, flattening nested (non-time)
+// struct fields into prefixed column names (e.g. Team.Color.Name -> "color_name").
+// emit is called with the final column name and the leaf reflect.Value for each
+// scalar field. This lets a single value-struct like TeamColor live in the same
+// table as flattened columns rather than a child table.
+func walkFields(v reflect.Value, prefix string, emit func(colName string, field reflect.Value) error) error {
 	t := v.Type()
 	for i := 0; i < t.NumField(); i++ {
 		field := t.Field(i)
 		if field.PkgPath != "" { // unexported
 			continue
 		}
-		name := columnName(field)
-		if name == "id" {
+		colName := prefix + columnName(field)
+		fv := v.Field(i)
+		if !isTimeLike(fv.Type()) && fv.Kind() == reflect.Struct {
+			if err := walkFields(fv, colName+"_", emit); err != nil {
+				return err
+			}
 			continue
 		}
-		val, err := encodeValue(v.Field(i))
-		if err != nil {
-			return nil, nil, fmt.Errorf("column %q: %w", name, err)
+		if err := emit(colName, fv); err != nil {
+			return err
 		}
-		cols = append(cols, name)
-		vals = append(vals, val)
 	}
-	return cols, vals, nil
+	return nil
 }
 
 // scanRow scans the current row into record, mapping columns back to struct
@@ -291,27 +317,37 @@ func scanRow(rows *sql.Rows, cols []string, record CrudRecord) error {
 }
 
 // fieldByColumn returns a map from JSON-tag column name to the struct's
-// settable field value (excluding the id column).
+// settable leaf field value (excluding the id column). Nested non-time struct
+// fields are flattened into prefixed column names, mirroring insertParts.
 func fieldByColumn(record CrudRecord) map[string]reflect.Value {
 	v := reflect.ValueOf(record)
 	if v.Kind() == reflect.Ptr {
 		v = v.Elem()
 	}
-	t := v.Type()
 
 	out := map[string]reflect.Value{}
+	walkFieldMap(v, "", out)
+	return out
+}
+
+func walkFieldMap(v reflect.Value, prefix string, out map[string]reflect.Value) {
+	t := v.Type()
 	for i := 0; i < t.NumField(); i++ {
 		field := t.Field(i)
 		if field.PkgPath != "" {
 			continue
 		}
-		name := columnName(field)
-		if name == "id" {
+		colName := prefix + columnName(field)
+		fv := v.Field(i)
+		if !isTimeLike(fv.Type()) && fv.Kind() == reflect.Struct {
+			walkFieldMap(fv, colName+"_", out)
 			continue
 		}
-		out[name] = v.Field(i)
+		if colName == "id" {
+			continue
+		}
+		out[colName] = fv
 	}
-	return out
 }
 
 // columnName returns the DB column name for a struct field: its JSON tag (if
@@ -324,6 +360,14 @@ func columnName(field reflect.StructField) string {
 		}
 	}
 	return snakeCase(field.Name)
+}
+
+// isTimeLike reports whether t is time.Time or a defined type over time.Time
+// (e.g. model.StartTime). Such structs are stored as RFC3339 TEXT columns; all
+// other structs are treated as nested value-structs and flattened by
+// walkFields / walkFieldMap.
+func isTimeLike(t reflect.Type) bool {
+	return t.Kind() == reflect.Struct && t.ConvertibleTo(reflect.TypeOf(time.Time{}))
 }
 
 func snakeCase(s string) string {
@@ -363,8 +407,9 @@ func encodeValue(field reflect.Value) (any, error) {
 		// ID family: store as 16-hex TEXT to avoid signed-64 overflow.
 		return fmt.Sprintf("%016x", field.Uint()), nil
 	case reflect.Struct:
-		if field.Type() == reflect.TypeOf(time.Time{}) {
-			return field.Interface().(time.Time).UTC().Format(time.RFC3339Nano), nil
+		if isTimeLike(field.Type()) {
+			ts := field.Convert(reflect.TypeOf(time.Time{})).Interface().(time.Time)
+			return ts.UTC().Format(time.RFC3339Nano), nil
 		}
 		return nil, fmt.Errorf("unsupported struct field %s", field.Type())
 	default:
@@ -400,12 +445,12 @@ func setField(field reflect.Value, raw any) error {
 		}
 		field.SetUint(u)
 	case reflect.Struct:
-		if field.Type() == reflect.TypeOf(time.Time{}) {
+		if isTimeLike(field.Type()) {
 			ts, err := time.Parse(time.RFC3339Nano, asString(raw))
 			if err != nil {
 				return err
 			}
-			field.Set(reflect.ValueOf(ts))
+			field.Set(reflect.ValueOf(ts).Convert(field.Type()))
 			return nil
 		}
 		return fmt.Errorf("unsupported struct field %s", field.Type())

--- a/database/sqlite_season_schedule_roundtrip_test.go
+++ b/database/sqlite_season_schedule_roundtrip_test.go
@@ -1,0 +1,873 @@
+package database_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"intraclub/database"
+	"intraclub/model"
+)
+
+// This file implements the #56 (Seasons & teams) and #57 (Schedules & weekly
+// matchups) SQLite round-trip tests: field-by-field losslessness across
+// Create -> GetOne/GetAll -> Update -> Delete on the SQLite provider.
+//
+// Most records are created through database.CreateOne (which also exercises
+// static/dynamic validation). A few records depend on tables from later model
+// tickets that don't exist yet, so they are persisted directly through the raw
+// provider methods:
+//   - TeamRating requires a Rating (table lands in #60)
+//   - Week requires a Draft (table lands in #58)
+//   - a second Season used to test a FK-field update would collide on the
+//     UNIQUE(draft_id) constraint, so it is created raw with a fabricated id
+//
+// Using the raw provider methods still exercises the exact SQLite column
+// mapping (insert/scan) that the round-trip test is about.
+
+// testUserSeq keeps generated emails unique within a single provider instance.
+var testUserSeq int
+
+func createTestUser(t *testing.T, p database.Provider) *model.User {
+	t.Helper()
+	testUserSeq++
+	u, err := database.CreateOne(context.Background(), p, &model.User{
+		FirstName:   fmt.Sprintf("Test%d", testUserSeq),
+		LastName:    "User",
+		PhoneNumber: model.PhoneNumber(fmt.Sprintf("770555%04d", testUserSeq)),
+		Email:       model.EmailAddress(fmt.Sprintf("roundtrip%04d@example.com", testUserSeq)),
+	})
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	return u
+}
+
+// createTestSeason creates a Season whose optional references (draft, facility,
+// schedule, playoff structure) are all unset, so it passes dynamic validation
+// without those tables existing yet.
+func createTestSeason(t *testing.T, p database.Provider) *model.Season {
+	t.Helper()
+	s := model.NewSeason()
+	s.Name = "Test Season"
+	s.StartTime = model.NewStartTime(8, 30)
+	v, err := database.CreateOne(context.Background(), p, s)
+	if err != nil {
+		t.Fatalf("create season: %v", err)
+	}
+	return v
+}
+
+// createTestSeasonRaw creates a Season directly through the provider with a
+// fabricated, distinct DraftId. Used only to obtain a second season for FK-field
+// update tests, where two CreateOne seasons would collide on UNIQUE(draft_id).
+func createTestSeasonRaw(t *testing.T, p database.Provider) *model.Season {
+	t.Helper()
+	s := model.NewSeason()
+	s.Name = "Raw Season"
+	s.StartTime = model.NewStartTime(9, 0)
+	s.DraftId = model.DraftId(database.NewRecordId())
+	if _, err := p.Create(context.Background(), s); err != nil {
+		t.Fatalf("raw create season: %v", err)
+	}
+	return s
+}
+
+// createTestTeam creates a Team with a captain user. Team.PostCreate adds a
+// TeamAssignment for the captain as a side effect.
+func createTestTeam(t *testing.T, p database.Provider) *model.Team {
+	t.Helper()
+	captain := createTestUser(t, p)
+	team := model.NewDefaultTeam(captain.ID, "Team")
+	team.Color = model.Blue
+	v, err := database.CreateOne(context.Background(), p, team)
+	if err != nil {
+		t.Fatalf("create team: %v", err)
+	}
+	return v
+}
+
+// createTestWeekForSeason creates a Week directly through the provider (the
+// draft table lands in #58) whose DraftId matches the season so that
+// WeeklyMatchup dynamic validation passes.
+func createTestWeekForSeason(t *testing.T, p database.Provider, season *model.Season) *model.Week {
+	t.Helper()
+	w := model.NewWeek()
+	w.DraftId = season.DraftId
+	w.Date = time.Date(2025, 1, 5, 8, 0, 0, 0, time.UTC)
+	w.Note = "week"
+	if _, err := p.Create(context.Background(), w); err != nil {
+		t.Fatalf("raw create week: %v", err)
+	}
+	return w
+}
+
+func timePtrEqual(a, b *time.Time) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return a.Equal(*b)
+}
+
+// ---- #56: Seasons & teams ----
+
+func TestSeasonRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	p := newSqliteProvider(t)
+
+	s := model.NewSeason()
+	s.Name = "Intraclub 2025"
+	s.StartTime = model.NewStartTime(8, 30)
+	created, err := database.CreateOne(ctx, p, s)
+	if err != nil {
+		t.Fatalf("CreateOne(season): %v", err)
+	}
+	if created.GetId() == database.InvalidRecordId {
+		t.Fatal("CreateOne(season) did not assign an ID")
+	}
+
+	got, exists, err := database.GetOneById(ctx, p, &model.Season{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(season): %v", err)
+	}
+	if !exists {
+		t.Fatal("GetOneById(season): record not found")
+	}
+	if got.Name != created.Name || got.Owner != created.Owner ||
+		got.Facility != created.Facility || got.DraftId != created.DraftId ||
+		got.ScheduleID != created.ScheduleID || got.PlayoffStructure != created.PlayoffStructure ||
+		!time.Time(got.StartTime).Equal(time.Time(created.StartTime)) {
+		t.Fatalf("season round-trip mismatch:\n  got  %+v\n  want %+v", got, created)
+	}
+
+	all, err := database.GetAll[*model.Season](ctx, p)
+	if err != nil {
+		t.Fatalf("GetAll(season): %v", err)
+	}
+	if len(all) != 1 || all[0].ID != created.ID {
+		t.Fatalf("GetAll(season): got %d records, want 1 matching the created season", len(all))
+	}
+
+	created.Name = "Renamed Season"
+	if err := database.UpdateOne(ctx, p, created); err != nil {
+		t.Fatalf("UpdateOne(season): %v", err)
+	}
+	got2, _, err := database.GetOneById(ctx, p, &model.Season{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(season) after update: %v", err)
+	}
+	if got2.Name != "Renamed Season" {
+		t.Fatalf("season update not persisted, got %+v", got2)
+	}
+
+	if _, _, err := database.DeleteOneById(ctx, p, &model.Season{}, created.GetId()); err != nil {
+		t.Fatalf("DeleteOneById(season): %v", err)
+	}
+	_, exists, err = database.GetOneById(ctx, p, &model.Season{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(season) after delete: %v", err)
+	}
+	if exists {
+		t.Fatal("season should have been deleted")
+	}
+}
+
+func TestTeamRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	p := newSqliteProvider(t)
+
+	team := model.NewDefaultTeam(createTestUser(t, p).ID, "Team A")
+	team.Color = model.Blue
+	created, err := database.CreateOne(ctx, p, team)
+	if err != nil {
+		t.Fatalf("CreateOne(team): %v", err)
+	}
+	if created.GetId() == database.InvalidRecordId {
+		t.Fatal("CreateOne(team) did not assign an ID")
+	}
+
+	got, exists, err := database.GetOneById(ctx, p, &model.Team{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(team): %v", err)
+	}
+	if !exists {
+		t.Fatal("GetOneById(team): record not found")
+	}
+	if got.Name != created.Name || got.Color != created.Color ||
+		!got.CreatedAt.Equal(created.CreatedAt) || !got.UpdatedAt.Equal(created.UpdatedAt) ||
+		!timePtrEqual(got.DeletedAt, created.DeletedAt) {
+		t.Fatalf("team round-trip mismatch:\n  got  %+v\n  want %+v", got, created)
+	}
+
+	all, err := database.GetAll[*model.Team](ctx, p)
+	if err != nil {
+		t.Fatalf("GetAll(team): %v", err)
+	}
+	if len(all) != 1 || all[0].ID != created.ID {
+		t.Fatalf("GetAll(team): got %d records, want 1 matching the created team", len(all))
+	}
+
+	created.Name = "Team B"
+	created.Color = model.Green
+	if err := database.UpdateOne(ctx, p, created); err != nil {
+		t.Fatalf("UpdateOne(team): %v", err)
+	}
+	got2, _, err := database.GetOneById(ctx, p, &model.Team{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(team) after update: %v", err)
+	}
+	if got2.Name != "Team B" || got2.Color != model.Green {
+		t.Fatalf("team update not persisted, got %+v", got2)
+	}
+
+	if _, _, err := database.DeleteOneById(ctx, p, &model.Team{}, created.GetId()); err != nil {
+		t.Fatalf("DeleteOneById(team): %v", err)
+	}
+	_, exists, err = database.GetOneById(ctx, p, &model.Team{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(team) after delete: %v", err)
+	}
+	if exists {
+		t.Fatal("team should have been deleted")
+	}
+}
+
+func TestTeamAssignmentRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	p := newSqliteProvider(t)
+
+	team := createTestTeam(t, p)
+	member := createTestUser(t, p)
+	a := &model.TeamAssignment{
+		TeamId:    team.ID,
+		UserId:    member.ID,
+		Role:      model.TeamRoleMember,
+		CreatedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+		UpdatedAt: time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC),
+	}
+	created, err := database.CreateOne(ctx, p, a)
+	if err != nil {
+		t.Fatalf("CreateOne(assignment): %v", err)
+	}
+	if created.GetId() == database.InvalidRecordId {
+		t.Fatal("CreateOne(assignment) did not assign an ID")
+	}
+
+	got, exists, err := database.GetOneById(ctx, p, &model.TeamAssignment{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(assignment): %v", err)
+	}
+	if !exists {
+		t.Fatal("GetOneById(assignment): record not found")
+	}
+	if got.TeamId != created.TeamId || got.UserId != created.UserId || got.Role != created.Role ||
+		!got.CreatedAt.Equal(created.CreatedAt) || !got.UpdatedAt.Equal(created.UpdatedAt) ||
+		!timePtrEqual(got.DeletedAt, created.DeletedAt) {
+		t.Fatalf("assignment round-trip mismatch:\n  got  %+v\n  want %+v", got, created)
+	}
+
+	// The team's PostCreate added a captain assignment, so assert presence
+	// rather than an exact count.
+	all, err := database.GetAll[*model.TeamAssignment](ctx, p)
+	if err != nil {
+		t.Fatalf("GetAll(assignment): %v", err)
+	}
+	found := false
+	for _, x := range all {
+		if x.ID == created.ID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("GetAll(assignment): created assignment %s not present", created.ID)
+	}
+
+	created.Role = model.TeamRoleCoCaptain
+	if err := database.UpdateOne(ctx, p, created); err != nil {
+		t.Fatalf("UpdateOne(assignment): %v", err)
+	}
+	got2, _, err := database.GetOneById(ctx, p, &model.TeamAssignment{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(assignment) after update: %v", err)
+	}
+	if got2.Role != model.TeamRoleCoCaptain {
+		t.Fatalf("assignment update not persisted, got %+v", got2)
+	}
+
+	if _, _, err := database.DeleteOneById(ctx, p, &model.TeamAssignment{}, created.GetId()); err != nil {
+		t.Fatalf("DeleteOneById(assignment): %v", err)
+	}
+	_, exists, err = database.GetOneById(ctx, p, &model.TeamAssignment{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(assignment) after delete: %v", err)
+	}
+	if exists {
+		t.Fatal("assignment should have been deleted")
+	}
+}
+
+func TestSeasonCommissionerRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	p := newSqliteProvider(t)
+
+	user := createTestUser(t, p)
+	season := createTestSeason(t, p)
+	sc := &model.SeasonCommissioner{
+		SeasonId:  season.ID,
+		UserId:    user.ID,
+		CreatedAt: time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC),
+		UpdatedAt: time.Date(2025, 2, 2, 0, 0, 0, 0, time.UTC),
+	}
+	created, err := database.CreateOne(ctx, p, sc)
+	if err != nil {
+		t.Fatalf("CreateOne(commissioner): %v", err)
+	}
+
+	got, exists, err := database.GetOneById(ctx, p, &model.SeasonCommissioner{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(commissioner): %v", err)
+	}
+	if !exists {
+		t.Fatal("GetOneById(commissioner): record not found")
+	}
+	if got.SeasonId != created.SeasonId || got.UserId != created.UserId ||
+		!got.CreatedAt.Equal(created.CreatedAt) || !got.UpdatedAt.Equal(created.UpdatedAt) {
+		t.Fatalf("commissioner round-trip mismatch:\n  got  %+v\n  want %+v", got, created)
+	}
+
+	all, err := database.GetAll[*model.SeasonCommissioner](ctx, p)
+	if err != nil {
+		t.Fatalf("GetAll(commissioner): %v", err)
+	}
+	if len(all) != 1 || all[0].ID != created.ID {
+		t.Fatalf("GetAll(commissioner): got %d records, want 1", len(all))
+	}
+
+	user2 := createTestUser(t, p)
+	created.UserId = user2.ID
+	if err := database.UpdateOne(ctx, p, created); err != nil {
+		t.Fatalf("UpdateOne(commissioner): %v", err)
+	}
+	got2, _, err := database.GetOneById(ctx, p, &model.SeasonCommissioner{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(commissioner) after update: %v", err)
+	}
+	if got2.UserId != user2.ID {
+		t.Fatalf("commissioner update not persisted, got %+v", got2)
+	}
+
+	if _, _, err := database.DeleteOneById(ctx, p, &model.SeasonCommissioner{}, created.GetId()); err != nil {
+		t.Fatalf("DeleteOneById(commissioner): %v", err)
+	}
+	_, exists, err = database.GetOneById(ctx, p, &model.SeasonCommissioner{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(commissioner) after delete: %v", err)
+	}
+	if exists {
+		t.Fatal("commissioner should have been deleted")
+	}
+}
+
+func TestSeasonLateAdditionRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	p := newSqliteProvider(t)
+
+	user := createTestUser(t, p)
+	season := createTestSeason(t, p)
+	sla := &model.SeasonLateAddition{
+		SeasonId:  season.ID,
+		UserId:    user.ID,
+		CreatedAt: time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC),
+		UpdatedAt: time.Date(2025, 3, 2, 0, 0, 0, 0, time.UTC),
+	}
+	created, err := database.CreateOne(ctx, p, sla)
+	if err != nil {
+		t.Fatalf("CreateOne(late_addition): %v", err)
+	}
+
+	got, exists, err := database.GetOneById(ctx, p, &model.SeasonLateAddition{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(late_addition): %v", err)
+	}
+	if !exists {
+		t.Fatal("GetOneById(late_addition): record not found")
+	}
+	if got.SeasonId != created.SeasonId || got.UserId != created.UserId ||
+		!got.CreatedAt.Equal(created.CreatedAt) || !got.UpdatedAt.Equal(created.UpdatedAt) {
+		t.Fatalf("late_addition round-trip mismatch:\n  got  %+v\n  want %+v", got, created)
+	}
+
+	all, err := database.GetAll[*model.SeasonLateAddition](ctx, p)
+	if err != nil {
+		t.Fatalf("GetAll(late_addition): %v", err)
+	}
+	if len(all) != 1 || all[0].ID != created.ID {
+		t.Fatalf("GetAll(late_addition): got %d records, want 1", len(all))
+	}
+
+	user2 := createTestUser(t, p)
+	created.UserId = user2.ID
+	if err := database.UpdateOne(ctx, p, created); err != nil {
+		t.Fatalf("UpdateOne(late_addition): %v", err)
+	}
+	got2, _, err := database.GetOneById(ctx, p, &model.SeasonLateAddition{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(late_addition) after update: %v", err)
+	}
+	if got2.UserId != user2.ID {
+		t.Fatalf("late_addition update not persisted, got %+v", got2)
+	}
+
+	if _, _, err := database.DeleteOneById(ctx, p, &model.SeasonLateAddition{}, created.GetId()); err != nil {
+		t.Fatalf("DeleteOneById(late_addition): %v", err)
+	}
+	_, exists, err = database.GetOneById(ctx, p, &model.SeasonLateAddition{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(late_addition) after delete: %v", err)
+	}
+	if exists {
+		t.Fatal("late_addition should have been deleted")
+	}
+}
+
+func TestSeasonTeamRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	p := newSqliteProvider(t)
+
+	season := createTestSeason(t, p)
+	team := createTestTeam(t, p)
+	st := &model.SeasonTeam{
+		SeasonId:  season.ID,
+		TeamId:    team.ID,
+		CreatedAt: time.Date(2025, 4, 1, 0, 0, 0, 0, time.UTC),
+		UpdatedAt: time.Date(2025, 4, 2, 0, 0, 0, 0, time.UTC),
+	}
+	created, err := database.CreateOne(ctx, p, st)
+	if err != nil {
+		t.Fatalf("CreateOne(season_team): %v", err)
+	}
+
+	got, exists, err := database.GetOneById(ctx, p, &model.SeasonTeam{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(season_team): %v", err)
+	}
+	if !exists {
+		t.Fatal("GetOneById(season_team): record not found")
+	}
+	if got.SeasonId != created.SeasonId || got.TeamId != created.TeamId ||
+		!got.CreatedAt.Equal(created.CreatedAt) || !got.UpdatedAt.Equal(created.UpdatedAt) {
+		t.Fatalf("season_team round-trip mismatch:\n  got  %+v\n  want %+v", got, created)
+	}
+
+	all, err := database.GetAll[*model.SeasonTeam](ctx, p)
+	if err != nil {
+		t.Fatalf("GetAll(season_team): %v", err)
+	}
+	if len(all) != 1 || all[0].ID != created.ID {
+		t.Fatalf("GetAll(season_team): got %d records, want 1", len(all))
+	}
+
+	season2 := createTestSeasonRaw(t, p)
+	created.SeasonId = season2.ID
+	if err := database.UpdateOne(ctx, p, created); err != nil {
+		t.Fatalf("UpdateOne(season_team): %v", err)
+	}
+	got2, _, err := database.GetOneById(ctx, p, &model.SeasonTeam{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(season_team) after update: %v", err)
+	}
+	if got2.SeasonId != season2.ID {
+		t.Fatalf("season_team update not persisted, got %+v", got2)
+	}
+
+	if _, _, err := database.DeleteOneById(ctx, p, &model.SeasonTeam{}, created.GetId()); err != nil {
+		t.Fatalf("DeleteOneById(season_team): %v", err)
+	}
+	_, exists, err = database.GetOneById(ctx, p, &model.SeasonTeam{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(season_team) after delete: %v", err)
+	}
+	if exists {
+		t.Fatal("season_team should have been deleted")
+	}
+}
+
+func TestTeamRatingRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	p := newSqliteProvider(t)
+
+	team := createTestTeam(t, p)
+	member := createTestUser(t, p)
+	tr := &model.TeamRating{
+		TeamId:   team.ID,
+		UserId:   member.ID,
+		RatingId: model.RatingId(database.NewRecordId()), // rating table lands in #60
+	}
+	// Created directly through the provider because TeamRating.DynamicallyValid
+	// requires a Rating record, whose table is not migrated yet (#60).
+	if _, err := p.Create(ctx, tr); err != nil {
+		t.Fatalf("Create(team_rating): %v", err)
+	}
+
+	got, exists, err := database.GetOneById(ctx, p, &model.TeamRating{}, tr.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(team_rating): %v", err)
+	}
+	if !exists {
+		t.Fatal("GetOneById(team_rating): record not found")
+	}
+	if got.TeamId != tr.TeamId || got.UserId != tr.UserId || got.RatingId != tr.RatingId {
+		t.Fatalf("team_rating round-trip mismatch:\n  got  %+v\n  want %+v", got, tr)
+	}
+
+	all, err := database.GetAll[*model.TeamRating](ctx, p)
+	if err != nil {
+		t.Fatalf("GetAll(team_rating): %v", err)
+	}
+	if len(all) != 1 || all[0].ID != tr.ID {
+		t.Fatalf("GetAll(team_rating): got %d records, want 1", len(all))
+	}
+
+	tr.RatingId = model.RatingId(database.NewRecordId())
+	if err := p.Update(ctx, tr); err != nil {
+		t.Fatalf("Update(team_rating): %v", err)
+	}
+	got2, _, err := database.GetOneById(ctx, p, &model.TeamRating{}, tr.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(team_rating) after update: %v", err)
+	}
+	if got2.RatingId != tr.RatingId {
+		t.Fatalf("team_rating update not persisted, got %+v", got2)
+	}
+
+	if _, _, err := database.DeleteOneById(ctx, p, &model.TeamRating{}, tr.GetId()); err != nil {
+		t.Fatalf("DeleteOneById(team_rating): %v", err)
+	}
+	_, exists, err = database.GetOneById(ctx, p, &model.TeamRating{}, tr.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(team_rating) after delete: %v", err)
+	}
+	if exists {
+		t.Fatal("team_rating should have been deleted")
+	}
+}
+
+// ---- #57: Schedules & weekly matchups ----
+
+func TestScheduleRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	p := newSqliteProvider(t)
+
+	season := createTestSeason(t, p)
+	s := &model.Schedule{SeasonId: season.ID}
+	created, err := database.CreateOne(ctx, p, s)
+	if err != nil {
+		t.Fatalf("CreateOne(schedule): %v", err)
+	}
+	if created.GetId() == database.InvalidRecordId {
+		t.Fatal("CreateOne(schedule) did not assign an ID")
+	}
+
+	got, exists, err := database.GetOneById(ctx, p, &model.Schedule{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(schedule): %v", err)
+	}
+	if !exists {
+		t.Fatal("GetOneById(schedule): record not found")
+	}
+	if got.SeasonId != created.SeasonId {
+		t.Fatalf("schedule round-trip mismatch:\n  got  %+v\n  want %+v", got, created)
+	}
+
+	all, err := database.GetAll[*model.Schedule](ctx, p)
+	if err != nil {
+		t.Fatalf("GetAll(schedule): %v", err)
+	}
+	if len(all) != 1 || all[0].ID != created.ID {
+		t.Fatalf("GetAll(schedule): got %d records, want 1", len(all))
+	}
+
+	season2 := createTestSeasonRaw(t, p)
+	created.SeasonId = season2.ID
+	if err := database.UpdateOne(ctx, p, created); err != nil {
+		t.Fatalf("UpdateOne(schedule): %v", err)
+	}
+	got2, _, err := database.GetOneById(ctx, p, &model.Schedule{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(schedule) after update: %v", err)
+	}
+	if got2.SeasonId != season2.ID {
+		t.Fatalf("schedule update not persisted, got %+v", got2)
+	}
+
+	if _, _, err := database.DeleteOneById(ctx, p, &model.Schedule{}, created.GetId()); err != nil {
+		t.Fatalf("DeleteOneById(schedule): %v", err)
+	}
+	_, exists, err = database.GetOneById(ctx, p, &model.Schedule{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(schedule) after delete: %v", err)
+	}
+	if exists {
+		t.Fatal("schedule should have been deleted")
+	}
+}
+
+func TestWeekRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	p := newSqliteProvider(t)
+
+	w := model.NewWeek()
+	w.DraftId = model.DraftId(database.NewRecordId()) // draft table lands in #58
+	w.Date = time.Date(2025, 1, 5, 8, 0, 0, 0, time.UTC)
+	w.Note = "Opening week"
+	// Created directly through the provider because Week.DynamicallyValid
+	// requires a Draft record, whose table is not migrated yet (#58).
+	if _, err := p.Create(ctx, w); err != nil {
+		t.Fatalf("Create(week): %v", err)
+	}
+
+	got, exists, err := database.GetOneById(ctx, p, &model.Week{}, w.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(week): %v", err)
+	}
+	if !exists {
+		t.Fatal("GetOneById(week): record not found")
+	}
+	if got.DraftId != w.DraftId || got.Note != w.Note || !got.Date.Equal(w.Date) {
+		t.Fatalf("week round-trip mismatch:\n  got  %+v\n  want %+v", got, w)
+	}
+
+	all, err := database.GetAll[*model.Week](ctx, p)
+	if err != nil {
+		t.Fatalf("GetAll(week): %v", err)
+	}
+	if len(all) != 1 || all[0].ID != w.ID {
+		t.Fatalf("GetAll(week): got %d records, want 1", len(all))
+	}
+
+	w.Note = "Updated week"
+	w.Date = time.Date(2025, 1, 12, 8, 0, 0, 0, time.UTC)
+	if err := p.Update(ctx, w); err != nil {
+		t.Fatalf("Update(week): %v", err)
+	}
+	got2, _, err := database.GetOneById(ctx, p, &model.Week{}, w.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(week) after update: %v", err)
+	}
+	if got2.Note != "Updated week" || !got2.Date.Equal(w.Date) {
+		t.Fatalf("week update not persisted, got %+v", got2)
+	}
+
+	if err := p.Delete(ctx, w); err != nil {
+		t.Fatalf("Delete(week): %v", err)
+	}
+	_, exists, err = database.GetOneById(ctx, p, &model.Week{}, w.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(week) after delete: %v", err)
+	}
+	if exists {
+		t.Fatal("week should have been deleted")
+	}
+}
+
+func TestWeeklyMatchupRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	p := newSqliteProvider(t)
+
+	season := createTestSeason(t, p)
+	week := createTestWeekForSeason(t, p, season)
+	wm := &model.WeeklyMatchup{WeekId: week.ID, SeasonId: season.ID}
+	created, err := database.CreateOne(ctx, p, wm)
+	if err != nil {
+		t.Fatalf("CreateOne(weekly_matchup): %v", err)
+	}
+	if created.GetId() == database.InvalidRecordId {
+		t.Fatal("CreateOne(weekly_matchup) did not assign an ID")
+	}
+
+	got, exists, err := database.GetOneById(ctx, p, &model.WeeklyMatchup{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(weekly_matchup): %v", err)
+	}
+	if !exists {
+		t.Fatal("GetOneById(weekly_matchup): record not found")
+	}
+	if got.WeekId != created.WeekId || got.SeasonId != created.SeasonId {
+		t.Fatalf("weekly_matchup round-trip mismatch:\n  got  %+v\n  want %+v", got, created)
+	}
+
+	all, err := database.GetAll[*model.WeeklyMatchup](ctx, p)
+	if err != nil {
+		t.Fatalf("GetAll(weekly_matchup): %v", err)
+	}
+	if len(all) != 1 || all[0].ID != created.ID {
+		t.Fatalf("GetAll(weekly_matchup): got %d records, want 1", len(all))
+	}
+
+	week2 := createTestWeekForSeason(t, p, season)
+	created.WeekId = week2.ID
+	if err := database.UpdateOne(ctx, p, created); err != nil {
+		t.Fatalf("UpdateOne(weekly_matchup): %v", err)
+	}
+	got2, _, err := database.GetOneById(ctx, p, &model.WeeklyMatchup{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(weekly_matchup) after update: %v", err)
+	}
+	if got2.WeekId != week2.ID {
+		t.Fatalf("weekly_matchup update not persisted, got %+v", got2)
+	}
+
+	if _, _, err := database.DeleteOneById(ctx, p, &model.WeeklyMatchup{}, created.GetId()); err != nil {
+		t.Fatalf("DeleteOneById(weekly_matchup): %v", err)
+	}
+	_, exists, err = database.GetOneById(ctx, p, &model.WeeklyMatchup{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(weekly_matchup) after delete: %v", err)
+	}
+	if exists {
+		t.Fatal("weekly_matchup should have been deleted")
+	}
+}
+
+func TestScheduleMatchupRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	p := newSqliteProvider(t)
+
+	season := createTestSeason(t, p)
+	week := createTestWeekForSeason(t, p, season)
+	wm, err := database.CreateOne(ctx, p, &model.WeeklyMatchup{WeekId: week.ID, SeasonId: season.ID})
+	if err != nil {
+		t.Fatalf("CreateOne(weekly_matchup): %v", err)
+	}
+	sched, err := database.CreateOne(ctx, p, &model.Schedule{SeasonId: season.ID})
+	if err != nil {
+		t.Fatalf("CreateOne(schedule): %v", err)
+	}
+
+	sm := &model.ScheduleMatchup{ScheduleId: sched.ID, WeeklyMatchupId: wm.ID, Position: 0}
+	created, err := database.CreateOne(ctx, p, sm)
+	if err != nil {
+		t.Fatalf("CreateOne(schedule_matchup): %v", err)
+	}
+	if created.GetId() == database.InvalidRecordId {
+		t.Fatal("CreateOne(schedule_matchup) did not assign an ID")
+	}
+
+	got, exists, err := database.GetOneById(ctx, p, &model.ScheduleMatchup{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(schedule_matchup): %v", err)
+	}
+	if !exists {
+		t.Fatal("GetOneById(schedule_matchup): record not found")
+	}
+	if got.ScheduleId != created.ScheduleId || got.WeeklyMatchupId != created.WeeklyMatchupId ||
+		got.Position != created.Position {
+		t.Fatalf("schedule_matchup round-trip mismatch:\n  got  %+v\n  want %+v", got, created)
+	}
+
+	all, err := database.GetAll[*model.ScheduleMatchup](ctx, p)
+	if err != nil {
+		t.Fatalf("GetAll(schedule_matchup): %v", err)
+	}
+	if len(all) != 1 || all[0].ID != created.ID {
+		t.Fatalf("GetAll(schedule_matchup): got %d records, want 1", len(all))
+	}
+
+	created.Position = 2
+	if err := database.UpdateOne(ctx, p, created); err != nil {
+		t.Fatalf("UpdateOne(schedule_matchup): %v", err)
+	}
+	got2, _, err := database.GetOneById(ctx, p, &model.ScheduleMatchup{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(schedule_matchup) after update: %v", err)
+	}
+	if got2.Position != 2 {
+		t.Fatalf("schedule_matchup update not persisted, got %+v", got2)
+	}
+
+	if _, _, err := database.DeleteOneById(ctx, p, &model.ScheduleMatchup{}, created.GetId()); err != nil {
+		t.Fatalf("DeleteOneById(schedule_matchup): %v", err)
+	}
+	_, exists, err = database.GetOneById(ctx, p, &model.ScheduleMatchup{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(schedule_matchup) after delete: %v", err)
+	}
+	if exists {
+		t.Fatal("schedule_matchup should have been deleted")
+	}
+}
+
+func TestWeeklyMatchupTeamMatchupRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	p := newSqliteProvider(t)
+
+	season := createTestSeason(t, p)
+	week := createTestWeekForSeason(t, p, season)
+	wm, err := database.CreateOne(ctx, p, &model.WeeklyMatchup{WeekId: week.ID, SeasonId: season.ID})
+	if err != nil {
+		t.Fatalf("CreateOne(weekly_matchup): %v", err)
+	}
+	teamA := createTestTeam(t, p)
+	teamB := createTestTeam(t, p)
+
+	wmtm := &model.WeeklyMatchupTeamMatchup{
+		WeeklyMatchupId: wm.ID,
+		HomeTeamId:      teamA.ID,
+		AwayTeamId:      teamB.ID,
+		Bye:             false,
+		Position:        0,
+	}
+	created, err := database.CreateOne(ctx, p, wmtm)
+	if err != nil {
+		t.Fatalf("CreateOne(weekly_matchup_team_matchup): %v", err)
+	}
+	if created.GetId() == database.InvalidRecordId {
+		t.Fatal("CreateOne(weekly_matchup_team_matchup) did not assign an ID")
+	}
+
+	got, exists, err := database.GetOneById(ctx, p, &model.WeeklyMatchupTeamMatchup{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(weekly_matchup_team_matchup): %v", err)
+	}
+	if !exists {
+		t.Fatal("GetOneById(weekly_matchup_team_matchup): record not found")
+	}
+	if got.WeeklyMatchupId != created.WeeklyMatchupId ||
+		got.HomeTeamId != created.HomeTeamId || got.AwayTeamId != created.AwayTeamId ||
+		got.Bye != created.Bye || got.Position != created.Position {
+		t.Fatalf("weekly_matchup_team_matchup round-trip mismatch:\n  got  %+v\n  want %+v", got, created)
+	}
+
+	all, err := database.GetAll[*model.WeeklyMatchupTeamMatchup](ctx, p)
+	if err != nil {
+		t.Fatalf("GetAll(weekly_matchup_team_matchup): %v", err)
+	}
+	if len(all) != 1 || all[0].ID != created.ID {
+		t.Fatalf("GetAll(weekly_matchup_team_matchup): got %d records, want 1", len(all))
+	}
+
+	created.Position = 3
+	if err := database.UpdateOne(ctx, p, created); err != nil {
+		t.Fatalf("UpdateOne(weekly_matchup_team_matchup): %v", err)
+	}
+	got2, _, err := database.GetOneById(ctx, p, &model.WeeklyMatchupTeamMatchup{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(weekly_matchup_team_matchup) after update: %v", err)
+	}
+	if got2.Position != 3 {
+		t.Fatalf("weekly_matchup_team_matchup update not persisted, got %+v", got2)
+	}
+
+	if _, _, err := database.DeleteOneById(ctx, p, &model.WeeklyMatchupTeamMatchup{}, created.GetId()); err != nil {
+		t.Fatalf("DeleteOneById(weekly_matchup_team_matchup): %v", err)
+	}
+	_, exists, err = database.GetOneById(ctx, p, &model.WeeklyMatchupTeamMatchup{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(weekly_matchup_team_matchup) after delete: %v", err)
+	}
+	if exists {
+		t.Fatal("weekly_matchup_team_matchup should have been deleted")
+	}
+}

--- a/docs/schema-conventions.md
+++ b/docs/schema-conventions.md
@@ -67,6 +67,14 @@ The schema uses **full normalization**:
   `WeeklyMatchupTeamMatchup`, `ScheduleMatchup`, `DraftRatingCutoff`,
   `CommissionerProposalVote`, …).
 
+A **single value-struct field** (not a map or slice) is *not* normalized into a
+child table; instead it is **flattened** into prefixed columns in its parent's
+table. The reflection mapper in `database/sqlite_db.go` walks nested struct
+fields and prefixes each with the parent column name, e.g. `Team.Color`
+(`TeamColor{Name, Hex}`) becomes the `color_name` / `color_hex` columns of the
+`team` table. `time.Time` and defined types over it (e.g. `StartTime`) are
+stored as single RFC3339 `TEXT` columns, never flattened.
+
 ## Naming
 
 - Table name = `record.Type()` (snake_case plural of the model, e.g. `users`,

--- a/model/schedule.go
+++ b/model/schedule.go
@@ -18,7 +18,7 @@ func (id ScheduleId) String() string {
 }
 
 type Schedule struct {
-	ID       ScheduleId
+	ID       ScheduleId `json:"id"`
 	SeasonId SeasonId
 }
 

--- a/model/season.go
+++ b/model/season.go
@@ -44,12 +44,12 @@ func (s StartTime) String() string {
 }
 
 type Season struct {
-	ID               SeasonId           // unique identifier for this Season
+	ID               SeasonId           `json:"id"` // unique identifier for this Season
 	Name             string             // descriptive name for this season, e.g. _Men's Intraclub 2025_
 	Facility         FacilityId         // ID of the Facility at which this Season is played
 	StartTime        StartTime          // time of day when the first matches kick off (e.g. _8:30 AM_)
 	DraftId          DraftId            // Draft results for this Season
-	ScheduleID       ScheduleId         // ID of the Schedule for this Season
+	ScheduleID       ScheduleId         `json:"schedule_id"` // ID of the Schedule for this Season
 	PlayoffStructure PlayoffStructureId // ID of the PlayoffStructure for the Season
 	Owner            database.UserId    // commissioner who owns this season
 }

--- a/model/week.go
+++ b/model/week.go
@@ -21,7 +21,7 @@ func (id WeekId) String() string {
 }
 
 type Week struct {
-	ID      WeekId
+	ID      WeekId `json:"id"`
 	DraftId DraftId
 	Date    time.Time
 	Note    string

--- a/model/weekly_matchup.go
+++ b/model/weekly_matchup.go
@@ -69,7 +69,7 @@ func teamMatchupFromRecord(wmtm *WeeklyMatchupTeamMatchup) *TeamMatchup {
 // during a Season's Schedule. The individual matchups are stored as separate
 // WeeklyMatchupTeamMatchup records rather than inline.
 type WeeklyMatchup struct {
-	ID       WeeklyMatchupId
+	ID       WeeklyMatchupId `json:"id"`
 	WeekId   WeekId   // Week that this WeeklyMatchup corresponds to, i.e. a particular date
 	SeasonId SeasonId // Season that this WeeklyMatchup corresponds to
 }


### PR DESCRIPTION
## Summary

Implements **#56** and **#57**, part of **#36** (SQLite database provider). These two tickets were implemented together because they share a reflection-mapper change.

## What changed

- **Migrations** (`database/migrations/0005–0016.sql`), one per table, following `docs/schema-conventions.md`:
  - #56: `season`, `season_commissioner`, `season_late_addition`, `season_team`, `team`, `team_assignment`, `team_rating`
  - #57: `schedule`, `schedule_matchup`, `weekly_matchup`, `weekly_matchup_team_matchup`, `week`
  - The former inline maps/slices (`Team.RatingsMap`, `Schedule.Matchups`, `WeeklyMatchup.Matchups`) were already normalized into the join-table records, so each table is flat scalar. `Team.Color` (a single value-struct) is stored as flattened `color_name`/`color_hex` columns.
- **`database/sqlite_db.go`** — extended the reflection-based column mapper:
  - `isTimeLike` handles `time.Time` and defined types over it (e.g. `Season.StartTime`) as RFC3339 `TEXT` (via `ConvertibleTo`).
  - `walkFields`/`walkFieldMap` flatten single value-struct fields into prefixed columns (e.g. `TeamColor` → `color_name`, `color_hex`).
- **Model json tags** — tagged the ID fields of `season`/`schedule`/`weekly_matchup`/`week` with `json:"id"` (and `Season.ScheduleID` with `json:"schedule_id"`) so the reflection mapper maps them to the primary-key column instead of the broken `i_d`/`schedule_i_d`.
- **`database/sqlite_season_schedule_roundtrip_test.go`** — field-by-field `Create → GetOne/GetAll → Update → Delete` round-trip tests for all twelve models.
- **`docs/schema-conventions.md`** — documented the nested value-struct flattening convention.

## Notes

- `team_rating` and `week` are persisted directly through the raw provider methods because their dynamic-validation prerequisites (`rating` → #60, `draft` → #58) land in later tickets whose tables aren't migrated yet. A second season used for FK-field update tests is also raw-created with a fabricated `draft_id` to avoid the `UNIQUE(draft_id)` collision. Comments explain each case.

## Verification

- `go build ./...`, `go vet ./...`, `go test ./... -count=1` — all green (includes the 12 new round-trip tests and the existing #55 tests).

Closes #56 · Closes #57