### PR TITLE
feat(db): SQLite schema + round-trip for Drafts (#58)

### DIFF
--- a/database/migrations/0017_create_drafts.sql
+++ b/database/migrations/0017_create_drafts.sql
@@ -1,0 +1,17 @@
+-- 0017_create_drafts.sql
+-- The draft table, matching the Draft record shape (model/draft.go).
+-- Table name equals record.Type() ("draft").
+--   id                  -> DraftId hex TEXT primary key
+--   name                -> TEXT
+--   owner               -> UserId hex TEXT
+--   format              -> FormatId hex TEXT
+--   completed_at        -> RFC3339 TEXT
+--   draft_order_pattern -> TEXT (DraftOrderPattern interface, stored by Name())
+CREATE TABLE draft (
+    id                  TEXT PRIMARY KEY,   -- DraftId hex string
+    name                TEXT NOT NULL,
+    owner               TEXT NOT NULL,      -- UserId hex string
+    format              TEXT NOT NULL,      -- FormatId hex string
+    completed_at        TEXT NOT NULL,      -- RFC3339
+    draft_order_pattern TEXT NOT NULL       -- DraftOrderPattern.Name()
+);

--- a/database/migrations/0018_create_draft_available_players.sql
+++ b/database/migrations/0018_create_draft_available_players.sql
@@ -1,0 +1,16 @@
+-- 0018_create_draft_available_players.sql
+-- The draft_available_player join table, matching the DraftAvailablePlayer
+-- record shape (model/draft_available_player.go).
+-- Table name equals record.Type() ("draft_available_player").
+--   id         -> RecordId hex TEXT primary key
+--   draft_id   -> DraftId hex TEXT
+--   player_id  -> UserId hex TEXT
+--   created_at -> RFC3339 TEXT
+--   updated_at -> RFC3339 TEXT
+CREATE TABLE draft_available_player (
+    id         TEXT PRIMARY KEY,   -- RecordId hex string
+    draft_id   TEXT NOT NULL,      -- DraftId hex string
+    player_id  TEXT NOT NULL,      -- UserId hex string
+    created_at TEXT NOT NULL,      -- RFC3339
+    updated_at TEXT NOT NULL       -- RFC3339
+);

--- a/database/migrations/0019_create_draft_captains.sql
+++ b/database/migrations/0019_create_draft_captains.sql
@@ -1,0 +1,20 @@
+-- 0019_create_draft_captains.sql
+-- The draft_captain join table, matching the DraftCaptain record shape
+-- (model/draft_captain.go).
+-- Table name equals record.Type() ("draft_captain").
+--   id          -> RecordId hex TEXT primary key
+--   draft_id    -> DraftId hex TEXT
+--   team_id     -> TeamId hex TEXT
+--   captain_id  -> UserId hex TEXT
+--   draft_order -> INTEGER
+--   created_at  -> RFC3339 TEXT
+--   updated_at  -> RFC3339 TEXT
+CREATE TABLE draft_captain (
+    id          TEXT PRIMARY KEY,   -- RecordId hex string
+    draft_id    TEXT NOT NULL,      -- DraftId hex string
+    team_id     TEXT NOT NULL,      -- TeamId hex string
+    captain_id  TEXT NOT NULL,      -- UserId hex string
+    draft_order INTEGER NOT NULL,
+    created_at  TEXT NOT NULL,      -- RFC3339
+    updated_at  TEXT NOT NULL       -- RFC3339
+);

--- a/database/migrations/0020_create_draft_formats.sql
+++ b/database/migrations/0020_create_draft_formats.sql
@@ -1,0 +1,14 @@
+-- 0020_create_draft_formats.sql
+-- The draft_format join table, matching the DraftFormat record shape
+-- (model/draft_format.go).
+-- Table name equals record.Type() ("draft_format").
+--   id        -> RecordId hex TEXT primary key
+--   draft_id  -> DraftId hex TEXT
+--   format_id -> FormatId hex TEXT
+-- One format per draft: UNIQUE(draft_id) mirrors DraftFormat.UniquenessEquivalent.
+CREATE TABLE draft_format (
+    id        TEXT PRIMARY KEY,   -- RecordId hex string
+    draft_id  TEXT NOT NULL,      -- DraftId hex string
+    format_id TEXT NOT NULL,      -- FormatId hex string
+    UNIQUE (draft_id)
+);

--- a/database/migrations/0021_create_draft_picks.sql
+++ b/database/migrations/0021_create_draft_picks.sql
@@ -1,0 +1,24 @@
+-- 0021_create_draft_picks.sql
+-- The draft_pick join table, matching the DraftPick record shape
+-- (model/draft_pick.go).
+-- Table name equals record.Type() ("draft_pick").
+--   id         -> RecordId hex TEXT primary key
+--   draft_id   -> DraftId hex TEXT
+--   team_id    -> TeamId hex TEXT
+--   user_id    -> UserId hex TEXT
+--   round      -> INTEGER
+--   pick       -> INTEGER
+--   rating     -> RatingId hex TEXT
+--   created_at -> RFC3339 TEXT
+--   updated_at -> RFC3339 TEXT
+CREATE TABLE draft_pick (
+    id         TEXT PRIMARY KEY,   -- RecordId hex string
+    draft_id   TEXT NOT NULL,      -- DraftId hex string
+    team_id    TEXT NOT NULL,      -- TeamId hex string
+    user_id    TEXT NOT NULL,      -- UserId hex string
+    round      INTEGER NOT NULL,
+    pick       INTEGER NOT NULL,
+    rating     TEXT NOT NULL,      -- RatingId hex string
+    created_at TEXT NOT NULL,      -- RFC3339
+    updated_at TEXT NOT NULL       -- RFC3339
+);

--- a/database/migrations/0022_create_draft_rating_cutoffs.sql
+++ b/database/migrations/0022_create_draft_rating_cutoffs.sql
@@ -1,0 +1,18 @@
+-- 0022_create_draft_rating_cutoffs.sql
+-- The draft_rating_cutoff join table, matching the DraftRatingCutoff record
+-- shape (model/draft_rating_cutoff.go). This is the normalized replacement for
+-- the former inline Draft.RatingCutoffs map (rating -> cutoff index).
+-- Table name equals record.Type() ("draft_rating_cutoff").
+--   id            -> RecordId hex TEXT primary key
+--   draft_id      -> DraftId hex TEXT
+--   rating_id     -> RatingId hex TEXT
+--   cutoff_index  -> INTEGER
+-- One cutoff per (draft, rating): UNIQUE(draft_id, rating_id) mirrors
+-- DraftRatingCutoff.UniquenessEquivalent.
+CREATE TABLE draft_rating_cutoff (
+    id           TEXT PRIMARY KEY,   -- RecordId hex string
+    draft_id     TEXT NOT NULL,      -- DraftId hex string
+    rating_id    TEXT NOT NULL,      -- RatingId hex string
+    cutoff_index INTEGER NOT NULL,
+    UNIQUE (draft_id, rating_id)
+);

--- a/database/migrations/0023_create_pre_draft_grades.sql
+++ b/database/migrations/0023_create_pre_draft_grades.sql
@@ -1,0 +1,21 @@
+-- 0023_create_pre_draft_grades.sql
+-- The pre_draft_grade table, matching the PreDraftGrade record shape
+-- (model/pre_draft_grade.go).
+-- Table name equals record.Type() ("pre_draft_grade").
+--   id        -> RecordId hex TEXT primary key
+--   player_id -> UserId hex TEXT
+--   draft_id  -> DraftId hex TEXT
+--   grader_id -> UserId hex TEXT
+--   modifier  -> INTEGER (PreDraftRatingModifier: 0 weak, 1 average, 2 strong)
+--   rating    -> RatingId hex TEXT
+-- One grade per (player, grader, draft): UNIQUE(player_id, grader_id, draft_id)
+-- mirrors PreDraftGrade.UniquenessEquivalent.
+CREATE TABLE pre_draft_grade (
+    id        TEXT PRIMARY KEY,   -- RecordId hex string
+    player_id TEXT NOT NULL,      -- UserId hex string
+    draft_id  TEXT NOT NULL,      -- DraftId hex string
+    grader_id TEXT NOT NULL,      -- UserId hex string
+    modifier  INTEGER NOT NULL,
+    rating    TEXT NOT NULL,      -- RatingId hex string
+    UNIQUE (player_id, grader_id, draft_id)
+);

--- a/database/sqlite_db.go
+++ b/database/sqlite_db.go
@@ -309,6 +309,17 @@ func scanRow(rows *sql.Rows, cols []string, record CrudRecord) error {
 			// column exists in the table but not on the struct; skip it
 			continue
 		}
+		if field.Kind() == reflect.Interface {
+			// Interface-valued field (e.g. Draft.DraftOrderPattern): let the
+			// record reconstruct the concrete value from its stored string.
+			if setter, ok := record.(InterfaceFieldSetter); ok {
+				if err := setter.SetInterfaceField(name, asString(raw[i])); err != nil {
+					return fmt.Errorf("column %q: %w", name, err)
+				}
+				continue
+			}
+			return fmt.Errorf("column %q: unsupported interface field %s", name, field.Type())
+		}
 		if err := setField(field, raw[i]); err != nil {
 			return fmt.Errorf("column %q: %w", name, err)
 		}
@@ -412,9 +423,37 @@ func encodeValue(field reflect.Value) (any, error) {
 			return ts.UTC().Format(time.RFC3339Nano), nil
 		}
 		return nil, fmt.Errorf("unsupported struct field %s", field.Type())
+	case reflect.Interface:
+		// Interface fields are persisted as a single TEXT column holding a
+		// stable string identity. Concrete values exposing Name() (e.g.
+		// model.DraftOrderPattern) are encoded by name; nil interfaces are
+		// stored as an empty string.
+		if field.IsNil() {
+			return "", nil
+		}
+		if n, ok := field.Interface().(StringKeyed); ok {
+			return n.Name(), nil
+		}
+		return nil, fmt.Errorf("unsupported interface field %s", field.Type())
 	default:
 		return nil, fmt.Errorf("unsupported field kind %s", field.Kind())
 	}
+}
+
+// StringKeyed is implemented by interface values whose concrete types expose a
+// stable string name (e.g. model.DraftOrderPattern). The SQLite mapper stores
+// such interface fields as a single TEXT column holding Name().
+type StringKeyed interface {
+	Name() string
+}
+
+// InterfaceFieldSetter is optionally implemented by CrudRecords that contain an
+// interface-valued field (e.g. Draft.DraftOrderPattern) persisted as a TEXT
+// column. On read, the mapper calls SetInterfaceField so the record can
+// reconstruct the concrete value from its stored string. It is needed because
+// the database package cannot import the model packages (import cycle).
+type InterfaceFieldSetter interface {
+	SetInterfaceField(field, value string) error
 }
 
 func setField(field reflect.Value, raw any) error {

--- a/database/sqlite_draft_roundtrip_test.go
+++ b/database/sqlite_draft_roundtrip_test.go
@@ -1,0 +1,506 @@
+package database_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"intraclub/database"
+	"intraclub/model"
+)
+
+// This file implements the #58 (Drafts) SQLite round-trip tests:
+// field-by-field losslessness across Create -> GetOne/GetAll -> Update -> Delete
+// on the SQLite provider for the draft, draft_available_player, draft_captain,
+// draft_format, draft_pick, draft_rating_cutoff, and pre_draft_grade tables.
+//
+// The Draft.RatingCutoffs inline map has already been normalized into the
+// draft_rating_cutoff join table (see model/draft.go), so the round-trip is
+// exercised on that child table rather than a map field.
+//
+// Records whose DynamicallyValid depends on tables that land in later model
+// tickets are persisted directly through the raw provider methods (which still
+// exercise the exact SQLite column mapping):
+//   - Draft requires a Format (table lands in #59)
+//   - DraftFormat requires a Format (#59)
+//   - DraftRatingCutoff requires a Rating (table lands in #60)
+//   - PreDraftGrade requires a Format (#59), a Rating (#60), and a non-empty
+//     available-player list
+//
+// The remaining records (draft_available_player, draft_captain, draft_pick) are
+// created through database.CreateOne, which also exercises static/dynamic
+// validation since all their referenced tables now exist.
+
+// createTestDraftRaw creates a Draft directly through the provider with a real
+// owner user but a fabricated Format (format table lands in #59).
+func createTestDraftRaw(t *testing.T, p database.Provider) *model.Draft {
+	t.Helper()
+	d := model.NewDraft()
+	d.Name = "Test Draft"
+	d.Owner = createTestUser(t, p).ID
+	d.Format = model.FormatId(database.NewRecordId()) // format table lands in #59
+	d.CompletedAt = time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	d.DraftOrderPattern = model.DraftOrderPatternSnake{}
+	if _, err := p.Create(context.Background(), d); err != nil {
+		t.Fatalf("raw create draft: %v", err)
+	}
+	return d
+}
+
+// ---- #58: Drafts ----
+
+func TestDraftRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	p := newSqliteProvider(t)
+
+	d := model.NewDraft()
+	d.Name = "Intraclub 2025"
+	d.Owner = createTestUser(t, p).ID
+	d.Format = model.FormatId(database.NewRecordId()) // format table lands in #59
+	d.CompletedAt = time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	d.DraftOrderPattern = model.DraftOrderPatternLastPickDouble{}
+	// Created directly through the provider because Draft.DynamicallyValid
+	// requires a Format record, whose table is not migrated yet (#59).
+	// p.Create mutates d in place, assigning its RecordId.
+	if _, err := p.Create(ctx, d); err != nil {
+		t.Fatalf("Create(draft): %v", err)
+	}
+	if d.GetId() == database.InvalidRecordId {
+		t.Fatal("Create(draft) did not assign an ID")
+	}
+
+	got, exists, err := database.GetOneById(ctx, p, &model.Draft{}, d.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(draft): %v", err)
+	}
+	if !exists {
+		t.Fatal("GetOneById(draft): record not found")
+	}
+	if got.Name != d.Name || got.Owner != d.Owner ||
+		got.Format != d.Format || !got.CompletedAt.Equal(d.CompletedAt) ||
+		got.DraftOrderPattern.Name() != "Last pick double" {
+		t.Fatalf("draft round-trip mismatch:\n  got  %+v\n  want %+v", got, d)
+	}
+
+	all, err := database.GetAll[*model.Draft](ctx, p)
+	if err != nil {
+		t.Fatalf("GetAll(draft): %v", err)
+	}
+	if len(all) != 1 || all[0].ID != d.ID {
+		t.Fatalf("GetAll(draft): got %d records, want 1 matching the created draft", len(all))
+	}
+
+	d.Name = "Renamed Draft"
+	d.DraftOrderPattern = model.DraftOrderPatternStraightUp{}
+	d.CompletedAt = time.Date(2025, 1, 2, 13, 0, 0, 0, time.UTC)
+	if err := p.Update(ctx, d); err != nil {
+		t.Fatalf("Update(draft): %v", err)
+	}
+	got2, _, err := database.GetOneById(ctx, p, &model.Draft{}, d.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(draft) after update: %v", err)
+	}
+	if got2.Name != "Renamed Draft" || got2.DraftOrderPattern.Name() != "Straight-up" ||
+		!got2.CompletedAt.Equal(d.CompletedAt) {
+		t.Fatalf("draft update not persisted, got %+v", got2)
+	}
+
+	if err := p.Delete(ctx, d); err != nil {
+		t.Fatalf("Delete(draft): %v", err)
+	}
+	_, exists, err = database.GetOneById(ctx, p, &model.Draft{}, d.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(draft) after delete: %v", err)
+	}
+	if exists {
+		t.Fatal("draft should have been deleted")
+	}
+}
+
+func TestDraftAvailablePlayerRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	p := newSqliteProvider(t)
+
+	draft := createTestDraftRaw(t, p)
+	player := createTestUser(t, p)
+	dap := &model.DraftAvailablePlayer{
+		DraftId:  draft.ID,
+		PlayerId: player.ID,
+	}
+	created, err := database.CreateOne(ctx, p, dap)
+	if err != nil {
+		t.Fatalf("CreateOne(draft_available_player): %v", err)
+	}
+	if created.GetId() == database.InvalidRecordId {
+		t.Fatal("CreateOne(draft_available_player) did not assign an ID")
+	}
+
+	got, exists, err := database.GetOneById(ctx, p, &model.DraftAvailablePlayer{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(draft_available_player): %v", err)
+	}
+	if !exists {
+		t.Fatal("GetOneById(draft_available_player): record not found")
+	}
+	if got.DraftId != created.DraftId || got.PlayerId != created.PlayerId ||
+		!got.CreatedAt.Equal(created.CreatedAt) || !got.UpdatedAt.Equal(created.UpdatedAt) {
+		t.Fatalf("draft_available_player round-trip mismatch:\n  got  %+v\n  want %+v", got, created)
+	}
+
+	all, err := database.GetAll[*model.DraftAvailablePlayer](ctx, p)
+	if err != nil {
+		t.Fatalf("GetAll(draft_available_player): %v", err)
+	}
+	if len(all) != 1 || all[0].ID != created.ID {
+		t.Fatalf("GetAll(draft_available_player): got %d records, want 1", len(all))
+	}
+
+	player2 := createTestUser(t, p)
+	created.PlayerId = player2.ID
+	if err := database.UpdateOne(ctx, p, created); err != nil {
+		t.Fatalf("UpdateOne(draft_available_player): %v", err)
+	}
+	got2, _, err := database.GetOneById(ctx, p, &model.DraftAvailablePlayer{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(draft_available_player) after update: %v", err)
+	}
+	if got2.PlayerId != player2.ID {
+		t.Fatalf("draft_available_player update not persisted, got %+v", got2)
+	}
+
+	if _, _, err := database.DeleteOneById(ctx, p, &model.DraftAvailablePlayer{}, created.GetId()); err != nil {
+		t.Fatalf("DeleteOneById(draft_available_player): %v", err)
+	}
+	_, exists, err = database.GetOneById(ctx, p, &model.DraftAvailablePlayer{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(draft_available_player) after delete: %v", err)
+	}
+	if exists {
+		t.Fatal("draft_available_player should have been deleted")
+	}
+}
+
+func TestDraftCaptainRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	p := newSqliteProvider(t)
+
+	draft := createTestDraftRaw(t, p)
+	captain := createTestUser(t, p)
+	team := model.NewDefaultTeam(captain.ID, "Captains")
+	team.Color = model.Blue
+	team, err := database.CreateOne(ctx, p, team)
+	if err != nil {
+		t.Fatalf("CreateOne(team): %v", err)
+	}
+
+	dc := &model.DraftCaptain{
+		DraftId:    draft.ID,
+		TeamId:     team.ID,
+		CaptainId:  captain.ID,
+		DraftOrder: 0,
+	}
+	created, err := database.CreateOne(ctx, p, dc)
+	if err != nil {
+		t.Fatalf("CreateOne(draft_captain): %v", err)
+	}
+	if created.GetId() == database.InvalidRecordId {
+		t.Fatal("CreateOne(draft_captain) did not assign an ID")
+	}
+
+	got, exists, err := database.GetOneById(ctx, p, &model.DraftCaptain{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(draft_captain): %v", err)
+	}
+	if !exists {
+		t.Fatal("GetOneById(draft_captain): record not found")
+	}
+	if got.DraftId != created.DraftId || got.TeamId != created.TeamId ||
+		got.CaptainId != created.CaptainId || got.DraftOrder != created.DraftOrder ||
+		!got.CreatedAt.Equal(created.CreatedAt) || !got.UpdatedAt.Equal(created.UpdatedAt) {
+		t.Fatalf("draft_captain round-trip mismatch:\n  got  %+v\n  want %+v", got, created)
+	}
+
+	all, err := database.GetAll[*model.DraftCaptain](ctx, p)
+	if err != nil {
+		t.Fatalf("GetAll(draft_captain): %v", err)
+	}
+	if len(all) != 1 || all[0].ID != created.ID {
+		t.Fatalf("GetAll(draft_captain): got %d records, want 1", len(all))
+	}
+
+	created.DraftOrder = 2
+	if err := database.UpdateOne(ctx, p, created); err != nil {
+		t.Fatalf("UpdateOne(draft_captain): %v", err)
+	}
+	got2, _, err := database.GetOneById(ctx, p, &model.DraftCaptain{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(draft_captain) after update: %v", err)
+	}
+	if got2.DraftOrder != 2 {
+		t.Fatalf("draft_captain update not persisted, got %+v", got2)
+	}
+
+	if _, _, err := database.DeleteOneById(ctx, p, &model.DraftCaptain{}, created.GetId()); err != nil {
+		t.Fatalf("DeleteOneById(draft_captain): %v", err)
+	}
+	_, exists, err = database.GetOneById(ctx, p, &model.DraftCaptain{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(draft_captain) after delete: %v", err)
+	}
+	if exists {
+		t.Fatal("draft_captain should have been deleted")
+	}
+}
+
+func TestDraftFormatRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	p := newSqliteProvider(t)
+
+	draft := createTestDraftRaw(t, p)
+	df := &model.DraftFormat{
+		DraftId:  draft.ID,
+		FormatId: model.FormatId(database.NewRecordId()), // format table lands in #59
+	}
+	// Created directly through the provider because DraftFormat.DynamicallyValid
+	// requires a Format record, whose table is not migrated yet (#59).
+	if _, err := p.Create(ctx, df); err != nil {
+		t.Fatalf("Create(draft_format): %v", err)
+	}
+
+	got, exists, err := database.GetOneById(ctx, p, &model.DraftFormat{}, df.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(draft_format): %v", err)
+	}
+	if !exists {
+		t.Fatal("GetOneById(draft_format): record not found")
+	}
+	if got.DraftId != df.DraftId || got.FormatId != df.FormatId {
+		t.Fatalf("draft_format round-trip mismatch:\n  got  %+v\n  want %+v", got, df)
+	}
+
+	all, err := database.GetAll[*model.DraftFormat](ctx, p)
+	if err != nil {
+		t.Fatalf("GetAll(draft_format): %v", err)
+	}
+	if len(all) != 1 || all[0].ID != df.ID {
+		t.Fatalf("GetAll(draft_format): got %d records, want 1", len(all))
+	}
+
+	df.FormatId = model.FormatId(database.NewRecordId())
+	if err := p.Update(ctx, df); err != nil {
+		t.Fatalf("Update(draft_format): %v", err)
+	}
+	got2, _, err := database.GetOneById(ctx, p, &model.DraftFormat{}, df.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(draft_format) after update: %v", err)
+	}
+	if got2.FormatId != df.FormatId {
+		t.Fatalf("draft_format update not persisted, got %+v", got2)
+	}
+
+	if err := p.Delete(ctx, df); err != nil {
+		t.Fatalf("Delete(draft_format): %v", err)
+	}
+	_, exists, err = database.GetOneById(ctx, p, &model.DraftFormat{}, df.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(draft_format) after delete: %v", err)
+	}
+	if exists {
+		t.Fatal("draft_format should have been deleted")
+	}
+}
+
+func TestDraftPickRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	p := newSqliteProvider(t)
+
+	draft := createTestDraftRaw(t, p)
+	team := createTestTeam(t, p)
+	user := createTestUser(t, p)
+	dp := &model.DraftPick{
+		DraftId: draft.ID,
+		TeamId:  team.ID,
+		UserId:  user.ID,
+		Round:   1,
+		Pick:    1,
+		Rating:  model.RatingId(database.NewRecordId()), // rating table lands in #60
+	}
+	created, err := database.CreateOne(ctx, p, dp)
+	if err != nil {
+		t.Fatalf("CreateOne(draft_pick): %v", err)
+	}
+	if created.GetId() == database.InvalidRecordId {
+		t.Fatal("CreateOne(draft_pick) did not assign an ID")
+	}
+
+	got, exists, err := database.GetOneById(ctx, p, &model.DraftPick{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(draft_pick): %v", err)
+	}
+	if !exists {
+		t.Fatal("GetOneById(draft_pick): record not found")
+	}
+	if got.DraftId != created.DraftId || got.TeamId != created.TeamId ||
+		got.UserId != created.UserId || got.Round != created.Round ||
+		got.Pick != created.Pick || got.Rating != created.Rating ||
+		!got.CreatedAt.Equal(created.CreatedAt) || !got.UpdatedAt.Equal(created.UpdatedAt) {
+		t.Fatalf("draft_pick round-trip mismatch:\n  got  %+v\n  want %+v", got, created)
+	}
+
+	all, err := database.GetAll[*model.DraftPick](ctx, p)
+	if err != nil {
+		t.Fatalf("GetAll(draft_pick): %v", err)
+	}
+	if len(all) != 1 || all[0].ID != created.ID {
+		t.Fatalf("GetAll(draft_pick): got %d records, want 1", len(all))
+	}
+
+	created.Pick = 4
+	created.Round = 2
+	if err := database.UpdateOne(ctx, p, created); err != nil {
+		t.Fatalf("UpdateOne(draft_pick): %v", err)
+	}
+	got2, _, err := database.GetOneById(ctx, p, &model.DraftPick{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(draft_pick) after update: %v", err)
+	}
+	if got2.Pick != 4 || got2.Round != 2 {
+		t.Fatalf("draft_pick update not persisted, got %+v", got2)
+	}
+
+	if _, _, err := database.DeleteOneById(ctx, p, &model.DraftPick{}, created.GetId()); err != nil {
+		t.Fatalf("DeleteOneById(draft_pick): %v", err)
+	}
+	_, exists, err = database.GetOneById(ctx, p, &model.DraftPick{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(draft_pick) after delete: %v", err)
+	}
+	if exists {
+		t.Fatal("draft_pick should have been deleted")
+	}
+}
+
+func TestDraftRatingCutoffRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	p := newSqliteProvider(t)
+
+	draft := createTestDraftRaw(t, p)
+	drc := &model.DraftRatingCutoff{
+		DraftId:     draft.ID,
+		RatingId:    model.RatingId(database.NewRecordId()), // rating table lands in #60
+		CutoffIndex: 8,
+	}
+	// Created directly through the provider because DraftRatingCutoff.DynamicallyValid
+	// requires a Rating record, whose table is not migrated yet (#60).
+	if _, err := p.Create(ctx, drc); err != nil {
+		t.Fatalf("Create(draft_rating_cutoff): %v", err)
+	}
+
+	got, exists, err := database.GetOneById(ctx, p, &model.DraftRatingCutoff{}, drc.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(draft_rating_cutoff): %v", err)
+	}
+	if !exists {
+		t.Fatal("GetOneById(draft_rating_cutoff): record not found")
+	}
+	if got.DraftId != drc.DraftId || got.RatingId != drc.RatingId ||
+		got.CutoffIndex != drc.CutoffIndex {
+		t.Fatalf("draft_rating_cutoff round-trip mismatch:\n  got  %+v\n  want %+v", got, drc)
+	}
+
+	all, err := database.GetAll[*model.DraftRatingCutoff](ctx, p)
+	if err != nil {
+		t.Fatalf("GetAll(draft_rating_cutoff): %v", err)
+	}
+	if len(all) != 1 || all[0].ID != drc.ID {
+		t.Fatalf("GetAll(draft_rating_cutoff): got %d records, want 1", len(all))
+	}
+
+	drc.CutoffIndex = 16
+	if err := p.Update(ctx, drc); err != nil {
+		t.Fatalf("Update(draft_rating_cutoff): %v", err)
+	}
+	got2, _, err := database.GetOneById(ctx, p, &model.DraftRatingCutoff{}, drc.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(draft_rating_cutoff) after update: %v", err)
+	}
+	if got2.CutoffIndex != 16 {
+		t.Fatalf("draft_rating_cutoff update not persisted, got %+v", got2)
+	}
+
+	if err := p.Delete(ctx, drc); err != nil {
+		t.Fatalf("Delete(draft_rating_cutoff): %v", err)
+	}
+	_, exists, err = database.GetOneById(ctx, p, &model.DraftRatingCutoff{}, drc.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(draft_rating_cutoff) after delete: %v", err)
+	}
+	if exists {
+		t.Fatal("draft_rating_cutoff should have been deleted")
+	}
+}
+
+func TestPreDraftGradeRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	p := newSqliteProvider(t)
+
+	draft := createTestDraftRaw(t, p)
+	player := createTestUser(t, p)
+	grader := createTestUser(t, p)
+	grade := &model.PreDraftGrade{
+		PlayerId: player.ID,
+		DraftId:  draft.ID,
+		GraderId: grader.ID,
+		Modifier: model.StrongModifier,
+		Rating:   model.RatingId(database.NewRecordId()), // rating table lands in #60
+	}
+	// Created directly through the provider because PreDraftGrade.DynamicallyValid
+	// requires Format (#59) and Rating (#60) records and a non-empty draft list.
+	if _, err := p.Create(ctx, grade); err != nil {
+		t.Fatalf("Create(pre_draft_grade): %v", err)
+	}
+
+	got, exists, err := database.GetOneById(ctx, p, &model.PreDraftGrade{}, grade.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(pre_draft_grade): %v", err)
+	}
+	if !exists {
+		t.Fatal("GetOneById(pre_draft_grade): record not found")
+	}
+	if got.PlayerId != grade.PlayerId || got.DraftId != grade.DraftId ||
+		got.GraderId != grade.GraderId || got.Modifier != grade.Modifier ||
+		got.Rating != grade.Rating {
+		t.Fatalf("pre_draft_grade round-trip mismatch:\n  got  %+v\n  want %+v", got, grade)
+	}
+
+	all, err := database.GetAll[*model.PreDraftGrade](ctx, p)
+	if err != nil {
+		t.Fatalf("GetAll(pre_draft_grade): %v", err)
+	}
+	if len(all) != 1 || all[0].ID != grade.ID {
+		t.Fatalf("GetAll(pre_draft_grade): got %d records, want 1", len(all))
+	}
+
+	grade.Modifier = model.WeakModifier
+	if err := p.Update(ctx, grade); err != nil {
+		t.Fatalf("Update(pre_draft_grade): %v", err)
+	}
+	got2, _, err := database.GetOneById(ctx, p, &model.PreDraftGrade{}, grade.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(pre_draft_grade) after update: %v", err)
+	}
+	if got2.Modifier != model.WeakModifier {
+		t.Fatalf("pre_draft_grade update not persisted, got %+v", got2)
+	}
+
+	if err := p.Delete(ctx, grade); err != nil {
+		t.Fatalf("Delete(pre_draft_grade): %v", err)
+	}
+	_, exists, err = database.GetOneById(ctx, p, &model.PreDraftGrade{}, grade.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(pre_draft_grade) after delete: %v", err)
+	}
+	if exists {
+		t.Fatal("pre_draft_grade should have been deleted")
+	}
+}

--- a/docs/schema-conventions.md
+++ b/docs/schema-conventions.md
@@ -75,6 +75,13 @@ fields and prefixes each with the parent column name, e.g. `Team.Color`
 `team` table. `time.Time` and defined types over it (e.g. `StartTime`) are
 stored as single RFC3339 `TEXT` columns, never flattened.
 
+An **interface-valued field** (e.g. `Draft.DraftOrderPattern`) is stored as a
+single `TEXT` column holding the concrete value's stable `Name()` string. On
+read, the record reconstructs the concrete value through the optional
+`database.InterfaceFieldSetter` hook (`SetInterfaceField`), since the database
+package cannot import the model packages. Only `Draft` currently has such a
+field.
+
 ## Naming
 
 - Table name = `record.Type()` (snake_case plural of the model, e.g. `users`,

--- a/model/draft.go
+++ b/model/draft.go
@@ -102,6 +102,28 @@ func NewDraft() *Draft {
 	}
 }
 
+// SetInterfaceField reconstructs the DraftOrderPattern interface field from its
+// persisted string name. The SQLite mapper calls this for interface-valued
+// columns (see database.InterfaceFieldSetter), since it cannot reflect on the
+// concrete type across the model/database package boundary.
+func (d *Draft) SetInterfaceField(field, value string) error {
+	if field != "draft_order_pattern" {
+		return fmt.Errorf("unsupported interface field %q", field)
+	}
+	// A nil interface is persisted as an empty string; leave the current
+	// pattern in place (NewDraft defaults to DraftOrderPatternSnake) rather
+	// than failing to reconstruct it.
+	if value == "" {
+		return nil
+	}
+	pattern, err := DraftOrderPatternFromString(value)
+	if err != nil {
+		return err
+	}
+	d.DraftOrderPattern = pattern
+	return nil
+}
+
 func (d *Draft) EditableBy(ctx context.Context, db database.Provider) []database.UserId {
 	return []database.UserId{d.Owner}
 }

--- a/model/pre_draft_grade.go
+++ b/model/pre_draft_grade.go
@@ -21,7 +21,7 @@ func (p PreDraftRatingModifier) Int() int {
 }
 
 type PreDraftGrade struct {
-	ID       database.RecordId      // unique ID of this PreDraftGrade
+	ID       database.RecordId      `json:"id"` // unique ID of this PreDraftGrade
 	PlayerId database.UserId        // ID of the User who is being graded
 	DraftId  DraftId                // ID of the Draft that this PreDraftGrade pertains to
 	GraderId database.UserId        // ID of the User providing a Grade


### PR DESCRIPTION
## Summary
Implements #58 — the fully-normalized SQLite schema + field-level round-trip tests for the Draft model family, following the established pattern from #55/#56/#57.

## Changes
- **7 new migrations** (`database/migrations/0017`–`0023`) for `draft`, `draft_available_player`, `draft_captain`, `draft_format`, `draft_pick`, `draft_rating_cutoff`, and `pre_draft_grade`, per `docs/schema-conventions.md` (hex `TEXT` PKs, RFC3339 timestamps, `INTEGER` ints/enums, `UNIQUE` mirrors of each model's `UniquenessEquivalent`).
  - The former inline `Draft.RatingCutoffs` map was already normalized into the `draft_rating_cutoff` join table (`model/draft.go`), so the round-trip exercises that child table rather than a map field.
- **Reflection mapper** (`database/sqlite_db.go`): persist interface-valued fields (e.g. `Draft.DraftOrderPattern`) as a single `TEXT` column holding `Name()`, reconstructing the concrete value on read via a new optional `database.InterfaceFieldSetter` hook (avoids the model↔database import cycle). Documented in `docs/schema-conventions.md`.
- **`model/pre_draft_grade.go`**: tag `ID` with `json:"id"` so reflection maps it to the primary-key column instead of snake_cased `i_d`.
- **Round-trip tests** (`database/sqlite_draft_roundtrip_test.go`): `Create -> GetOne/GetAll -> Update -> Delete` field-by-field losslessness for all seven models. `draft`, `draft_format`, `draft_rating_cutoff`, and `pre_draft_grade` are persisted through the raw provider because their dynamic-validation prerequisites (format #59, rating #60) land in later tickets; the rest go through `database.CreateOne` to also exercise validation.

## Verification
- `go build ./...` clean
- `go vet ./database/ ./model/` clean
- `go test ./...` green, including the 7 new draft round-trip tests

Closes #58