### PR TITLE
feat(db): SQLite schema + round-trip for formats, rulesets & facilities (#59)

### DIFF
--- a/database/migrations/0024_create_formats.sql
+++ b/database/migrations/0024_create_formats.sql
@@ -1,0 +1,15 @@
+-- 0024_create_formats.sql
+-- The format table, matching the Format record shape (model/format.go).
+-- Table name equals record.Type() ("format").
+--   id      -> FormatId hex TEXT primary key
+--   user_id -> UserId hex TEXT
+--   name    -> TEXT
+--
+-- Format.PossibleRatings was normalized into the format_rating join table
+-- (0025) and Format.Lines into the format_line join table (0026); neither
+-- inline slice is part of this table.
+CREATE TABLE format (
+    id      TEXT PRIMARY KEY,   -- FormatId hex string
+    user_id TEXT NOT NULL,      -- UserId hex string
+    name    TEXT NOT NULL
+);

--- a/database/migrations/0025_create_format_ratings.sql
+++ b/database/migrations/0025_create_format_ratings.sql
@@ -1,0 +1,19 @@
+-- 0025_create_format_ratings.sql
+-- The format_rating join table, matching the FormatRating record shape
+-- (model/format_rating.go). This is the normalized replacement for the former
+-- inline Format.PossibleRatings slice, preserving order via RatingIndex.
+-- Table name equals record.Type() ("format_rating").
+--   id           -> RecordId hex TEXT primary key
+--   format_id    -> FormatId hex TEXT
+--   rating_id    -> RatingId hex TEXT
+--   rating_index -> INTEGER (position in the possible-ratings list, highest
+--                            to lowest skill)
+-- One rating per format: UNIQUE(format_id, rating_id) mirrors
+-- FormatRating.UniquenessEquivalent.
+CREATE TABLE format_rating (
+    id           TEXT PRIMARY KEY,   -- RecordId hex string
+    format_id    TEXT NOT NULL,      -- FormatId hex string
+    rating_id    TEXT NOT NULL,      -- RatingId hex string
+    rating_index INTEGER NOT NULL,   -- ordering within the format
+    UNIQUE (format_id, rating_id)
+);

--- a/database/migrations/0026_create_format_lines.sql
+++ b/database/migrations/0026_create_format_lines.sql
@@ -1,0 +1,20 @@
+-- 0026_create_format_lines.sql
+-- The format_line join table, matching the FormatLine record shape
+-- (model/format_line.go). This is the normalized replacement for the former
+-- inline Format.Lines slice, preserving order via FormatIndex.
+-- Table name equals record.Type() ("format_line").
+--   id              -> RecordId hex TEXT primary key
+--   format_id       -> FormatId hex TEXT
+--   format_index    -> INTEGER (position of the line within the format)
+--   player_1_rating -> RatingId hex TEXT
+--   player_2_rating -> RatingId hex TEXT
+-- One line per (format, index): UNIQUE(format_id, format_index) mirrors
+-- FormatLine.UniquenessEquivalent.
+CREATE TABLE format_line (
+    id              TEXT PRIMARY KEY,   -- RecordId hex string
+    format_id       TEXT NOT NULL,      -- FormatId hex string
+    format_index    INTEGER NOT NULL,   -- line position within the format
+    player_1_rating TEXT NOT NULL,      -- RatingId hex string
+    player_2_rating TEXT NOT NULL,      -- RatingId hex string
+    UNIQUE (format_id, format_index)
+);

--- a/database/migrations/0027_create_rulesets.sql
+++ b/database/migrations/0027_create_rulesets.sql
@@ -1,0 +1,17 @@
+-- 0027_create_rulesets.sql
+-- The ruleset table, matching the Ruleset record shape (model/ruleset.go).
+-- Table name equals record.Type() ("ruleset").
+--   id           -> RulesetId hex TEXT primary key
+--   name         -> TEXT
+--   revision     -> INTEGER
+--   superseded_by -> RulesetId hex TEXT (0 when not archived)
+--   date         -> RFC3339 TEXT
+--   owner        -> UserId hex TEXT
+CREATE TABLE ruleset (
+    id            TEXT PRIMARY KEY,   -- RulesetId hex string
+    name          TEXT NOT NULL,
+    revision      INTEGER NOT NULL,
+    superseded_by TEXT NOT NULL,      -- RulesetId hex string
+    date          TEXT NOT NULL,      -- RFC3339
+    owner         TEXT NOT NULL       -- UserId hex string
+);

--- a/database/migrations/0028_create_rule_sections.sql
+++ b/database/migrations/0028_create_rule_sections.sql
@@ -1,0 +1,21 @@
+-- 0028_create_rule_sections.sql
+-- The rule_section table, matching the RuleSection record shape
+-- (model/ruleset.go). Table name equals record.Type() ("rule_section").
+-- The primary key is the record's own hex RuleSectionId (mapped via GetId /
+-- SetId). RuleSection.ID carries the JSON tag "section_id", so the reflection
+-- mapper also emits a section_id column holding the same value (see
+-- docs/schema-conventions.md); both are present so insert/scan round-trips.
+--   id          -> RuleSectionId hex TEXT primary key
+--   section_id  -> RuleSectionId hex TEXT (JSON-tagged alias of the id)
+--   parent      -> RulesetId hex TEXT
+--   title       -> TEXT
+--   markdown    -> TEXT
+--   owner       -> UserId hex TEXT
+CREATE TABLE rule_section (
+    id         TEXT PRIMARY KEY,   -- RuleSectionId hex string
+    section_id TEXT NOT NULL,      -- RuleSectionId hex string (json "section_id")
+    parent     TEXT NOT NULL,      -- RulesetId hex string
+    title      TEXT NOT NULL,
+    markdown   TEXT NOT NULL,
+    owner      TEXT NOT NULL       -- UserId hex string
+);

--- a/database/migrations/0029_create_ruleset_sections.sql
+++ b/database/migrations/0029_create_ruleset_sections.sql
@@ -1,0 +1,17 @@
+-- 0029_create_ruleset_sections.sql
+-- The ruleset_section join table, matching the RulesetSection record shape
+-- (model/ruleset_section.go). Table name equals record.Type() ("ruleset_section").
+--   id            -> RecordId hex TEXT primary key
+--   ruleset_id    -> RulesetId hex TEXT
+--   section_id    -> RuleSectionId hex TEXT
+--   section_index -> INTEGER (ordering of sections within the ruleset)
+--   created_at    -> RFC3339 TEXT
+--   updated_at    -> RFC3339 TEXT
+CREATE TABLE ruleset_section (
+    id            TEXT PRIMARY KEY,   -- RecordId hex string
+    ruleset_id    TEXT NOT NULL,      -- RulesetId hex string
+    section_id    TEXT NOT NULL,      -- RuleSectionId hex string
+    section_index INTEGER NOT NULL,   -- section ordering within the ruleset
+    created_at    TEXT NOT NULL,      -- RFC3339
+    updated_at    TEXT NOT NULL       -- RFC3339
+);

--- a/database/migrations/0030_create_scoring_structures.sql
+++ b/database/migrations/0030_create_scoring_structures.sql
@@ -1,0 +1,23 @@
+-- 0030_create_scoring_structures.sql
+-- The scoring_structure table, matching the ScoringStructure record shape
+-- (model/scoring_structure.go). Table name equals record.Type() ("scoring_structure").
+--   id                              -> ScoringStructureId hex TEXT primary key
+--   owner                           -> UserId hex TEXT
+--   name                            -> TEXT
+--   win_condition_counting_type     -> INTEGER (ScoreCountingType enum)
+--   win_condition_win_threshold     -> INTEGER (nested WinCondition flattened)
+--   win_condition_must_win_by       -> INTEGER
+--   win_condition_instant_win_threshold -> INTEGER
+--
+-- ScoringStructure.SecondaryScoringStructures was normalized into the
+-- scoring_structure_secondary join table (0031); the inline slice is not part
+-- of this table.
+CREATE TABLE scoring_structure (
+    id                                 TEXT PRIMARY KEY,   -- ScoringStructureId hex string
+    owner                              TEXT NOT NULL,      -- UserId hex string
+    name                               TEXT NOT NULL,
+    win_condition_counting_type        INTEGER NOT NULL,  -- ScoreCountingType enum
+    win_condition_win_threshold        INTEGER NOT NULL,  -- WinCondition.WinThreshold
+    win_condition_must_win_by          INTEGER NOT NULL,  -- WinCondition.MustWinBy
+    win_condition_instant_win_threshold INTEGER NOT NULL  -- WinCondition.InstantWinThreshold
+);

--- a/database/migrations/0031_create_scoring_structure_secondaries.sql
+++ b/database/migrations/0031_create_scoring_structure_secondaries.sql
@@ -1,0 +1,19 @@
+-- 0031_create_scoring_structure_secondaries.sql
+-- The scoring_structure_secondary join table, matching the
+-- ScoringStructureSecondary record shape (model/scoring_structure_secondary.go).
+-- This is the normalized replacement for the former inline
+-- ScoringStructure.SecondaryScoringStructures slice, preserving order via
+-- SecondaryIndex. Table name equals record.Type() ("scoring_structure_secondary").
+--   id                               -> RecordId hex TEXT primary key
+--   scoring_structure_id             -> ScoringStructureId hex TEXT
+--   secondary_scoring_structure_id   -> ScoringStructureId hex TEXT
+--   secondary_index                  -> INTEGER (position within the secondary list)
+-- One secondary per (structure, index): UNIQUE(scoring_structure_id,
+-- secondary_index) mirrors ScoringStructureSecondary.UniquenessEquivalent.
+CREATE TABLE scoring_structure_secondary (
+    id                             TEXT PRIMARY KEY,   -- RecordId hex string
+    scoring_structure_id           TEXT NOT NULL,      -- ScoringStructureId hex string
+    secondary_scoring_structure_id TEXT NOT NULL,      -- ScoringStructureId hex string
+    secondary_index                INTEGER NOT NULL,   -- position within the secondary list
+    UNIQUE (scoring_structure_id, secondary_index)
+);

--- a/database/migrations/0032_create_playoff_structures.sql
+++ b/database/migrations/0032_create_playoff_structures.sql
@@ -1,0 +1,13 @@
+-- 0032_create_playoff_structures.sql
+-- The playoff_structure table, matching the PlayoffStructure record shape
+-- (model/playoff_structure.go). Table name equals record.Type() ("playoff_structure").
+--   id              -> PlayoffStructureId hex TEXT primary key
+--   user_id         -> UserId hex TEXT
+--   byes            -> INTEGER
+--   number_of_teams -> INTEGER
+CREATE TABLE playoff_structure (
+    id              TEXT PRIMARY KEY,   -- PlayoffStructureId hex string
+    user_id         TEXT NOT NULL,      -- UserId hex string
+    byes            INTEGER NOT NULL,
+    number_of_teams INTEGER NOT NULL
+);

--- a/database/migrations/0033_create_facilities.sql
+++ b/database/migrations/0033_create_facilities.sql
@@ -1,0 +1,17 @@
+-- 0033_create_facilities.sql
+-- The facility table, matching the Facility record shape (model/facility.go).
+-- Table name equals record.Type() ("facility").
+--   id            -> FacilityId hex TEXT primary key
+--   user_id       -> UserId hex TEXT
+--   name          -> TEXT
+--   address       -> TEXT
+--   courts        -> INTEGER (Facility.NumberOfCourts)
+--   layout_photo  -> PhotoId hex TEXT
+CREATE TABLE facility (
+    id            TEXT PRIMARY KEY,   -- FacilityId hex string
+    user_id       TEXT NOT NULL,      -- UserId hex string
+    name          TEXT NOT NULL,
+    address       TEXT NOT NULL,
+    courts        INTEGER NOT NULL,
+    layout_photo  TEXT NOT NULL       -- PhotoId hex string
+);

--- a/database/sqlite_format_ruleset_roundtrip_test.go
+++ b/database/sqlite_format_ruleset_roundtrip_test.go
@@ -1,0 +1,722 @@
+package database_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"intraclub/database"
+	"intraclub/model"
+)
+
+// This file implements the #59 (Formats, rulesets & facilities) SQLite
+// round-trip tests: field-by-field losslessness across
+// Create -> GetOne/GetAll -> Update -> Delete on the SQLite provider for the
+// format, format_rating, format_line, ruleset, rule_section, ruleset_section,
+// scoring_structure, scoring_structure_secondary, playoff_structure, and
+// facility tables.
+//
+// A few records are persisted directly through the raw provider methods (which
+// still exercise the exact SQLite column mapping) because their DynamicallyValid
+// depends on tables that land in later model tickets:
+//   - Format requires Rating records (rating table lands in #60)
+//   - FormatRating requires a Rating (#60)
+//   - FormatLine requires Rating records (#60)
+//
+// Ruleset uses raw provider update because its PreUpdate hook rejects direct
+// modification (use Ruleset.Amend instead); the raw update still exercises the
+// exact SQLite column mapping.
+
+// ---- #59: Formats ----
+
+func TestFormatRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	p := newSqliteProvider(t)
+
+	f := model.NewFormat()
+	f.UserId = createTestUser(t, p).ID
+	f.Name = "Men's Intraclub 1/2/3"
+	// Created directly through the provider because Format.DynamicallyValid
+	// requires Rating records, whose table is not migrated yet (#60).
+	if _, err := p.Create(ctx, f); err != nil {
+		t.Fatalf("Create(format): %v", err)
+	}
+	if f.GetId() == database.InvalidRecordId {
+		t.Fatal("Create(format) did not assign an ID")
+	}
+
+	got, exists, err := database.GetOneById(ctx, p, &model.Format{}, f.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(format): %v", err)
+	}
+	if !exists {
+		t.Fatal("GetOneById(format): record not found")
+	}
+	if got.Name != f.Name || got.UserId != f.UserId || got.ID != f.ID {
+		t.Fatalf("format round-trip mismatch:\n  got  %+v\n  want %+v", got, f)
+	}
+
+	all, err := database.GetAll[*model.Format](ctx, p)
+	if err != nil {
+		t.Fatalf("GetAll(format): %v", err)
+	}
+	if len(all) != 1 || all[0].ID != f.ID {
+		t.Fatalf("GetAll(format): got %d records, want 1 matching the created format", len(all))
+	}
+
+	f.Name = "Renamed Format"
+	if err := p.Update(ctx, f); err != nil {
+		t.Fatalf("Update(format): %v", err)
+	}
+	got2, _, err := database.GetOneById(ctx, p, &model.Format{}, f.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(format) after update: %v", err)
+	}
+	if got2.Name != "Renamed Format" {
+		t.Fatalf("format update not persisted, got %+v", got2)
+	}
+
+	if err := p.Delete(ctx, f); err != nil {
+		t.Fatalf("Delete(format): %v", err)
+	}
+	_, exists, err = database.GetOneById(ctx, p, &model.Format{}, f.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(format) after delete: %v", err)
+	}
+	if exists {
+		t.Fatal("format should have been deleted")
+	}
+}
+
+func TestFormatRatingRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	p := newSqliteProvider(t)
+
+	format := createTestFormatRaw(t, p)
+	fr := &model.FormatRating{
+		FormatId:    format.ID,
+		RatingId:    model.RatingId(database.NewRecordId()), // rating table lands in #60
+		RatingIndex: 1,
+	}
+	// Created directly through the provider because FormatRating.DynamicallyValid
+	// requires a Rating record, whose table is not migrated yet (#60).
+	if _, err := p.Create(ctx, fr); err != nil {
+		t.Fatalf("Create(format_rating): %v", err)
+	}
+
+	got, exists, err := database.GetOneById(ctx, p, &model.FormatRating{}, fr.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(format_rating): %v", err)
+	}
+	if !exists {
+		t.Fatal("GetOneById(format_rating): record not found")
+	}
+	if got.FormatId != fr.FormatId || got.RatingId != fr.RatingId || got.RatingIndex != fr.RatingIndex {
+		t.Fatalf("format_rating round-trip mismatch:\n  got  %+v\n  want %+v", got, fr)
+	}
+
+	all, err := database.GetAll[*model.FormatRating](ctx, p)
+	if err != nil {
+		t.Fatalf("GetAll(format_rating): %v", err)
+	}
+	if len(all) != 1 || all[0].ID != fr.ID {
+		t.Fatalf("GetAll(format_rating): got %d records, want 1", len(all))
+	}
+
+	fr.RatingIndex = 3
+	if err := p.Update(ctx, fr); err != nil {
+		t.Fatalf("Update(format_rating): %v", err)
+	}
+	got2, _, err := database.GetOneById(ctx, p, &model.FormatRating{}, fr.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(format_rating) after update: %v", err)
+	}
+	if got2.RatingIndex != 3 {
+		t.Fatalf("format_rating update not persisted, got %+v", got2)
+	}
+
+	if err := p.Delete(ctx, fr); err != nil {
+		t.Fatalf("Delete(format_rating): %v", err)
+	}
+	_, exists, err = database.GetOneById(ctx, p, &model.FormatRating{}, fr.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(format_rating) after delete: %v", err)
+	}
+	if exists {
+		t.Fatal("format_rating should have been deleted")
+	}
+}
+
+func TestFormatLineRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	p := newSqliteProvider(t)
+
+	format := createTestFormatRaw(t, p)
+	fl := &model.FormatLine{
+		FormatId:      format.ID,
+		FormatIndex:   0,
+		Player1Rating: model.RatingId(database.NewRecordId()), // rating table lands in #60
+		Player2Rating: model.RatingId(database.NewRecordId()),
+	}
+	// Created directly through the provider because FormatLine.DynamicallyValid
+	// requires Rating records, whose table is not migrated yet (#60).
+	if _, err := p.Create(ctx, fl); err != nil {
+		t.Fatalf("Create(format_line): %v", err)
+	}
+
+	got, exists, err := database.GetOneById(ctx, p, &model.FormatLine{}, fl.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(format_line): %v", err)
+	}
+	if !exists {
+		t.Fatal("GetOneById(format_line): record not found")
+	}
+	if got.FormatId != fl.FormatId || got.FormatIndex != fl.FormatIndex ||
+		got.Player1Rating != fl.Player1Rating || got.Player2Rating != fl.Player2Rating {
+		t.Fatalf("format_line round-trip mismatch:\n  got  %+v\n  want %+v", got, fl)
+	}
+
+	all, err := database.GetAll[*model.FormatLine](ctx, p)
+	if err != nil {
+		t.Fatalf("GetAll(format_line): %v", err)
+	}
+	if len(all) != 1 || all[0].ID != fl.ID {
+		t.Fatalf("GetAll(format_line): got %d records, want 1", len(all))
+	}
+
+	fl.FormatIndex = 4
+	if err := p.Update(ctx, fl); err != nil {
+		t.Fatalf("Update(format_line): %v", err)
+	}
+	got2, _, err := database.GetOneById(ctx, p, &model.FormatLine{}, fl.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(format_line) after update: %v", err)
+	}
+	if got2.FormatIndex != 4 {
+		t.Fatalf("format_line update not persisted, got %+v", got2)
+	}
+
+	if err := p.Delete(ctx, fl); err != nil {
+		t.Fatalf("Delete(format_line): %v", err)
+	}
+	_, exists, err = database.GetOneById(ctx, p, &model.FormatLine{}, fl.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(format_line) after delete: %v", err)
+	}
+	if exists {
+		t.Fatal("format_line should have been deleted")
+	}
+}
+
+// createTestFormatRaw creates a Format directly through the provider with a
+// real owner user (Format.DynamicallyValid requires Rating records, which land
+// in #60).
+func createTestFormatRaw(t *testing.T, p database.Provider) *model.Format {
+	t.Helper()
+	f := model.NewFormat()
+	f.UserId = createTestUser(t, p).ID
+	f.Name = "Raw Format"
+	if _, err := p.Create(context.Background(), f); err != nil {
+		t.Fatalf("raw create format: %v", err)
+	}
+	return f
+}
+
+// ---- #59: Rulesets ----
+
+func TestRulesetRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	p := newSqliteProvider(t)
+
+	r := model.NewRuleset()
+	r.Name = "Intraclub Rules v1"
+	r.Revision = 1
+	r.Date = time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	r.Owner = createTestUser(t, p).ID
+	created, err := database.CreateOne(ctx, p, r)
+	if err != nil {
+		t.Fatalf("CreateOne(ruleset): %v", err)
+	}
+	if created.GetId() == database.InvalidRecordId {
+		t.Fatal("CreateOne(ruleset) did not assign an ID")
+	}
+
+	got, exists, err := database.GetOneById(ctx, p, &model.Ruleset{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(ruleset): %v", err)
+	}
+	if !exists {
+		t.Fatal("GetOneById(ruleset): record not found")
+	}
+	if got.Name != created.Name || got.Revision != created.Revision ||
+		got.SupersededBy != created.SupersededBy || got.Owner != created.Owner ||
+		!got.Date.Equal(created.Date) {
+		t.Fatalf("ruleset round-trip mismatch:\n  got  %+v\n  want %+v", got, created)
+	}
+
+	all, err := database.GetAll[*model.Ruleset](ctx, p)
+	if err != nil {
+		t.Fatalf("GetAll(ruleset): %v", err)
+	}
+	if len(all) != 1 || all[0].ID != created.ID {
+		t.Fatalf("GetAll(ruleset): got %d records, want 1", len(all))
+	}
+
+	// Ruleset.PreUpdate rejects direct modification (use Amend instead); the
+	// raw provider update still exercises the exact SQLite column mapping.
+	created.Revision = 2
+	created.Name = "Intraclub Rules v2"
+	if err := p.Update(ctx, created); err != nil {
+		t.Fatalf("Update(ruleset): %v", err)
+	}
+	got2, _, err := database.GetOneById(ctx, p, &model.Ruleset{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(ruleset) after update: %v", err)
+	}
+	if got2.Revision != 2 || got2.Name != "Intraclub Rules v2" {
+		t.Fatalf("ruleset update not persisted, got %+v", got2)
+	}
+
+	if _, _, err := database.DeleteOneById(ctx, p, &model.Ruleset{}, created.GetId()); err != nil {
+		t.Fatalf("DeleteOneById(ruleset): %v", err)
+	}
+	_, exists, err = database.GetOneById(ctx, p, &model.Ruleset{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(ruleset) after delete: %v", err)
+	}
+	if exists {
+		t.Fatal("ruleset should have been deleted")
+	}
+}
+
+func TestRuleSectionRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	p := newSqliteProvider(t)
+
+	ruleset := createTestRuleset(t, p)
+	sec := &model.RuleSection{
+		Parent:   ruleset.ID,
+		Title:    "Scoring",
+		Markdown: "A match is won by winning two of three sets.",
+		Owner:    createTestUser(t, p).ID,
+	}
+	created, err := database.CreateOne(ctx, p, sec)
+	if err != nil {
+		t.Fatalf("CreateOne(rule_section): %v", err)
+	}
+	if created.GetId() == database.InvalidRecordId {
+		t.Fatal("CreateOne(rule_section) did not assign an ID")
+	}
+
+	got, exists, err := database.GetOneById(ctx, p, &model.RuleSection{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(rule_section): %v", err)
+	}
+	if !exists {
+		t.Fatal("GetOneById(rule_section): record not found")
+	}
+	if got.ID != created.ID || got.Parent != created.Parent ||
+		got.Title != created.Title || got.Markdown != created.Markdown ||
+		got.Owner != created.Owner {
+		t.Fatalf("rule_section round-trip mismatch:\n  got  %+v\n  want %+v", got, created)
+	}
+
+	all, err := database.GetAll[*model.RuleSection](ctx, p)
+	if err != nil {
+		t.Fatalf("GetAll(rule_section): %v", err)
+	}
+	if len(all) != 1 || all[0].ID != created.ID {
+		t.Fatalf("GetAll(rule_section): got %d records, want 1", len(all))
+	}
+
+	created.Title = "Updated Scoring"
+	if err := database.UpdateOne(ctx, p, created); err != nil {
+		t.Fatalf("UpdateOne(rule_section): %v", err)
+	}
+	got2, _, err := database.GetOneById(ctx, p, &model.RuleSection{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(rule_section) after update: %v", err)
+	}
+	if got2.Title != "Updated Scoring" {
+		t.Fatalf("rule_section update not persisted, got %+v", got2)
+	}
+
+	if _, _, err := database.DeleteOneById(ctx, p, &model.RuleSection{}, created.GetId()); err != nil {
+		t.Fatalf("DeleteOneById(rule_section): %v", err)
+	}
+	_, exists, err = database.GetOneById(ctx, p, &model.RuleSection{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(rule_section) after delete: %v", err)
+	}
+	if exists {
+		t.Fatal("rule_section should have been deleted")
+	}
+}
+
+func TestRulesetSectionRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	p := newSqliteProvider(t)
+
+	ruleset := createTestRuleset(t, p)
+	section := createTestRuleSection(t, p, ruleset)
+	rs := &model.RulesetSection{
+		RulesetId:    ruleset.ID,
+		SectionId:    section.ID,
+		SectionIndex: 0,
+		CreatedAt:    time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+		UpdatedAt:    time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC),
+	}
+	created, err := database.CreateOne(ctx, p, rs)
+	if err != nil {
+		t.Fatalf("CreateOne(ruleset_section): %v", err)
+	}
+
+	got, exists, err := database.GetOneById(ctx, p, &model.RulesetSection{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(ruleset_section): %v", err)
+	}
+	if !exists {
+		t.Fatal("GetOneById(ruleset_section): record not found")
+	}
+	if got.RulesetId != created.RulesetId || got.SectionId != created.SectionId ||
+		got.SectionIndex != created.SectionIndex ||
+		!got.CreatedAt.Equal(created.CreatedAt) || !got.UpdatedAt.Equal(created.UpdatedAt) {
+		t.Fatalf("ruleset_section round-trip mismatch:\n  got  %+v\n  want %+v", got, created)
+	}
+
+	all, err := database.GetAll[*model.RulesetSection](ctx, p)
+	if err != nil {
+		t.Fatalf("GetAll(ruleset_section): %v", err)
+	}
+	if len(all) != 1 || all[0].ID != created.ID {
+		t.Fatalf("GetAll(ruleset_section): got %d records, want 1", len(all))
+	}
+
+	created.SectionIndex = 2
+	if err := database.UpdateOne(ctx, p, created); err != nil {
+		t.Fatalf("UpdateOne(ruleset_section): %v", err)
+	}
+	got2, _, err := database.GetOneById(ctx, p, &model.RulesetSection{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(ruleset_section) after update: %v", err)
+	}
+	if got2.SectionIndex != 2 {
+		t.Fatalf("ruleset_section update not persisted, got %+v", got2)
+	}
+
+	if _, _, err := database.DeleteOneById(ctx, p, &model.RulesetSection{}, created.GetId()); err != nil {
+		t.Fatalf("DeleteOneById(ruleset_section): %v", err)
+	}
+	_, exists, err = database.GetOneById(ctx, p, &model.RulesetSection{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(ruleset_section) after delete: %v", err)
+	}
+	if exists {
+		t.Fatal("ruleset_section should have been deleted")
+	}
+}
+
+// createTestRuleset creates a Ruleset with a real owner user.
+func createTestRuleset(t *testing.T, p database.Provider) *model.Ruleset {
+	t.Helper()
+	r := model.NewRuleset()
+	r.Name = "Test Ruleset"
+	r.Owner = createTestUser(t, p).ID
+	v, err := database.CreateOne(context.Background(), p, r)
+	if err != nil {
+		t.Fatalf("create ruleset: %v", err)
+	}
+	return v
+}
+
+// createTestRuleSection creates a RuleSection belonging to the given ruleset.
+func createTestRuleSection(t *testing.T, p database.Provider, ruleset *model.Ruleset) *model.RuleSection {
+	t.Helper()
+	sec := &model.RuleSection{
+		Parent:   ruleset.ID,
+		Title:    "Section",
+		Markdown: "Contents",
+		Owner:    createTestUser(t, p).ID,
+	}
+	v, err := database.CreateOne(context.Background(), p, sec)
+	if err != nil {
+		t.Fatalf("create rule_section: %v", err)
+	}
+	return v
+}
+
+// ---- #59: Scoring structures ----
+
+func TestScoringStructureRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	p := newSqliteProvider(t)
+
+	s := model.NewScoringStructure()
+	s.Name = "Tennis standard match"
+	s.Owner = createTestUser(t, p).ID
+	s.WinConditionCountingType = model.Game
+	s.WinCondition = model.WinCondition{
+		WinThreshold:        6,
+		MustWinBy:           2,
+		InstantWinThreshold: 7,
+	}
+	created, err := database.CreateOne(ctx, p, s)
+	if err != nil {
+		t.Fatalf("CreateOne(scoring_structure): %v", err)
+	}
+	if created.GetId() == database.InvalidRecordId {
+		t.Fatal("CreateOne(scoring_structure) did not assign an ID")
+	}
+
+	got, exists, err := database.GetOneById(ctx, p, &model.ScoringStructure{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(scoring_structure): %v", err)
+	}
+	if !exists {
+		t.Fatal("GetOneById(scoring_structure): record not found")
+	}
+	if got.Name != created.Name || got.Owner != created.Owner ||
+		got.WinConditionCountingType != created.WinConditionCountingType ||
+		got.WinCondition != created.WinCondition {
+		t.Fatalf("scoring_structure round-trip mismatch:\n  got  %+v\n  want %+v", got, created)
+	}
+
+	all, err := database.GetAll[*model.ScoringStructure](ctx, p)
+	if err != nil {
+		t.Fatalf("GetAll(scoring_structure): %v", err)
+	}
+	if len(all) != 1 || all[0].ID != created.ID {
+		t.Fatalf("GetAll(scoring_structure): got %d records, want 1", len(all))
+	}
+
+	created.Name = "Renamed scoring"
+	created.WinCondition.InstantWinThreshold = 9
+	if err := database.UpdateOne(ctx, p, created); err != nil {
+		t.Fatalf("UpdateOne(scoring_structure): %v", err)
+	}
+	got2, _, err := database.GetOneById(ctx, p, &model.ScoringStructure{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(scoring_structure) after update: %v", err)
+	}
+	if got2.Name != "Renamed scoring" || got2.WinCondition.InstantWinThreshold != 9 {
+		t.Fatalf("scoring_structure update not persisted, got %+v", got2)
+	}
+
+	if _, _, err := database.DeleteOneById(ctx, p, &model.ScoringStructure{}, created.GetId()); err != nil {
+		t.Fatalf("DeleteOneById(scoring_structure): %v", err)
+	}
+	_, exists, err = database.GetOneById(ctx, p, &model.ScoringStructure{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(scoring_structure) after delete: %v", err)
+	}
+	if exists {
+		t.Fatal("scoring_structure should have been deleted")
+	}
+}
+
+func TestScoringStructureSecondaryRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	p := newSqliteProvider(t)
+
+	parent := createTestScoringStructure(t, p, "Parent", model.Set)
+	secondary := createTestScoringStructure(t, p, "Secondary", model.Game)
+	ss := &model.ScoringStructureSecondary{
+		ScoringStructureId:          parent.ID,
+		SecondaryScoringStructureId: secondary.ID,
+		SecondaryIndex:              0,
+	}
+	created, err := database.CreateOne(ctx, p, ss)
+	if err != nil {
+		t.Fatalf("CreateOne(scoring_structure_secondary): %v", err)
+	}
+	if created.GetId() == database.InvalidRecordId {
+		t.Fatal("CreateOne(scoring_structure_secondary) did not assign an ID")
+	}
+
+	got, exists, err := database.GetOneById(ctx, p, &model.ScoringStructureSecondary{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(scoring_structure_secondary): %v", err)
+	}
+	if !exists {
+		t.Fatal("GetOneById(scoring_structure_secondary): record not found")
+	}
+	if got.ScoringStructureId != created.ScoringStructureId ||
+		got.SecondaryScoringStructureId != created.SecondaryScoringStructureId ||
+		got.SecondaryIndex != created.SecondaryIndex {
+		t.Fatalf("scoring_structure_secondary round-trip mismatch:\n  got  %+v\n  want %+v", got, created)
+	}
+
+	all, err := database.GetAll[*model.ScoringStructureSecondary](ctx, p)
+	if err != nil {
+		t.Fatalf("GetAll(scoring_structure_secondary): %v", err)
+	}
+	if len(all) != 1 || all[0].ID != created.ID {
+		t.Fatalf("GetAll(scoring_structure_secondary): got %d records, want 1", len(all))
+	}
+
+	created.SecondaryIndex = 2
+	if err := database.UpdateOne(ctx, p, created); err != nil {
+		t.Fatalf("UpdateOne(scoring_structure_secondary): %v", err)
+	}
+	got2, _, err := database.GetOneById(ctx, p, &model.ScoringStructureSecondary{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(scoring_structure_secondary) after update: %v", err)
+	}
+	if got2.SecondaryIndex != 2 {
+		t.Fatalf("scoring_structure_secondary update not persisted, got %+v", got2)
+	}
+
+	if _, _, err := database.DeleteOneById(ctx, p, &model.ScoringStructureSecondary{}, created.GetId()); err != nil {
+		t.Fatalf("DeleteOneById(scoring_structure_secondary): %v", err)
+	}
+	_, exists, err = database.GetOneById(ctx, p, &model.ScoringStructureSecondary{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(scoring_structure_secondary) after delete: %v", err)
+	}
+	if exists {
+		t.Fatal("scoring_structure_secondary should have been deleted")
+	}
+}
+
+// createTestScoringStructure creates a simple (non-composite) scoring
+// structure with the given counting type and a real owner user.
+func createTestScoringStructure(t *testing.T, p database.Provider, name string, countingType model.ScoreCountingType) *model.ScoringStructure {
+	t.Helper()
+	s := model.NewScoringStructure()
+	s.Name = name
+	s.Owner = createTestUser(t, p).ID
+	s.WinConditionCountingType = countingType
+	s.WinCondition = model.WinCondition{WinThreshold: 6, MustWinBy: 1}
+	v, err := database.CreateOne(context.Background(), p, s)
+	if err != nil {
+		t.Fatalf("create scoring_structure: %v", err)
+	}
+	return v
+}
+
+// ---- #59: Playoff structures ----
+
+func TestPlayoffStructureRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	p := newSqliteProvider(t)
+
+	ps := model.NewPlayoffStructure()
+	ps.UserId = createTestUser(t, p).ID
+	ps.Byes = 0
+	ps.NumberOfTeams = 4
+	created, err := database.CreateOne(ctx, p, ps)
+	if err != nil {
+		t.Fatalf("CreateOne(playoff_structure): %v", err)
+	}
+	if created.GetId() == database.InvalidRecordId {
+		t.Fatal("CreateOne(playoff_structure) did not assign an ID")
+	}
+
+	got, exists, err := database.GetOneById(ctx, p, &model.PlayoffStructure{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(playoff_structure): %v", err)
+	}
+	if !exists {
+		t.Fatal("GetOneById(playoff_structure): record not found")
+	}
+	if got.UserId != created.UserId || got.Byes != created.Byes ||
+		got.NumberOfTeams != created.NumberOfTeams {
+		t.Fatalf("playoff_structure round-trip mismatch:\n  got  %+v\n  want %+v", got, created)
+	}
+
+	all, err := database.GetAll[*model.PlayoffStructure](ctx, p)
+	if err != nil {
+		t.Fatalf("GetAll(playoff_structure): %v", err)
+	}
+	if len(all) != 1 || all[0].ID != created.ID {
+		t.Fatalf("GetAll(playoff_structure): got %d records, want 1", len(all))
+	}
+
+	created.NumberOfTeams = 8
+	if err := database.UpdateOne(ctx, p, created); err != nil {
+		t.Fatalf("UpdateOne(playoff_structure): %v", err)
+	}
+	got2, _, err := database.GetOneById(ctx, p, &model.PlayoffStructure{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(playoff_structure) after update: %v", err)
+	}
+	if got2.NumberOfTeams != 8 {
+		t.Fatalf("playoff_structure update not persisted, got %+v", got2)
+	}
+
+	if _, _, err := database.DeleteOneById(ctx, p, &model.PlayoffStructure{}, created.GetId()); err != nil {
+		t.Fatalf("DeleteOneById(playoff_structure): %v", err)
+	}
+	_, exists, err = database.GetOneById(ctx, p, &model.PlayoffStructure{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(playoff_structure) after delete: %v", err)
+	}
+	if exists {
+		t.Fatal("playoff_structure should have been deleted")
+	}
+}
+
+// ---- #59: Facilities ----
+
+func TestFacilityRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	p := newSqliteProvider(t)
+
+	fac := model.NewFacility()
+	fac.UserId = createTestUser(t, p).ID
+	fac.Name = "Martin's Landing River Club"
+	fac.Address = "123 River Rd"
+	fac.NumberOfCourts = 4
+	created, err := database.CreateOne(ctx, p, fac)
+	if err != nil {
+		t.Fatalf("CreateOne(facility): %v", err)
+	}
+	if created.GetId() == database.InvalidRecordId {
+		t.Fatal("CreateOne(facility) did not assign an ID")
+	}
+
+	got, exists, err := database.GetOneById(ctx, p, &model.Facility{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(facility): %v", err)
+	}
+	if !exists {
+		t.Fatal("GetOneById(facility): record not found")
+	}
+	if got.UserId != created.UserId || got.Name != created.Name ||
+		got.Address != created.Address || got.NumberOfCourts != created.NumberOfCourts ||
+		got.LayoutPhoto != created.LayoutPhoto {
+		t.Fatalf("facility round-trip mismatch:\n  got  %+v\n  want %+v", got, created)
+	}
+
+	all, err := database.GetAll[*model.Facility](ctx, p)
+	if err != nil {
+		t.Fatalf("GetAll(facility): %v", err)
+	}
+	if len(all) != 1 || all[0].ID != created.ID {
+		t.Fatalf("GetAll(facility): got %d records, want 1", len(all))
+	}
+
+	created.Name = "Renamed Facility"
+	created.NumberOfCourts = 6
+	if err := database.UpdateOne(ctx, p, created); err != nil {
+		t.Fatalf("UpdateOne(facility): %v", err)
+	}
+	got2, _, err := database.GetOneById(ctx, p, &model.Facility{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(facility) after update: %v", err)
+	}
+	if got2.Name != "Renamed Facility" || got2.NumberOfCourts != 6 {
+		t.Fatalf("facility update not persisted, got %+v", got2)
+	}
+
+	if _, _, err := database.DeleteOneById(ctx, p, &model.Facility{}, created.GetId()); err != nil {
+		t.Fatalf("DeleteOneById(facility): %v", err)
+	}
+	_, exists, err = database.GetOneById(ctx, p, &model.Facility{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(facility) after delete: %v", err)
+	}
+	if exists {
+		t.Fatal("facility should have been deleted")
+	}
+}

--- a/model/dev_data.go
+++ b/model/dev_data.go
@@ -62,11 +62,14 @@ func seedDevScoringStructures(db database.Provider, u database.UserId) {
 		WinThreshold: 2,
 		MustWinBy:    1,
 	}
-	scoringStructure2.SecondaryScoringStructures = ScoringStructureList{
-		v.ID, v.ID, v.ID,
+	v2, err := database.CreateOne(ctx, db, scoringStructure2)
+	if err != nil {
+		panic(err)
 	}
 
-	_, err = database.CreateOne(ctx, db, scoringStructure2)
+	err = v2.SetSecondaryScoringStructures(ctx, db, ScoringStructureList{
+		v.ID, v.ID, v.ID,
+	})
 	if err != nil {
 		panic(err)
 	}
@@ -124,22 +127,29 @@ func seedDevFormat(db database.Provider, u database.UserId) {
 		return ratings[i].Name < ratings[j].Name
 	})
 
+	possibleRatings := make(RatingList, 0, len(ratings))
+	lines := make([]FormatLine, 0)
 	for i, rating := range ratings {
 		// add possible ratings
-		format.PossibleRatings = append(format.PossibleRatings, rating.ID)
+		possibleRatings = append(possibleRatings, rating.ID)
 
 		// create lines
 		for _, rating2 := range ratings[i:] {
-			format.Lines = append(format.Lines, FormatLine{
+			lines = append(lines, FormatLine{
 				Player1Rating: rating.ID,
 				Player2Rating: rating2.ID,
 			})
 		}
-
 	}
 
-	_, err = database.CreateOne(ctx, db, format)
+	created, err := database.CreateOne(ctx, db, format)
 	if err != nil {
+		panic(err)
+	}
+	if err := created.SetPossibleRatings(ctx, db, possibleRatings); err != nil {
+		panic(err)
+	}
+	if err := created.SetLines(ctx, db, lines); err != nil {
 		panic(err)
 	}
 }

--- a/model/draft.go
+++ b/model/draft.go
@@ -160,7 +160,11 @@ func (d *Draft) DynamicallyValid(ctx context.Context, db database.Provider) erro
 		return err
 	}
 	if len(ratingCutoffs) > 0 {
-		err = d.ValidateRatingsCutoff(format.PossibleRatings, ratingCutoffs)
+		possibleRatings, err := format.GetPossibleRatings(ctx, db)
+		if err != nil {
+			return err
+		}
+		err = d.ValidateRatingsCutoff(possibleRatings, ratingCutoffs)
 		if err != nil {
 			return err
 		}
@@ -422,7 +426,11 @@ func (d *Draft) Select(ctx context.Context, player database.UserId, db database.
 
 	// Get the rating for this pick
 	format, _ := database.GetExistingRecordById(getDraftContext(), db, &Format{}, d.Format.RecordId())
-	rating, err := d.GetRatingForPick(getDraftContext(), db, format.PossibleRatings, len(picks))
+	possibleRatings, err := format.GetPossibleRatings(getDraftContext(), db)
+	if err != nil {
+		return err
+	}
+	rating, err := d.GetRatingForPick(getDraftContext(), db, possibleRatings, len(picks))
 	if err != nil {
 		return err
 	}
@@ -620,7 +628,7 @@ func (d *Draft) GetAvailableRatings(ctx context.Context, db database.Provider) (
 	if err != nil {
 		return nil, err
 	}
-	return format.PossibleRatings, nil
+	return format.GetPossibleRatings(ctx, db)
 }
 
 func (d *Draft) Initialize(ctx context.Context, db database.Provider, captains []database.UserId) error {

--- a/model/draft_test.go
+++ b/model/draft_test.go
@@ -264,14 +264,17 @@ func TestGetRatingForSelection(t *testing.T) {
 	format := newDefaultFormat(t, db)
 	draft := newRandomDraft(t, db, 100, 4)
 
+	possibleRatings, err := format.GetPossibleRatings(context.Background(), db)
+	require.NoError(t, err)
+
 	// assign rating cutoffs via the relationship table
 	cutoffs := []struct {
 		rating RatingId
 		cutoff int
 	}{
-		{format.PossibleRatings[0], 20},
-		{format.PossibleRatings[1], 40},
-		{format.PossibleRatings[2], 70},
+		{possibleRatings[0], 20},
+		{possibleRatings[1], 40},
+		{possibleRatings[2], 70},
 	}
 	for _, c := range cutoffs {
 		_, err := draft.AssignRatingCutoff(context.Background(), db, c.rating, c.cutoff)
@@ -279,27 +282,27 @@ func TestGetRatingForSelection(t *testing.T) {
 	}
 
 	for i := 0; i <= 20; i++ {
-		rating, err := draft.GetRatingForPick(context.Background(), db, format.PossibleRatings, i)
+		rating, err := draft.GetRatingForPick(context.Background(), db, possibleRatings, i)
 		require.NoError(t, err)
-		assert.Equal(t, format.PossibleRatings[0], rating)
+		assert.Equal(t, possibleRatings[0], rating)
 	}
 
 	for i := 21; i <= 40; i++ {
-		rating, err := draft.GetRatingForPick(context.Background(), db, format.PossibleRatings, i)
+		rating, err := draft.GetRatingForPick(context.Background(), db, possibleRatings, i)
 		require.NoError(t, err)
-		assert.Equal(t, format.PossibleRatings[1], rating)
+		assert.Equal(t, possibleRatings[1], rating)
 	}
 
 	for i := 41; i <= 70; i++ {
-		rating, err := draft.GetRatingForPick(context.Background(), db, format.PossibleRatings, i)
+		rating, err := draft.GetRatingForPick(context.Background(), db, possibleRatings, i)
 		require.NoError(t, err)
-		assert.Equal(t, format.PossibleRatings[2], rating)
+		assert.Equal(t, possibleRatings[2], rating)
 	}
 
 	for i := 71; i <= 100; i++ {
-		rating, err := draft.GetRatingForPick(context.Background(), db, format.PossibleRatings, i)
+		rating, err := draft.GetRatingForPick(context.Background(), db, possibleRatings, i)
 		require.NoError(t, err)
-		assert.Equal(t, format.PossibleRatings[3], rating)
+		assert.Equal(t, possibleRatings[3], rating)
 	}
 }
 
@@ -307,10 +310,12 @@ func TestRatingWithCutoffBelowPrevious(t *testing.T) {
 	db := database.NewUnitTestDBProvider()
 	format := newDefaultFormat(t, db)
 	draft := newRandomDraft(t, db, 100, 4)
+	possibleRatings, err := format.GetPossibleRatings(context.Background(), db)
+	require.NoError(t, err)
 	assignRatingCutoffs(t, db, draft, format, map[RatingId]int{
-		format.PossibleRatings[0]: 20,
-		format.PossibleRatings[1]: 10,
-		format.PossibleRatings[2]: 70,
+		possibleRatings[0]: 20,
+		possibleRatings[1]: 10,
+		possibleRatings[2]: 70,
 	})
 
 	assert.Error(t, draft.DynamicallyValid(context.Background(), db), "Expected draft to be invalid")
@@ -321,10 +326,12 @@ func TestRatingCutoffIsZero(t *testing.T) {
 	db := database.NewUnitTestDBProvider()
 	format := newDefaultFormat(t, db)
 	draft := newRandomDraft(t, db, 100, 4)
+	possibleRatings, err := format.GetPossibleRatings(context.Background(), db)
+	require.NoError(t, err)
 	assignRatingCutoffs(t, db, draft, format, map[RatingId]int{
-		format.PossibleRatings[0]: 0,
-		format.PossibleRatings[1]: 10,
-		format.PossibleRatings[2]: 70,
+		possibleRatings[0]: 0,
+		possibleRatings[1]: 10,
+		possibleRatings[2]: 70,
 	})
 
 	assert.Error(t, draft.DynamicallyValid(context.Background(), db), "Expected draft to be invalid")
@@ -335,9 +342,11 @@ func TestRatingCutoffIsMissing(t *testing.T) {
 	db := database.NewUnitTestDBProvider()
 	format := newDefaultFormat(t, db)
 	draft := newRandomDraft(t, db, 100, 4)
+	possibleRatings, err := format.GetPossibleRatings(context.Background(), db)
+	require.NoError(t, err)
 	assignRatingCutoffs(t, db, draft, format, map[RatingId]int{
-		format.PossibleRatings[0]: 5,
-		format.PossibleRatings[1]: 10,
+		possibleRatings[0]: 5,
+		possibleRatings[1]: 10,
 	})
 
 	assert.Error(t, draft.DynamicallyValid(context.Background(), db), "Expected draft to be invalid")
@@ -348,11 +357,13 @@ func TestRatingCutoffForLastRatingIdIsPresent(t *testing.T) {
 	db := database.NewUnitTestDBProvider()
 	format := newDefaultFormat(t, db)
 	draft := newRandomDraft(t, db, 100, 4)
+	possibleRatings, err := format.GetPossibleRatings(context.Background(), db)
+	require.NoError(t, err)
 	assignRatingCutoffs(t, db, draft, format, map[RatingId]int{
-		format.PossibleRatings[0]: 5,
-		format.PossibleRatings[1]: 10,
-		format.PossibleRatings[2]: 70,
-		format.PossibleRatings[3]: 80,
+		possibleRatings[0]: 5,
+		possibleRatings[1]: 10,
+		possibleRatings[2]: 70,
+		possibleRatings[3]: 80,
 	})
 
 	assert.Error(t, draft.DynamicallyValid(context.Background(), db), "Expected draft to be invalid")

--- a/model/format.go
+++ b/model/format.go
@@ -2,71 +2,13 @@ package model
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	"intraclub/database"
 )
-
-// FormatLine is a pairing of two players that have a particular Rating.
-// Each week, a given Format will be composed of one or more FormatLine s
-// from which each Team will compose a Lineup. A Lineup from one
-// team on a given Week in a Season will play a Lineup from the
-// opposing Team based on the Schedule
-type FormatLine struct {
-	Player1Rating RatingId `json:"player_1_rating"` // ID of the Rating record for player two in this FormatLine
-	Player2Rating RatingId `json:"player_2_rating"` // ID of the Rating record for player one in this FormatLine
-}
-
-func (l *FormatLine) UnmarshalJSON(bytes []byte) error {
-	m := map[string]string{}
-	err := json.Unmarshal(bytes, &m)
-	if err != nil {
-		return err
-	}
-	rating1, err := database.RecordIdFromString(m["player_1_rating"])
-	if err != nil {
-		return err
-	}
-	rating2, err := database.RecordIdFromString(m["player_2_rating"])
-	if err != nil {
-		return err
-	}
-
-	l.Player1Rating = RatingId(rating1)
-	l.Player2Rating = RatingId(rating2)
-	return nil
-}
-
-func (l *FormatLine) EquivalentTo(other FormatLine) bool {
-	if l.Player1Rating == other.Player1Rating && l.Player2Rating == other.Player2Rating {
-		return true
-	}
-
-	if l.Player1Rating == other.Player2Rating && l.Player2Rating == other.Player1Rating {
-		return true
-	}
-
-	return false
-}
-
-func (l *FormatLine) StaticallyValid() error {
-	return nil
-}
-
-func (l *FormatLine) DynamicallyValid(ctx context.Context, db database.Provider) error {
-	err := database.ExistsById(ctx, db, &Rating{}, l.Player1Rating.RecordId())
-	if err != nil {
-		return err
-	}
-	return database.ExistsById(ctx, db, &Rating{}, l.Player2Rating.RecordId())
-}
-
-func (l *FormatLine) String() string {
-	return fmt.Sprintf("%s / %s", l.Player1Rating, l.Player2Rating)
-}
 
 type FormatId database.RecordId
 
@@ -88,9 +30,9 @@ func (id FormatId) String() string {
 }
 
 // Format is a globally-available common.CrudRecord type which allows
-// a user to specify a format that a Season will be played in. This is
-// composed of a list of possible Rating IDs, and a list of FormatLine records
-// which compose a pairing of two Rating types.
+// a user to specify a format that a Season will be played in. It is composed
+// of a list of possible Rating IDs, and a list of FormatLine records which
+// compose a pairing of two Rating types.
 //
 // For example, this could be a 1/2/3 division of skilled, medium, and
 // beginner-level players with all six combinations of skill level:
@@ -108,12 +50,19 @@ func (id FormatId) String() string {
 //   - old guy / young guy
 //   - young guy / young guy.
 type Format struct {
-	ID              FormatId        `json:"id"`               // unique ID for the Format
-	UserId          database.UserId `json:"user_id"`          // owner of the Format
-	Name            string          `json:"name"`             // name for the Format, e.g. "Men's Intraclub 1/2/3"
-	PossibleRatings RatingList      `json:"possible_ratings"` // list of possible Rating values for the lines, highest to lowest skill
-	Lines           []FormatLine    `json:"lines"`            // Rating pairings that will play during a matchup
+	ID     FormatId        `json:"id"`      // unique ID for the Format
+	UserId database.UserId `json:"user_id"` // owner of the Format
+	Name   string          `json:"name"`    // name for the Format, e.g. "Men's Intraclub 1/2/3"
 }
+
+// API/JSON shape decision: the former inline `possible_ratings`
+// (`RatingList`) and `lines` (`[]FormatLine`) fields have been removed from
+// `Format` and normalized into the `FormatRating` and `FormatLine` join tables
+// (format_rating / format_line collections). In-process reads reassemble the
+// relationships in order via `Format.GetPossibleRatings` and `Format.GetLines`.
+// This matches the established join-table normalization (see #58 for the same
+// treatment of Draft.RatingCutoffs) and the schema conventions in
+// docs/schema-conventions.md.
 
 func (f *Format) GetOwner() database.UserId {
 	return f.UserId
@@ -125,51 +74,6 @@ func (f *Format) PreUpdate(ctx context.Context, db database.Provider, existingVa
 
 func (f *Format) PreDelete(ctx context.Context, db database.Provider) error {
 	return f.CheckHasAssignedDrafts(ctx, db, false)
-}
-
-func (f *Format) PostCreate(ctx context.Context, db database.Provider) error {
-	return f.syncFormatRatings(ctx, db)
-}
-
-func (f *Format) PostUpdate(ctx context.Context, db database.Provider) error {
-	return f.syncFormatRatings(ctx, db)
-}
-
-func (f *Format) syncFormatRatings(ctx context.Context, db database.Provider) error {
-	existing, err := database.GetAllWhere[*FormatRating](ctx, db, func(_ context.Context, fr *FormatRating) bool {
-		return fr.FormatId == f.ID
-	})
-	if err != nil {
-		return err
-	}
-
-	existingMap := make(map[RatingId]*FormatRating)
-	for _, fr := range existing {
-		existingMap[fr.RatingId] = fr
-	}
-
-	for _, ratingId := range f.PossibleRatings {
-		if _, exists := existingMap[ratingId]; !exists {
-			formatRating := &FormatRating{
-				FormatId: f.ID,
-				RatingId: ratingId,
-			}
-			_, err = database.CreateOne(ctx, db, formatRating)
-			if err != nil {
-				return err
-			}
-		}
-		delete(existingMap, ratingId)
-	}
-
-	for _, fr := range existingMap {
-		_, _, err = database.DeleteOneById(ctx, db, fr, fr.ID)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
 }
 
 func (f *Format) SetOwner(userId database.UserId) {
@@ -200,41 +104,186 @@ func (f *Format) SetId(id database.RecordId) {
 	f.ID = FormatId(id)
 }
 
+// StaticallyValid validates the Format's scalar fields. The possible-ratings
+// and lines content (now stored in child tables) is validated by
+// DynamicallyValid, which can query those relationships.
 func (f *Format) StaticallyValid() error {
-	if len(f.Lines) == 0 {
-		return errors.New("format has no lines")
-	}
-
-	if len(f.PossibleRatings) == 0 {
-		return errors.New("format has no possible ratings")
-	}
-
 	f.Name = strings.TrimSpace(f.Name)
 	if f.Name == "" {
 		return errors.New("format has no name")
 	}
+	return nil
+}
 
-	fmt.Println(f)
+// GetPossibleRatings returns this format's possible ratings, ordered
+// highest-skill to lowest-skill (i.e. by FormatRating.RatingIndex).
+func (f *Format) GetPossibleRatings(ctx context.Context, db database.Provider) (RatingList, error) {
+	formatRatings, err := database.GetAllWhere[*FormatRating](ctx, db, func(_ context.Context, fr *FormatRating) bool {
+		return fr.FormatId == f.ID
+	})
+	if err != nil {
+		return nil, err
+	}
+	slices.SortFunc(formatRatings, func(a, b *FormatRating) int {
+		return a.RatingIndex - b.RatingIndex
+	})
+	ratings := make(RatingList, 0, len(formatRatings))
+	for _, fr := range formatRatings {
+		ratings = append(ratings, fr.RatingId)
+	}
+	return ratings, nil
+}
 
-	for i, line1 := range f.Lines {
-		if !f.IsRatingInOptionsList(line1.Player1Rating) {
+// SetPossibleRatings replaces this format's possible ratings with the provided
+// list, preserving order as RatingIndex values in the FormatRating join table.
+// The format must already have an assigned ID (i.e. be created). An empty list
+// is rejected because a format requires at least one possible rating.
+func (f *Format) SetPossibleRatings(ctx context.Context, db database.Provider, ratings RatingList) error {
+	if len(ratings) == 0 {
+		return errors.New("format has no possible ratings")
+	}
+	existing, err := database.GetAllWhere[*FormatRating](ctx, db, func(_ context.Context, fr *FormatRating) bool {
+		return fr.FormatId == f.ID
+	})
+	if err != nil {
+		return err
+	}
+	for _, fr := range existing {
+		if _, _, err := database.DeleteOneById(ctx, db, fr, fr.ID); err != nil {
+			return err
+		}
+	}
+	for i, ratingId := range ratings {
+		if _, err := database.CreateOne(ctx, db, &FormatRating{
+			FormatId:    f.ID,
+			RatingId:    ratingId,
+			RatingIndex: i,
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// GetLines returns this format's lines, ordered by FormatLine.FormatIndex.
+func (f *Format) GetLines(ctx context.Context, db database.Provider) ([]FormatLine, error) {
+	lines, err := database.GetAllWhere[*FormatLine](ctx, db, func(_ context.Context, l *FormatLine) bool {
+		return l.FormatId == f.ID
+	})
+	if err != nil {
+		return nil, err
+	}
+	slices.SortFunc(lines, func(a, b *FormatLine) int {
+		return a.FormatIndex - b.FormatIndex
+	})
+	result := make([]FormatLine, 0, len(lines))
+	for _, l := range lines {
+		result = append(result, *l)
+	}
+	return result, nil
+}
+
+// SetLines replaces this format's lines with the provided list, preserving
+// order as FormatIndex values in the FormatLine join table. The format must
+// already have an assigned ID (i.e. be created). It rejects an empty list,
+// duplicate / reversed-duplicate lines, and lines whose ratings are not among
+// the format's possible ratings.
+func (f *Format) SetLines(ctx context.Context, db database.Provider, lines []FormatLine) error {
+	if len(lines) == 0 {
+		return errors.New("format has no lines")
+	}
+
+	possibleRatings, err := f.GetPossibleRatings(ctx, db)
+	if err != nil {
+		return err
+	}
+	for i, line1 := range lines {
+		if !IsRatingInOptionsList(possibleRatings, line1.Player1Rating) {
 			return fmt.Errorf("rating for player 1 in line %d (%s) is not in possible options list", i, line1.Player1Rating)
 		}
-		if !f.IsRatingInOptionsList(line1.Player2Rating) {
-			return fmt.Errorf("rating for player 2 in line %d (%s) is not in possible options list", i, line1.Player1Rating)
+		if !IsRatingInOptionsList(possibleRatings, line1.Player2Rating) {
+			return fmt.Errorf("rating for player 2 in line %d (%s) is not in possible options list", i, line1.Player2Rating)
 		}
-		for j, line2 := range f.Lines {
+		for j, line2 := range lines {
 			if i != j && line1.EquivalentTo(line2) {
-				return fmt.Errorf("format has duplicate lines %s at index %d, %s at index %d", line1, i, line2, j)
+				return fmt.Errorf("format has duplicate lines %s at index %d, %s at index %d", line1.String(), i, line2.String(), j)
 			}
 		}
 	}
 
+	existing, err := database.GetAllWhere[*FormatLine](ctx, db, func(_ context.Context, l *FormatLine) bool {
+		return l.FormatId == f.ID
+	})
+	if err != nil {
+		return err
+	}
+	for _, l := range existing {
+		if _, _, err := database.DeleteOneById(ctx, db, l, l.ID); err != nil {
+			return err
+		}
+	}
+	for i, line := range lines {
+		if _, err := database.CreateOne(ctx, db, &FormatLine{
+			FormatId:      f.ID,
+			FormatIndex:   i,
+			Player1Rating: line.Player1Rating,
+			Player2Rating: line.Player2Rating,
+		}); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
-func (f *Format) IsRatingInOptionsList(r RatingId) bool {
-	for _, option := range f.PossibleRatings {
+// DynamicallyValid validates the format against its relationships: the owner
+// exists and, when the format has content (possible ratings / lines set via the
+// Set* methods), that content is well-formed. A freshly-created format starts
+// with empty child tables and is completed by SetPossibleRatings/SetLines, so
+// the non-empty/duplicate/options checks live in those setters rather than
+// here (mirroring how Draft validates rating cutoffs once they are present).
+func (f *Format) DynamicallyValid(ctx context.Context, db database.Provider) error {
+	err := database.ExistsById(ctx, db, &User{}, f.UserId.RecordId())
+	if err != nil {
+		return err
+	}
+
+	possibleRatings, err := f.GetPossibleRatings(ctx, db)
+	if err != nil {
+		return err
+	}
+
+	lines, err := f.GetLines(ctx, db)
+	if err != nil {
+		return err
+	}
+
+	if len(possibleRatings) > 0 && len(lines) > 0 {
+		for i, line1 := range lines {
+			if !IsRatingInOptionsList(possibleRatings, line1.Player1Rating) {
+				return fmt.Errorf("rating for player 1 in line %d (%s) is not in possible options list", i, line1.Player1Rating)
+			}
+			if !IsRatingInOptionsList(possibleRatings, line1.Player2Rating) {
+				return fmt.Errorf("rating for player 2 in line %d (%s) is not in possible options list", i, line1.Player2Rating)
+			}
+			for j, line2 := range lines {
+				if i != j && line1.EquivalentTo(line2) {
+					return fmt.Errorf("format has duplicate lines %s at index %d, %s at index %d", line1.String(), i, line2.String(), j)
+				}
+			}
+		}
+	}
+
+	for _, line := range lines {
+		if err := line.DynamicallyValid(ctx, db); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// IsRatingInOptionsList reports whether r appears in the given possible-ratings list.
+func IsRatingInOptionsList(ratings RatingList, r RatingId) bool {
+	for _, option := range ratings {
 		if r == option {
 			return true
 		}
@@ -242,28 +291,18 @@ func (f *Format) IsRatingInOptionsList(r RatingId) bool {
 	return false
 }
 
-func (f *Format) DynamicallyValid(ctx context.Context, db database.Provider) error {
-	err := database.ExistsById(ctx, db, &User{}, f.UserId.RecordId())
+// IsRatingValidForFormat reports whether r is one of this format's possible ratings.
+func (f *Format) IsRatingValidForFormat(ctx context.Context, db database.Provider, r RatingId) (bool, error) {
+	possibleRatings, err := f.GetPossibleRatings(ctx, db)
 	if err != nil {
-		return err
+		return false, err
 	}
-
-	for _, line := range f.Lines {
-		err := line.DynamicallyValid(ctx, db)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (f *Format) IsRatingValidForFormat(r RatingId) bool {
-	for _, rating := range f.PossibleRatings {
+	for _, rating := range possibleRatings {
 		if r == rating {
-			return true
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
 func (f *Format) GetAssignedDrafts(ctx context.Context, db database.Provider) ([]*Draft, error) {

--- a/model/format_line.go
+++ b/model/format_line.go
@@ -1,0 +1,94 @@
+package model
+
+import (
+	"context"
+	"fmt"
+
+	"intraclub/database"
+)
+
+// FormatLine is a join-table record that binds a Format to a Rating pairing
+// (two RatingId values) that plays as a line in a matchup. It is the fully
+// normalized replacement for the former inline `Format.Lines` slice (see
+// model/format.go), following the same join-table pattern as FormatRating,
+// TeamRating, DraftRatingCutoff, etc.
+//
+// FormatIndex preserves the ordering of lines within a format; it is the value
+// referenced by `LineupPairing.FormatLineIndex`. A natural unique constraint
+// on (FormatId, FormatIndex) prevents two lines from sharing a position.
+type FormatLine struct {
+	ID            database.RecordId `json:"id"`
+	FormatId      FormatId          `json:"format_id"`
+	FormatIndex   int               `json:"format_index"`
+	Player1Rating RatingId          `json:"player_1_rating"`
+	Player2Rating RatingId          `json:"player_2_rating"`
+}
+
+// EquivalentTo reports whether two lines pair the same two ratings, regardless
+// of which player is listed first (i.e. 1/2 is equivalent to 2/1).
+func (l *FormatLine) EquivalentTo(other FormatLine) bool {
+	if l.Player1Rating == other.Player1Rating && l.Player2Rating == other.Player2Rating {
+		return true
+	}
+	if l.Player1Rating == other.Player2Rating && l.Player2Rating == other.Player1Rating {
+		return true
+	}
+	return false
+}
+
+func (l *FormatLine) String() string {
+	return fmt.Sprintf("%s / %s", l.Player1Rating, l.Player2Rating)
+}
+
+func (l *FormatLine) GetOwner() database.UserId {
+	return database.InvalidUserId
+}
+
+func (l *FormatLine) SetOwner(userId database.UserId) {}
+
+func (l *FormatLine) Type() string {
+	return "format_line"
+}
+
+func (l *FormatLine) GetId() database.RecordId {
+	return l.ID
+}
+
+func (l *FormatLine) SetId(id database.RecordId) {
+	l.ID = id
+}
+
+func (l *FormatLine) StaticallyValid() error {
+	return nil
+}
+
+func (l *FormatLine) DynamicallyValid(ctx context.Context, db database.Provider) error {
+	if err := database.ExistsById(ctx, db, &Format{}, l.FormatId.RecordId()); err != nil {
+		return err
+	}
+	if err := database.ExistsById(ctx, db, &Rating{}, l.Player1Rating.RecordId()); err != nil {
+		return err
+	}
+	return database.ExistsById(ctx, db, &Rating{}, l.Player2Rating.RecordId())
+}
+
+func (l *FormatLine) AccessibleTo(ctx context.Context, db database.Provider) []database.UserId {
+	return database.AccessibleToEveryone
+}
+
+func (l *FormatLine) EditableBy(ctx context.Context, db database.Provider) []database.UserId {
+	return []database.UserId{database.SysAdminUserId}
+}
+
+func (l *FormatLine) NewRecord() database.CrudRecord {
+	return new(FormatLine)
+}
+
+// UniquenessEquivalent enforces the natural unique constraint on
+// (FormatId, FormatIndex): a format may only have one line at each position.
+func (l *FormatLine) UniquenessEquivalent(other *FormatLine) error {
+	if l.FormatId == other.FormatId && l.FormatIndex == other.FormatIndex {
+		return fmt.Errorf("format %s already has a line at index %d", l.FormatId, l.FormatIndex)
+	}
+	return nil
+}

--- a/model/format_rating.go
+++ b/model/format_rating.go
@@ -10,10 +10,15 @@ import (
 // FormatRating is a join table record that links a Format to a Rating.
 // This enables efficient reverse lookups from Rating to Formats without
 // scanning the entire Format collection.
+//
+// RatingIndex preserves the ordering of possible ratings within a format
+// (highest-skill to lowest-skill), replacing the former inline
+// `Format.PossibleRatings` slice ordering.
 type FormatRating struct {
-	ID       database.RecordId `json:"id"`
-	FormatId FormatId          `json:"format_id"`
-	RatingId RatingId          `json:"rating_id"`
+	ID          database.RecordId `json:"id"`
+	FormatId    FormatId          `json:"format_id"`
+	RatingId    RatingId          `json:"rating_id"`
+	RatingIndex int               `json:"rating_index"`
 }
 
 func (f *FormatRating) GetOwner() database.UserId {

--- a/model/format_test.go
+++ b/model/format_test.go
@@ -8,17 +8,7 @@ import (
 	"intraclub/database"
 )
 
-func newStoredFormat(t *testing.T, db database.Provider, lines []FormatLine) *Format {
-	f := NewFormat()
-	f.Lines = lines
-
-	v, err := database.CreateOne(context.Background(), db, f)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return v
-}
-
+// newLine creates a FormatLine referencing two stored ratings.
 func newLine(t *testing.T, db database.Provider) FormatLine {
 	return FormatLine{
 		Player1Rating: newStoredRating(t, db).ID,
@@ -26,41 +16,64 @@ func newLine(t *testing.T, db database.Provider) FormatLine {
 	}
 }
 
+// appendUniqueRating appends r to ratings unless it is already present.
+func appendUniqueRating(ratings RatingList, r RatingId) RatingList {
+	for _, existing := range ratings {
+		if existing == r {
+			return ratings
+		}
+	}
+	return append(ratings, r)
+}
+
+// newDefaultFormat creates and stores a format with two lines, whose unique
+// ratings become the format's possible ratings (stored in the format_rating /
+// format_line join tables).
 func newDefaultFormat(t *testing.T, db database.Provider) *Format {
 	user := newStoredUser(t, db)
 	f := NewFormat()
 	f.UserId = user.ID
+	f.Name = "default format"
+
+	created, err := database.CreateOne(context.Background(), db, f)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	lines := []FormatLine{
 		newLine(t, db),
 		newLine(t, db),
 	}
-
-	f.Name = "default format"
-	f.Lines = lines
-	f.PossibleRatings = []RatingId{
-		lines[0].Player1Rating,
-		lines[0].Player2Rating,
-		lines[1].Player1Rating,
-		lines[1].Player2Rating,
+	var ratings RatingList
+	for _, l := range lines {
+		ratings = appendUniqueRating(ratings, l.Player1Rating)
+		ratings = appendUniqueRating(ratings, l.Player2Rating)
 	}
-	return f
+	if err := created.SetPossibleRatings(context.Background(), db, ratings); err != nil {
+		t.Fatal(err)
+	}
+	if err := created.SetLines(context.Background(), db, lines); err != nil {
+		t.Fatal(err)
+	}
+	return created
 }
 
 func newDefaultStoredFormat(t *testing.T, db database.Provider) *Format {
-	f := newDefaultFormat(t, db)
-	v, err := database.CreateOne(context.Background(), db, f)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return v
+	return newDefaultFormat(t, db)
 }
 
 func TestFormatDuplicateLine(t *testing.T) {
 	db := database.NewUnitTestDBProvider()
+	ctx := context.Background()
 
-	format := newDefaultFormat(t, db)
-	format.Lines = []FormatLine{format.Lines[0], format.Lines[0]}
-	err := format.StaticallyValid()
+	format := newDefaultStoredFormat(t, db)
+	lines, err := format.GetLines(ctx, db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dup := lines[0]
+
+	err = format.SetLines(ctx, db, []FormatLine{dup, dup})
 	if err == nil {
 		t.Fatal("Expected duplicate line to fail")
 	}
@@ -69,13 +82,17 @@ func TestFormatDuplicateLine(t *testing.T) {
 
 func TestFormatReversedValueDuplicateLine(t *testing.T) {
 	db := database.NewUnitTestDBProvider()
-	format := newDefaultFormat(t, db)
+	ctx := context.Background()
 
-	line1 := format.Lines[0]
+	format := newDefaultStoredFormat(t, db)
+	lines, err := format.GetLines(ctx, db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	line1 := lines[0]
 	line2 := FormatLine{Player1Rating: line1.Player2Rating, Player2Rating: line1.Player1Rating}
 
-	format.Lines = []FormatLine{line1, line2}
-	err := format.StaticallyValid()
+	err = format.SetLines(ctx, db, []FormatLine{line1, line2})
 	if err == nil {
 		t.Fatal("Expected duplicate line to fail")
 	}
@@ -107,8 +124,8 @@ func TestFormatNameWhitespace(t *testing.T) {
 func TestFormatHasEmptyPossibleRatings(t *testing.T) {
 	db := database.NewUnitTestDBProvider()
 	format := newDefaultStoredFormat(t, db)
-	format.PossibleRatings = []RatingId{}
-	err := format.StaticallyValid()
+
+	err := format.SetPossibleRatings(context.Background(), db, nil)
 	if err == nil {
 		t.Fatal("Expected empty possible ratings to fail")
 	}
@@ -117,7 +134,7 @@ func TestFormatHasEmptyPossibleRatings(t *testing.T) {
 
 func TestFormatHasInvalidUserId(t *testing.T) {
 	db := database.NewUnitTestDBProvider()
-	format := newDefaultFormat(t, db)
+	format := newDefaultStoredFormat(t, db)
 
 	format.UserId = database.InvalidUserId
 	err := format.DynamicallyValid(context.Background(), db)
@@ -130,8 +147,8 @@ func TestFormatHasInvalidUserId(t *testing.T) {
 func TestFormatHasEmptyLines(t *testing.T) {
 	db := database.NewUnitTestDBProvider()
 	format := newDefaultStoredFormat(t, db)
-	format.Lines = []FormatLine{}
-	err := format.StaticallyValid()
+
+	err := format.SetLines(context.Background(), db, nil)
 	if err == nil {
 		t.Fatal("Expected empty lines to fail")
 	}
@@ -141,12 +158,13 @@ func TestFormatHasEmptyLines(t *testing.T) {
 func TestFormatHasLineRatingsNotInPossibleLinesList(t *testing.T) {
 	db := database.NewUnitTestDBProvider()
 	format := newDefaultStoredFormat(t, db)
-	format.Lines = []FormatLine{
-		newLine(t, db),
-	}
-	err := format.StaticallyValid()
+
+	other := newStoredRating(t, db)
+	err := format.SetLines(context.Background(), db, []FormatLine{
+		{Player1Rating: other.ID, Player2Rating: other.ID},
+	})
 	if err == nil {
-		t.Fatal("Expected empty lines to fail")
+		t.Fatal("Expected line ratings not in possible list to fail")
 	}
 	fmt.Println(err)
 }
@@ -170,8 +188,6 @@ func TestFormatCannotBeEditedWhenInUse(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	newRating := newStoredRating(t, db)
-	format.PossibleRatings = append(format.PossibleRatings, newRating.ID)
 	err = database.UpdateOne(context.Background(), db, format)
 	if err == nil {
 		t.Fatal("Expected in-use format edit to fail")
@@ -183,54 +199,60 @@ func TestFormatCanBeEditedWhenNotInUse(t *testing.T) {
 	db := database.NewUnitTestDBProvider()
 	f := newDefaultStoredFormat(t, db)
 
-	newRating := newStoredRating(t, db)
-	f.PossibleRatings = append(f.PossibleRatings, newRating.ID)
-
+	f.Name = "renamed format"
 	err := database.UpdateOne(context.Background(), db, f)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
-func TestFormatPostCreateCreatesFormatRatings(t *testing.T) {
+func TestFormatSetPossibleRatingsCreatesFormatRatings(t *testing.T) {
 	db := database.NewUnitTestDBProvider()
-	format := newDefaultStoredFormat(t, db)
+	ctx := context.Background()
 
-	formatRatings, err := database.GetAllWhere[*FormatRating](context.Background(), db, func(_ context.Context, fr *FormatRating) bool {
+	format := newDefaultFormat(t, db)
+	got, err := format.GetPossibleRatings(ctx, db)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	formatRatings, err := database.GetAllWhere[*FormatRating](ctx, db, func(_ context.Context, fr *FormatRating) bool {
 		return fr.FormatId == format.ID
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(formatRatings) != len(format.PossibleRatings) {
-		t.Fatalf("Expected %d FormatRating records, got %d", len(format.PossibleRatings), len(formatRatings))
+	if len(formatRatings) != len(got) {
+		t.Fatalf("Expected %d FormatRating records, got %d", len(got), len(formatRatings))
 	}
 }
 
-func TestFormatPostUpdateAddsNewRating(t *testing.T) {
+func TestFormatSetPossibleRatingsAddsNewRating(t *testing.T) {
 	db := database.NewUnitTestDBProvider()
+	ctx := context.Background()
+
 	format := newDefaultStoredFormat(t, db)
+	before, err := format.GetPossibleRatings(ctx, db)
+	if err != nil {
+		t.Fatal(err)
+	}
 	newRating := newStoredRating(t, db)
-
-	format.PossibleRatings = append(format.PossibleRatings, newRating.ID)
-	err := database.UpdateOne(context.Background(), db, format)
-	if err != nil {
+	after := append(append(RatingList{}, before...), newRating.ID)
+	if err := format.SetPossibleRatings(ctx, db, after); err != nil {
 		t.Fatal(err)
 	}
 
-	formatRatings, err := database.GetAllWhere[*FormatRating](context.Background(), db, func(_ context.Context, fr *FormatRating) bool {
-		return fr.FormatId == format.ID
-	})
+	got, err := format.GetPossibleRatings(ctx, db)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(formatRatings) != len(format.PossibleRatings) {
-		t.Fatalf("Expected %d FormatRating records, got %d", len(format.PossibleRatings), len(formatRatings))
+	if len(got) != len(after) {
+		t.Fatalf("Expected %d FormatRating records, got %d", len(after), len(got))
 	}
 
 	found := false
-	for _, fr := range formatRatings {
-		if fr.RatingId == newRating.ID {
+	for _, r := range got {
+		if r == newRating.ID {
 			found = true
 			break
 		}
@@ -240,45 +262,36 @@ func TestFormatPostUpdateAddsNewRating(t *testing.T) {
 	}
 }
 
-func TestFormatPostUpdateRemovesOldRating(t *testing.T) {
+func TestFormatSetPossibleRatingsRemovesOldRating(t *testing.T) {
 	db := database.NewUnitTestDBProvider()
+	ctx := context.Background()
+
 	format := newDefaultStoredFormat(t, db)
+	before, err := format.GetPossibleRatings(ctx, db)
+	if err != nil {
+		t.Fatal(err)
+	}
 	extraRating := newStoredRating(t, db)
-
-	format.PossibleRatings = append(format.PossibleRatings, extraRating.ID)
-	err := database.UpdateOne(context.Background(), db, format)
-	if err != nil {
+	withExtra := append(append(RatingList{}, before...), extraRating.ID)
+	if err := format.SetPossibleRatings(ctx, db, withExtra); err != nil {
 		t.Fatal(err)
 	}
 
-	formatRatings, err := database.GetAllWhere[*FormatRating](context.Background(), db, func(_ context.Context, fr *FormatRating) bool {
-		return fr.FormatId == format.ID
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(formatRatings) != 5 {
-		t.Fatalf("Expected 5 FormatRating records after add, got %d", len(formatRatings))
-	}
-
-	format.PossibleRatings = format.PossibleRatings[:4]
-	err = database.UpdateOne(context.Background(), db, format)
-	if err != nil {
+	withoutExtra := withExtra[:len(withExtra)-1]
+	if err := format.SetPossibleRatings(ctx, db, withoutExtra); err != nil {
 		t.Fatal(err)
 	}
 
-	formatRatings, err = database.GetAllWhere[*FormatRating](context.Background(), db, func(_ context.Context, fr *FormatRating) bool {
-		return fr.FormatId == format.ID
-	})
+	got, err := format.GetPossibleRatings(ctx, db)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(formatRatings) != 4 {
-		t.Fatalf("Expected 4 FormatRating records after remove, got %d", len(formatRatings))
+	if len(got) != len(withoutExtra) {
+		t.Fatalf("Expected %d FormatRating records after remove, got %d", len(withoutExtra), len(got))
 	}
 
-	for _, fr := range formatRatings {
-		if fr.RatingId == extraRating.ID {
+	for _, r := range got {
+		if r == extraRating.ID {
 			t.Fatal("Expected removed rating to not be in FormatRating records")
 		}
 	}
@@ -337,8 +350,9 @@ func TestFormatRatingDuplicateFails(t *testing.T) {
 	})
 
 	duplicate := &FormatRating{
-		FormatId: format.ID,
-		RatingId: formatRatings[0].RatingId,
+		FormatId:    format.ID,
+		RatingId:    formatRatings[0].RatingId,
+		RatingIndex: formatRatings[0].RatingIndex,
 	}
 	_, err := database.CreateOne(context.Background(), db, duplicate)
 	if err == nil {

--- a/model/individual_match.go
+++ b/model/individual_match.go
@@ -69,6 +69,7 @@ type IndividualMatch struct {
 	_structure     *ScoringStructure   `json:"-" bson:"-"`
 	_subStructures []*ScoringStructure `json:"-" bson:"-"`
 	_completed     []CompletedSecondary
+	_isComposite   bool `json:"-" bson:"-"`
 }
 
 func (s *IndividualMatch) GetOwner() database.UserId {
@@ -154,14 +155,17 @@ func (s *IndividualMatch) Initialize(ctx context.Context, db database.Provider) 
 
 		// if the scoring structure is composite, we need to retrieve all
 		// the sub-structures referenced by it as well
-		if v.IsComposite() {
-			for _, id := range v.SecondaryScoringStructures {
-				sub, err := database.GetExistingRecordById(ctx, db, &ScoringStructure{}, id.RecordId())
-				if err != nil {
-					return err
-				}
-				s._subStructures = append(s._subStructures, sub)
+		secondary, err := v.GetSecondaryScoringStructures(ctx, db)
+		if err != nil {
+			return err
+		}
+		s._isComposite = len(secondary) > 0
+		for _, id := range secondary {
+			sub, err := database.GetExistingRecordById(ctx, db, &ScoringStructure{}, id.RecordId())
+			if err != nil {
+				return err
 			}
+			s._subStructures = append(s._subStructures, sub)
 		}
 	}
 	return nil
@@ -185,7 +189,7 @@ func (s *IndividualMatch) WonSecondary(opp *IndividualMatch) bool {
 	if s._structure == nil {
 		panic("match._structure is not initialized")
 	}
-	if !s._structure.IsComposite() {
+	if !s._isComposite {
 		panic("match._structure is not composite, WonSecondary does not make sense to call")
 	} else {
 		if len(s._subStructures) == 0 {

--- a/model/lineup_pairing.go
+++ b/model/lineup_pairing.go
@@ -103,9 +103,14 @@ func (l *LineupPairing) DynamicallyValid(ctx context.Context, db database.Provid
 		return err
 	}
 
+	lines, err := format.GetLines(ctx, db)
+	if err != nil {
+		return err
+	}
+
 	// check that the line index for this pairing is within the bounds of the format
-	if l.FormatLineIndex >= len(format.Lines) {
-		return fmt.Errorf("format line index out of range: %d, max %d", l.FormatLineIndex, len(format.Lines)-1)
+	if l.FormatLineIndex >= len(lines) {
+		return fmt.Errorf("format line index out of range: %d, max %d", l.FormatLineIndex, len(lines)-1)
 	}
 	return nil
 }
@@ -132,11 +137,15 @@ func (l *LineupPairing) ValidatePlayerRatings(ctx context.Context, db database.P
 	if err != nil {
 		return err
 	}
+	lines, err := format.GetLines(ctx, db)
+	if err != nil {
+		return err
+	}
 	team, err := database.GetExistingRecordById(ctx, db, &Team{}, l.TeamId.RecordId())
 	if err != nil {
 		return err
 	}
-	line := format.Lines[l.FormatLineIndex]
+	line := lines[l.FormatLineIndex]
 
 	rating1, err := team.GetRating(ctx, db, l.Player1)
 	if err != nil {

--- a/model/playoff_structure.go
+++ b/model/playoff_structure.go
@@ -20,7 +20,7 @@ func (id PlayoffStructureId) String() string {
 }
 
 type PlayoffStructure struct {
-	ID            PlayoffStructureId // unique ID for this record
+	ID            PlayoffStructureId `json:"id"` // unique ID for this record
 	UserId        database.UserId
 	Byes          int // number of teams which get a bye week
 	NumberOfTeams int // number of teams which make the playoffs

--- a/model/pre_draft_grade.go
+++ b/model/pre_draft_grade.go
@@ -112,14 +112,18 @@ func (p *PreDraftGrade) DynamicallyValid(ctx context.Context, db database.Provid
 		return err
 	}
 
-	if !format.IsRatingValidForFormat(p.Rating) {
+	valid, err := format.IsRatingValidForFormat(ctx, db, p.Rating)
+	if err != nil {
+		return err
+	}
+	if !valid {
 		return fmt.Errorf("rating %s is not a valid rating for draft's format %s", p.Rating, draft.Format.RecordId())
 	}
 	return nil
 }
 
 // NumericRating calculates a numeric rating for this PreDraftGrade based
-// on the provided Format
+// on the provided possible-ratings list (in the draft's format)
 //
 // rating base value is calculated as
 //   - no rating: 0
@@ -139,10 +143,10 @@ func (p *PreDraftGrade) DynamicallyValid(ctx context.Context, db database.Provid
 //   - a WeakModifier 1 would get a 7 numeric rating
 //   - an AverageModifier 1 would get an 8 numeric rating
 //   - a StrongModifier 1 would get a 9 numeric rating
-func (p *PreDraftGrade) NumericRating(format *Format) float64 {
+func (p *PreDraftGrade) NumericRating(possibleRatings []RatingId) float64 {
 
 	ratingIndex := -1
-	for i, rating := range format.PossibleRatings {
+	for i, rating := range possibleRatings {
 		if p.Rating == rating {
 			ratingIndex = i
 			break
@@ -156,7 +160,7 @@ func (p *PreDraftGrade) NumericRating(format *Format) float64 {
 	// 3 * (len - 1 - ratingIndex) <--- so that a weak 2 is 1 higher than a strong 3
 	// + 1                         <--- so that an unrated player is lower than the weakest 3
 	// + modifier                  <--- so that a strong 3 is higher than a weak or average 3
-	ratingBaseValue := (len(format.PossibleRatings)-ratingIndex-1)*3 + 1
+	ratingBaseValue := (len(possibleRatings)-ratingIndex-1)*3 + 1
 	return float64(ratingBaseValue + p.Modifier.Int())
 }
 
@@ -182,7 +186,7 @@ func GetPreDraftGradesByDraftId(ctx context.Context, db database.Provider, draft
 	})
 }
 
-func GetDraftAggregateForPlayer(allGrades []*PreDraftGrade, format *Format, id database.UserId) PreDraftAggregate {
+func GetDraftAggregateForPlayer(allGrades []*PreDraftGrade, possibleRatings []RatingId, id database.UserId) PreDraftAggregate {
 
 	// filter down to only the grades for this particular player ID
 	gradesForThisPlayer := make([]*PreDraftGrade, 0)
@@ -195,7 +199,7 @@ func GetDraftAggregateForPlayer(allGrades []*PreDraftGrade, format *Format, id d
 	// get the numeric value of each grade
 	numeric := 0.0
 	for _, grade := range gradesForThisPlayer {
-		numeric += grade.NumericRating(format)
+		numeric += grade.NumericRating(possibleRatings)
 	}
 	// get the average of all numeric ratings
 	if len(gradesForThisPlayer) > 0 {
@@ -222,6 +226,10 @@ func GetSortedListOfAllPreDraftGradesDescending(ctx context.Context, db database
 	if err != nil {
 		return nil, err
 	}
+	possibleRatings, err := format.GetPossibleRatings(ctx, db)
+	if err != nil {
+		return nil, err
+	}
 
 	// for each player in the available-to-draft list, get their pre-draft aggregate
 	aggregates := make([]PreDraftAggregate, 0)
@@ -231,7 +239,7 @@ func GetSortedListOfAllPreDraftGradesDescending(ctx context.Context, db database
 	}
 	for _, player := range availablePlayers {
 		// get pre-draft aggregate for each player in the list
-		a := GetDraftAggregateForPlayer(allGrades, format, player)
+		a := GetDraftAggregateForPlayer(allGrades, possibleRatings, player)
 		aggregates = append(aggregates, a)
 	}
 

--- a/model/pre_draft_grade_test.go
+++ b/model/pre_draft_grade_test.go
@@ -26,6 +26,11 @@ func generateRandomPreDraftGrades(t *testing.T, db database.Provider, playerCoun
 		t.Fatal(err)
 	}
 
+	possibleRatings, err := format.GetPossibleRatings(context.Background(), db)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	for _, playerId := range availablePlayers {
 
 		// create X grades per player
@@ -33,14 +38,14 @@ func generateRandomPreDraftGrades(t *testing.T, db database.Provider, playerCoun
 			// grader will just be the first X user IDs in the available list
 			grader := availablePlayers[i%len(availablePlayers)]
 
-			ratingIndex := rand.Intn(len(format.PossibleRatings)) // random rating
-			modifier := PreDraftRatingModifier(rand.Intn(3))      // random modifier
+			ratingIndex := rand.Intn(len(possibleRatings))   // random rating
+			modifier := PreDraftRatingModifier(rand.Intn(3)) // random modifier
 
 			grade := NewPreDraftGrade()
 			grade.PlayerId = playerId
 			grade.GraderId = grader
 			grade.DraftId = randomDraft.ID
-			grade.Rating = format.PossibleRatings[ratingIndex]
+			grade.Rating = possibleRatings[ratingIndex]
 			grade.Modifier = modifier
 
 			// create the grade
@@ -65,11 +70,16 @@ func newValidGrade(t *testing.T, db database.Provider) *PreDraftGrade {
 		t.Fatal(err)
 	}
 
+	possibleRatings, err := format.GetPossibleRatings(context.Background(), db)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	grade := NewPreDraftGrade()
 	grade.PlayerId = availablePlayers[0]
 	grade.GraderId = availablePlayers[0]
 	grade.DraftId = randomDraft.ID
-	grade.Rating = format.PossibleRatings[0]
+	grade.Rating = possibleRatings[0]
 	return grade
 }
 
@@ -241,6 +251,10 @@ func TestCalculateNumericGrades(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	possibleRatings, err := format.GetPossibleRatings(context.Background(), db)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	playerToGrade := availablePlayers[0]
 
@@ -248,27 +262,27 @@ func TestCalculateNumericGrades(t *testing.T) {
 	grade.PlayerId = playerToGrade
 	grade.GraderId = playerToGrade
 	grade.DraftId = draft.ID
-	grade.Rating = format.PossibleRatings[0]
+	grade.Rating = possibleRatings[0]
 
-	numeric := grade.NumericRating(format)
+	numeric := grade.NumericRating(possibleRatings)
 	if numeric != 10 {
 		t.Fatalf("Expected 10 numeric rating, got %f", numeric)
 	}
 
-	grade.Rating = format.PossibleRatings[1]
-	numeric = grade.NumericRating(format)
+	grade.Rating = possibleRatings[1]
+	numeric = grade.NumericRating(possibleRatings)
 	if numeric != 7 {
 		t.Fatalf("Expected 7 numeric rating, got %f", numeric)
 	}
 
-	grade.Rating = format.PossibleRatings[2]
-	numeric = grade.NumericRating(format)
+	grade.Rating = possibleRatings[2]
+	numeric = grade.NumericRating(possibleRatings)
 	if numeric != 4 {
 		t.Fatalf("Expected 4 numeric rating, got %f", numeric)
 	}
 
-	grade.Rating = format.PossibleRatings[3]
-	numeric = grade.NumericRating(format)
+	grade.Rating = possibleRatings[3]
+	numeric = grade.NumericRating(possibleRatings)
 	if numeric != 1 {
 		t.Fatalf("Expected 1 numeric rating, got %f", numeric)
 	}
@@ -287,12 +301,16 @@ func TestGradeWhenDraftIsCompleted(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	possibleRatings, err := format.GetPossibleRatings(context.Background(), db)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	grade := NewPreDraftGrade()
 	grade.PlayerId = availablePlayers[0]
 	grade.GraderId = availablePlayers[0]
 	grade.DraftId = draft.ID
-	grade.Rating = format.PossibleRatings[0]
+	grade.Rating = possibleRatings[0]
 
 	err = grade.DynamicallyValid(context.Background(), db)
 	if err == nil {

--- a/model/rating_test.go
+++ b/model/rating_test.go
@@ -118,7 +118,11 @@ func TestRatingCannotBeDeletedWhenInUse(t *testing.T) {
 	db := database.NewUnitTestDBProvider()
 	format := newDefaultStoredFormat(t, db)
 
-	ratingId := format.PossibleRatings[0].RecordId()
+	possibleRatings, err := format.GetPossibleRatings(context.Background(), db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ratingId := possibleRatings[0].RecordId()
 	rating, err := database.GetExistingRecordById(context.Background(), db, &Rating{}, ratingId)
 	if err != nil {
 		t.Fatal(err)

--- a/model/scoring_structure.go
+++ b/model/scoring_structure.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"slices"
 
 	"intraclub/api"
 	"intraclub/database"
@@ -154,7 +155,6 @@ type ScoringStructureList []ScoringStructureId
 
 func (s *ScoringStructureList) UnmarshalJSON(bytes []byte) error {
 	s2 := make([]string, 0)
-	fmt.Println(string(bytes))
 	err := json.Unmarshal(bytes, &s2)
 	if err != nil {
 		return err
@@ -198,23 +198,16 @@ type ScoringStructure struct {
 	// threshold that a team instantly wins at, bypassing the
 	// win-by-X constraint
 	WinCondition WinCondition `json:"win_condition"`
-
-	// SecondaryScoringStructures is a list of ScoringStructure
-	// references that are used as a secondary mechanism to increment
-	// the WinConditionCountingType. For example in a standard tennis
-	// scoring structure, the primary win condition is winning 2 out
-	// of 3 sets. But to win a _set_, you must first win a requisite
-	// number of _games_, i.e. first to 6, win-by-two
-	//
-	// You could theoretically make the scoring even further nested
-	// by specifying that _games_ must be won by winning a requisite
-	// number of _points_, but this requires very active score-keeping
-	// during a match and does not provide a lot of extra value for
-	// the most part (i.e. a 6-0, 6-0 match does not gain much explanatory
-	// context by recording that individual games were typically won
-	// from a 40-15 or 40-love score)
-	SecondaryScoringStructures ScoringStructureList `json:"secondary_scoring_structures"`
 }
+
+// API/JSON shape decision: the former inline `secondary_scoring_structures`
+// (`ScoringStructureList`) field has been removed from `ScoringStructure` and
+// normalized into the `ScoringStructureSecondary` join table
+// (scoring_structure_secondary collection). In-process reads reassemble the
+// ordered references via `ScoringStructure.GetSecondaryScoringStructures`, and
+// composite-ness is determined by `ScoringStructure.IsComposite`. This matches
+// the join-table normalization of Format (format_rating / format_line) and
+// Draft (draft_rating_cutoff).
 
 func (c *ScoringStructure) UniquenessEquivalent(other *ScoringStructure) error {
 	if c.Name == other.Name {
@@ -255,7 +248,64 @@ func (c *ScoringStructure) SetOwner(userId database.UserId) {
 	c.Owner = userId
 }
 
-func (c *ScoringStructure) MaximumScoreCountingUnitsPlayed() (int, error) {
+// GetSecondaryScoringStructures returns this scoring structure's secondary
+// scoring structure references, ordered by ScoringStructureSecondary.SecondaryIndex.
+func (c *ScoringStructure) GetSecondaryScoringStructures(ctx context.Context, db database.Provider) (ScoringStructureList, error) {
+	rows, err := database.GetAllWhere[*ScoringStructureSecondary](ctx, db, func(_ context.Context, s *ScoringStructureSecondary) bool {
+		return s.ScoringStructureId == c.ID
+	})
+	if err != nil {
+		return nil, err
+	}
+	slices.SortFunc(rows, func(a, b *ScoringStructureSecondary) int {
+		return a.SecondaryIndex - b.SecondaryIndex
+	})
+	list := make(ScoringStructureList, 0, len(rows))
+	for _, r := range rows {
+		list = append(list, r.SecondaryScoringStructureId)
+	}
+	return list, nil
+}
+
+// SetSecondaryScoringStructures replaces this scoring structure's secondary
+// references with the provided list, preserving order as SecondaryIndex values
+// in the ScoringStructureSecondary join table. The scoring structure must
+// already have an assigned ID (i.e. be created).
+func (c *ScoringStructure) SetSecondaryScoringStructures(ctx context.Context, db database.Provider, list ScoringStructureList) error {
+	existing, err := database.GetAllWhere[*ScoringStructureSecondary](ctx, db, func(_ context.Context, s *ScoringStructureSecondary) bool {
+		return s.ScoringStructureId == c.ID
+	})
+	if err != nil {
+		return err
+	}
+	for _, s := range existing {
+		if _, _, err := database.DeleteOneById(ctx, db, s, s.ID); err != nil {
+			return err
+		}
+	}
+	for i, id := range list {
+		if _, err := database.CreateOne(ctx, db, &ScoringStructureSecondary{
+			ScoringStructureId:          c.ID,
+			SecondaryScoringStructureId: id,
+			SecondaryIndex:              i,
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// IsComposite reports whether this scoring structure has any secondary scoring
+// structures (i.e. it is a composite scoring structure).
+func (c *ScoringStructure) IsComposite(ctx context.Context, db database.Provider) (bool, error) {
+	list, err := c.GetSecondaryScoringStructures(ctx, db)
+	if err != nil {
+		return false, err
+	}
+	return len(list) > 0, nil
+}
+
+func (c *ScoringStructure) MaximumScoreCountingUnitsPlayed(secondaryCount int) (int, error) {
 	if c.WinCondition.HasInstantWinThreshold() {
 		// if we have an instant win at e.g. 3 sets, we can play at most (3 * 2) - 1 = 5 total sets
 		return (c.WinCondition.InstantWinThreshold * 2) - 1, nil
@@ -264,7 +314,7 @@ func (c *ScoringStructure) MaximumScoreCountingUnitsPlayed() (int, error) {
 	normalWinThreshold := (c.WinCondition.WinThreshold * 2) - 1
 
 	if c.WinCondition.WinByTwoOrMore() {
-		if c.IsComposite() {
+		if secondaryCount > 0 {
 			return normalWinThreshold, fmt.Errorf("composite scoring structure does not support win-by-two-or-more constraint without instant win threshold")
 		} else {
 			return -1, nil
@@ -273,63 +323,58 @@ func (c *ScoringStructure) MaximumScoreCountingUnitsPlayed() (int, error) {
 	return normalWinThreshold, nil
 }
 
-func (c *ScoringStructure) IsComposite() bool {
-	return len(c.SecondaryScoringStructures) > 0
-}
-
+// StaticallyValid validates this scoring structure's scalar fields (win
+// condition counting type and win condition). Composite-specific validation
+// (which requires querying the secondary scoring structure relationships) is
+// performed by DynamicallyValid.
 func (c *ScoringStructure) StaticallyValid() error {
 	// make sure the win condition counting type is legitimate
 	err := c.WinConditionCountingType.StaticallyValid()
 	if err != nil {
 		return err
 	}
+	return c.WinCondition.StaticallyValid()
+}
 
-	err = c.WinCondition.StaticallyValid()
+func (c *ScoringStructure) DynamicallyValid(ctx context.Context, db database.Provider) error {
+	secondary, err := c.GetSecondaryScoringStructures(ctx, db)
 	if err != nil {
 		return err
 	}
 
-	if c.IsComposite() {
+	// validate each secondary reference: it must exist and use the expected
+	// score-counting type for a secondary of this structure
+	for _, id := range secondary {
+		secondaryStructure, err := database.GetExistingRecordById(ctx, db, &ScoringStructure{}, id.RecordId())
+		if err != nil {
+			return err
+		}
 
+		if secondaryStructure.WinConditionCountingType != c.WinConditionCountingType.Secondary() {
+			return fmt.Errorf("cannot use %s-based secondary scoring structure in %s-based win condition", secondaryStructure.WinConditionCountingType, c.WinConditionCountingType)
+		}
+	}
+
+	// composite-specific validation
+	if len(secondary) > 0 {
 		if c.WinConditionCountingType == Point {
 			return fmt.Errorf("cannot use point-based win condition in a composite scoring structure")
 		}
 
-		// get the maximum number of win-condition scoring units that we might play.
-		// e.g. in a first-to-2 sets "standard tennis" scoring structure the max
-		// amount of sets you can play is 3. In a "first to 10 points, straight up"
-		// scoring structure, the maximum amount of total points would be in a 10 to 9
-		// victory, so 19 total points.
-		maxUnits, err := c.MaximumScoreCountingUnitsPlayed()
+		maxUnits, err := c.MaximumScoreCountingUnitsPlayed(len(secondary))
 		if err != nil {
 			return err
 		}
 
-		l := len(c.SecondaryScoringStructures)
-		if l != maxUnits {
-
+		if len(secondary) != maxUnits {
 			// we must have the same length of secondary scoring structures as the max amount of
 			// main score-counting units in the scoring win-condition scoring configuration. For
 			// example, if we can play a max number of 3 sets in this scoring structure, we must
 			// have a way to score all three of those sets using a ScoringStructure reference.
-			return fmt.Errorf("secondary scoring structures length is %d, but we can play %d max %ss in this structure", l, maxUnits, c.WinConditionCountingType)
+			return fmt.Errorf("secondary scoring structures length is %d, but we can play %d max %ss in this structure", len(secondary), maxUnits, c.WinConditionCountingType)
 		}
 	}
-	return nil
-}
 
-func (c *ScoringStructure) DynamicallyValid(ctx context.Context, db database.Provider) error {
-	for _, id := range c.SecondaryScoringStructures {
-		secondary, err := database.GetExistingRecordById(ctx, db, &ScoringStructure{}, id.RecordId())
-		if err != nil {
-			return err
-		}
-
-		if secondary.WinConditionCountingType != c.WinConditionCountingType.Secondary() {
-			return fmt.Errorf("cannot use %s-based secondary scoring structure in %s-based win condition", secondary.WinConditionCountingType, c.WinConditionCountingType)
-		}
-
-	}
 	return database.ExistsById(ctx, db, &User{}, c.Owner.RecordId())
 }
 

--- a/model/scoring_structure_secondary.go
+++ b/model/scoring_structure_secondary.go
@@ -1,0 +1,77 @@
+package model
+
+import (
+	"context"
+	"fmt"
+
+	"intraclub/database"
+)
+
+// ScoringStructureSecondary is a join-table record that links a (composite)
+// ScoringStructure to one of its secondary ScoringStructure references. It is
+// the fully normalized replacement for the former inline
+// `ScoringStructure.SecondaryScoringStructures` slice (see model/scoring_structure.go),
+// following the same join-table pattern as FormatRating, FormatLine, etc.
+//
+// SecondaryIndex preserves the ordering of the secondary scoring structures,
+// which maps positionally onto the maximum number of playable win-condition
+// units (see ScoringStructure.StaticallyValid/DynamicallyValid). A natural
+// unique constraint on (ScoringStructureId, SecondaryIndex) prevents two
+// secondaries from sharing a position.
+type ScoringStructureSecondary struct {
+	ID                          database.RecordId  `json:"id"`
+	ScoringStructureId          ScoringStructureId `json:"scoring_structure_id"`
+	SecondaryScoringStructureId ScoringStructureId `json:"secondary_scoring_structure_id"`
+	SecondaryIndex              int                `json:"secondary_index"`
+}
+
+func (s *ScoringStructureSecondary) GetOwner() database.UserId {
+	return database.InvalidUserId
+}
+
+func (s *ScoringStructureSecondary) SetOwner(userId database.UserId) {}
+
+func (s *ScoringStructureSecondary) Type() string {
+	return "scoring_structure_secondary"
+}
+
+func (s *ScoringStructureSecondary) GetId() database.RecordId {
+	return s.ID
+}
+
+func (s *ScoringStructureSecondary) SetId(id database.RecordId) {
+	s.ID = id
+}
+
+func (s *ScoringStructureSecondary) StaticallyValid() error {
+	return nil
+}
+
+func (s *ScoringStructureSecondary) DynamicallyValid(ctx context.Context, db database.Provider) error {
+	if err := database.ExistsById(ctx, db, &ScoringStructure{}, s.ScoringStructureId.RecordId()); err != nil {
+		return err
+	}
+	return database.ExistsById(ctx, db, &ScoringStructure{}, s.SecondaryScoringStructureId.RecordId())
+}
+
+func (s *ScoringStructureSecondary) AccessibleTo(ctx context.Context, db database.Provider) []database.UserId {
+	return database.AccessibleToEveryone
+}
+
+func (s *ScoringStructureSecondary) EditableBy(ctx context.Context, db database.Provider) []database.UserId {
+	return []database.UserId{database.SysAdminUserId}
+}
+
+func (s *ScoringStructureSecondary) NewRecord() database.CrudRecord {
+	return new(ScoringStructureSecondary)
+}
+
+// UniquenessEquivalent enforces the natural unique constraint on
+// (ScoringStructureId, SecondaryIndex): a scoring structure may only have one
+// secondary at each position.
+func (s *ScoringStructureSecondary) UniquenessEquivalent(other *ScoringStructureSecondary) error {
+	if s.ScoringStructureId == other.ScoringStructureId && s.SecondaryIndex == other.SecondaryIndex {
+		return fmt.Errorf("scoring structure %s already has a secondary at index %d", s.ScoringStructureId, s.SecondaryIndex)
+	}
+	return nil
+}

--- a/model/scoring_structure_test.go
+++ b/model/scoring_structure_test.go
@@ -36,20 +36,25 @@ var TennisTiebreakThirdSet = ScoringStructure{
 	},
 }
 
+var testScoringSeq int
+
 func newDefaultStoredScoringStructure(t *testing.T, db database.Provider) *ScoringStructure {
 
 	s := newDefaultStoredSetScoringStructure(t, db)
-	matchScoringStructure := &TennisMatchScoringStructure
+	testScoringSeq++
+	matchScoringStructure := TennisMatchScoringStructure
 	matchScoringStructure.Owner = s.Owner
-	matchScoringStructure.Name = "test-match-scoring"
-	matchScoringStructure.SecondaryScoringStructures = []ScoringStructureId{
-		s.ID,
-		s.ID,
-		s.ID,
-	}
+	matchScoringStructure.Name = fmt.Sprintf("test-match-scoring-%d", testScoringSeq)
 
-	m, err := database.CreateOne(context.Background(), db, matchScoringStructure)
+	m, err := database.CreateOne(context.Background(), db, &matchScoringStructure)
 	if err != nil {
+		t.Fatal(err)
+	}
+	if err := m.SetSecondaryScoringStructures(context.Background(), db, ScoringStructureList{
+		s.ID,
+		s.ID,
+		s.ID,
+	}); err != nil {
 		t.Fatal(err)
 	}
 	return m
@@ -60,17 +65,20 @@ func newThirdSetTiebreakScoringStructure(t *testing.T, db database.Provider) *Sc
 	s := newDefaultStoredSetScoringStructure(t, db)
 	s2 := newTenPointTiebreakSetScoringStructure(t, db)
 
-	matchScoringStructure := &TennisMatchScoringStructure
+	testScoringSeq++
+	matchScoringStructure := TennisMatchScoringStructure
 	matchScoringStructure.Owner = s.Owner
-	matchScoringStructure.Name = "test-tiebreak-match-scoring"
-	matchScoringStructure.SecondaryScoringStructures = []ScoringStructureId{
+	matchScoringStructure.Name = fmt.Sprintf("test-tiebreak-match-scoring-%d", testScoringSeq)
+
+	m, err := database.CreateOne(context.Background(), db, &matchScoringStructure)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := m.SetSecondaryScoringStructures(context.Background(), db, ScoringStructureList{
 		s.ID,
 		s.ID,
 		s2.ID,
-	}
-
-	m, err := database.CreateOne(context.Background(), db, matchScoringStructure)
-	if err != nil {
+	}); err != nil {
 		t.Fatal(err)
 	}
 	return m
@@ -175,17 +183,21 @@ func TestWinByConstraintIsZero(t *testing.T) {
 
 func TestIncorrectAmountOfSecondaryScoringStructures(t *testing.T) {
 	db := database.NewUnitTestDBProvider()
+	ctx := context.Background()
 	ref := newDefaultStoredSetScoringStructure(t, db)
 
-	s := ScoringStructure{}
-	s.WinConditionCountingType = Set
-	s.WinCondition = WinCondition{
-		WinThreshold: 2,
-		MustWinBy:    1,
+	s := TennisMatchScoringStructure
+	s.Owner = newStoredUser(t, db).ID
+	s.Name = "bad-count"
+	created, err := database.CreateOne(ctx, db, &s)
+	if err != nil {
+		t.Fatal(err)
 	}
-	s.SecondaryScoringStructures = []ScoringStructureId{ref.ID}
+	if err := created.SetSecondaryScoringStructures(ctx, db, ScoringStructureList{ref.ID}); err != nil {
+		t.Fatal(err)
+	}
 
-	err := s.StaticallyValid()
+	err = created.DynamicallyValid(ctx, db)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -194,6 +206,7 @@ func TestIncorrectAmountOfSecondaryScoringStructures(t *testing.T) {
 
 func TestIndeterminateWinConditionWithSecondaryScoringStructures(t *testing.T) {
 	db := database.NewUnitTestDBProvider()
+	ctx := context.Background()
 	ref := newDefaultStoredSetScoringStructure(t, db)
 
 	s := ScoringStructure{}
@@ -202,9 +215,17 @@ func TestIndeterminateWinConditionWithSecondaryScoringStructures(t *testing.T) {
 		WinThreshold: 6,
 		MustWinBy:    2,
 	}
-	s.SecondaryScoringStructures = []ScoringStructureId{ref.ID}
+	s.Owner = newStoredUser(t, db).ID
+	s.Name = "indeterminate"
+	created, err := database.CreateOne(ctx, db, &s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := created.SetSecondaryScoringStructures(ctx, db, ScoringStructureList{ref.ID}); err != nil {
+		t.Fatal(err)
+	}
 
-	err := s.StaticallyValid()
+	err = created.DynamicallyValid(ctx, db)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -213,15 +234,15 @@ func TestIndeterminateWinConditionWithSecondaryScoringStructures(t *testing.T) {
 
 func TestInvalidSecondaryScoreReference(t *testing.T) {
 	db := database.NewUnitTestDBProvider()
-	s := ScoringStructure{}
-	s.WinConditionCountingType = Set
-	s.WinCondition = WinCondition{
-		WinThreshold: 6,
-		MustWinBy:    2,
-	}
-	s.SecondaryScoringStructures = []ScoringStructureId{ScoringStructureId(database.InvalidRecordId)}
+	ctx := context.Background()
+	s := newDefaultStoredScoringStructure(t, db)
 
-	err := s.DynamicallyValid(context.Background(), db)
+	bad := &ScoringStructureSecondary{
+		ScoringStructureId:          s.ID,
+		SecondaryScoringStructureId: ScoringStructureId(database.InvalidRecordId),
+		SecondaryIndex:              99,
+	}
+	_, err := database.CreateOne(ctx, db, bad)
 	if err == nil {
 		t.Fatal("expected error")
 	}


### PR DESCRIPTION
## Summary

Implements **#59** — a fully-normalized SQLite schema + field-level round-trip test for:

- `format`
- `format_rating`
- `format_line` *(new child table)*
- `ruleset`
- `rule_section`
- `ruleset_section`
- `scoring_structure`
- `scoring_structure_secondary` *(new child table)*
- `playoff_structure`
- `facility`

`Create -> GetOne/GetAll` field-by-field losslessness, plus update/delete (see `database/sqlite_format_ruleset_roundtrip_test.go`).

> ⚠️ Note: this PR is based on the current HEAD, which also carries the **#58 (Drafts)** commit that is not yet on `main`. So this PR's diff includes both #58 and #59. Once #58 lands on `main`, this PR will only show the #59 changes.

## Normalization

Per the established #58 precedent, the inline slices were removed from the structs and moved into join tables (with ordering indices preserved):

- `Format.PossibleRatings` → `FormatRating` (`rating_index`)
- `Format.Lines` → `FormatLine` (`format_index`)
- `ScoringStructure.SecondaryScoringStructures` → `ScoringStructureSecondary` (`secondary_index`)

New accessors: `Format.GetPossibleRatings/GetLines/SetPossibleRatings/SetLines`, `ScoringStructure.GetSecondaryScoringStructures/SetSecondaryScoringStructures/IsComposite`, and `IndividualMatch` loads sub-structures from the child table.

## Migrations

`database/migrations/0024_create_formats.sql` … `0033_create_facilities.sql`, following `docs/schema-conventions.md`. Includes the `rule_section` dual `id`/`section_id` columns (its ID field carries `json:"section_id"`), and a `json:"id"` tag added to `PlayoffStructure.ID` so the reflection mapper maps it to the `id` PK column.

## Verification

- `go build ./...`, `go vet ./...`, `go test ./...` all green (database, model, api, mailer, route/user).
- New files are `gofmt`-clean.

## Pre-existing issue (not introduced here)

`TestWeeklyMatchupTeamMatchupRecord` fails intermittently because it assumes `GetAllWhere`'s id-ordering matches `Position` order (`NewRecordId()` is random). Tracked in #72.