### PR TITLE
test: make TestWeeklyMatchupTeamMatchupRecord deterministic

### DIFF
--- a/model/weekly_matchup_test.go
+++ b/model/weekly_matchup_test.go
@@ -3,6 +3,7 @@ package model
 import (
 	"context"
 	"fmt"
+	"slices"
 	"testing"
 
 	"intraclub/database"
@@ -408,6 +409,9 @@ func TestWeeklyMatchupTeamMatchupRecord(t *testing.T) {
 	}
 
 	// Verify Position field preserves ordering
+	slices.SortFunc(records, func(a, b *WeeklyMatchupTeamMatchup) int {
+		return a.Position - b.Position
+	})
 	if records[0].Position != 0 {
 		t.Fatalf("Expected position 0, got %d", records[0].Position)
 	}


### PR DESCRIPTION
## Summary

Fixes #72.

`TestWeeklyMatchupTeamMatchupRecord` was flaky: it assumed `GetAllWhere` returned rows in `Position` order, but rows are ordered by id. Ids are random (`RecordId(rand.Uint64())`), so the record with `Position 1` had a ~50% chance of getting the smaller id and appearing first, intermittently failing with:

```
weekly_matchup_test.go:412: Expected position 0, got 1
```

## Change

Sort the returned records by `Position` (`slices.SortFunc`) before asserting the ordering, making the test deterministic.

Verified: `go test ./model/ -run TestWeeklyMatchupTeamMatchupRecord -count=20` passes consistently.