### PR TITLE
feat(db): SQLite schema + round-trip for communications & proposals (#61)

### DIFF
--- a/database/migrations/0042_create_photos.sql
+++ b/database/migrations/0042_create_photos.sql
@@ -1,0 +1,15 @@
+-- 0042_create_photos.sql
+-- The photo table, matching the Photo record shape (model/photo.go).
+-- Table name equals record.Type() ("photo").
+--   id        -> PhotoId hex TEXT primary key
+--   owner     -> UserId hex TEXT
+--   alt_text  -> TEXT
+--   contents  -> BLOB (the binary image payload, []byte)
+--   file_type -> INTEGER (PhotoType)
+CREATE TABLE photo (
+    id        TEXT PRIMARY KEY,   -- PhotoId hex string
+    owner     TEXT NOT NULL,      -- UserId hex string
+    alt_text  TEXT NOT NULL,
+    contents  BLOB NOT NULL,      -- binary image content
+    file_type INTEGER NOT NULL    -- PhotoType
+);

--- a/database/migrations/0043_create_blurbs.sql
+++ b/database/migrations/0043_create_blurbs.sql
@@ -1,0 +1,18 @@
+-- 0043_create_blurbs.sql
+-- The blurb table, matching the Blurb record shape (model/blurb.go).
+-- Table name equals record.Type() ("blurb").
+--   id      -> BlurbId hex TEXT primary key
+--   title   -> TEXT
+--   content -> TEXT
+--   owner   -> UserId hex TEXT
+--   season  -> SeasonId hex TEXT
+-- The former inline Blurb.Photos and Blurb.Reactions slices were normalized
+-- into the blurb_photo (0044) and blurb_reaction (0046) child tables; they are
+-- not part of this table.
+CREATE TABLE blurb (
+    id      TEXT PRIMARY KEY,   -- BlurbId hex string
+    title   TEXT NOT NULL,
+    content TEXT NOT NULL,
+    owner   TEXT NOT NULL,      -- UserId hex string
+    season  TEXT NOT NULL       -- SeasonId hex string
+);

--- a/database/migrations/0044_create_blurb_photos.sql
+++ b/database/migrations/0044_create_blurb_photos.sql
@@ -1,0 +1,13 @@
+-- 0044_create_blurb_photos.sql
+-- The blurb_photo join table, matching the BlurbPhoto record shape
+-- (model/blurb.go). This is the normalized replacement for the former inline
+-- Blurb.Photos slice.
+-- Table name equals record.Type() ("blurb_photo").
+--   id       -> RecordId hex TEXT primary key
+--   blurb_id -> BlurbId hex TEXT
+--   photo_id -> PhotoId hex TEXT
+CREATE TABLE blurb_photo (
+    id       TEXT PRIMARY KEY,   -- RecordId hex string
+    blurb_id TEXT NOT NULL,      -- BlurbId hex string
+    photo_id TEXT NOT NULL       -- PhotoId hex string
+);

--- a/database/migrations/0045_create_comments.sql
+++ b/database/migrations/0045_create_comments.sql
@@ -1,0 +1,21 @@
+-- 0045_create_comments.sql
+-- The comment table, matching the Comment record shape (model/comment.go).
+-- Table name equals record.Type() ("comment").
+--   id         -> CommentId hex TEXT primary key
+--   blurb      -> BlurbId hex TEXT
+--   reply_to   -> CommentId hex TEXT
+--   user_id    -> UserId hex TEXT (Comment.Owner)
+--   content    -> TEXT
+--   edited_at  -> RFC3339 TEXT
+--   created_at -> RFC3339 TEXT
+-- The former inline Comment.Reactions slice was normalized into the
+-- comment_reaction child table (0047); it is not part of this table.
+CREATE TABLE comment (
+    id         TEXT PRIMARY KEY,   -- CommentId hex string
+    blurb      TEXT NOT NULL,      -- BlurbId hex string
+    reply_to   TEXT NOT NULL,      -- CommentId hex string
+    user_id    TEXT NOT NULL,      -- UserId hex string
+    content    TEXT NOT NULL,
+    edited_at  TEXT NOT NULL,      -- RFC3339
+    created_at TEXT NOT NULL       -- RFC3339
+);

--- a/database/migrations/0046_create_blurb_reactions.sql
+++ b/database/migrations/0046_create_blurb_reactions.sql
@@ -1,0 +1,19 @@
+-- 0046_create_blurb_reactions.sql
+-- The blurb_reaction child table, matching the BlurbReaction record shape
+-- (model/blurb.go). This is the normalized replacement for the former inline
+-- Blurb.Reactions slice.
+-- Table name equals record.Type() ("blurb_reaction").
+--   id             -> RecordId hex TEXT primary key
+--   blurb_id       -> BlurbId hex TEXT
+--   user_id        -> UserId hex TEXT
+--   reaction_type  -> INTEGER (reactionType)
+-- One reaction per (blurb, user, type): UNIQUE(blurb_id, user_id,
+-- reaction_type) mirrors the no-duplicate-reaction invariant of
+-- ReactionList.StaticallyValid.
+CREATE TABLE blurb_reaction (
+    id             TEXT PRIMARY KEY,   -- RecordId hex string
+    blurb_id       TEXT NOT NULL,      -- BlurbId hex string
+    user_id        TEXT NOT NULL,      -- UserId hex string
+    reaction_type  INTEGER NOT NULL,   -- reactionType
+    UNIQUE (blurb_id, user_id, reaction_type)
+);

--- a/database/migrations/0047_create_comment_reactions.sql
+++ b/database/migrations/0047_create_comment_reactions.sql
@@ -1,0 +1,19 @@
+-- 0047_create_comment_reactions.sql
+-- The comment_reaction child table, matching the CommentReaction record shape
+-- (model/comment.go). This is the normalized replacement for the former inline
+-- Comment.Reactions slice.
+-- Table name equals record.Type() ("comment_reaction").
+--   id             -> RecordId hex TEXT primary key
+--   comment_id     -> CommentId hex TEXT
+--   user_id        -> UserId hex TEXT
+--   reaction_type  -> INTEGER (reactionType)
+-- One reaction per (comment, user, type): UNIQUE(comment_id, user_id,
+-- reaction_type) mirrors the no-duplicate-reaction invariant of
+-- ReactionList.StaticallyValid.
+CREATE TABLE comment_reaction (
+    id             TEXT PRIMARY KEY,   -- RecordId hex string
+    comment_id     TEXT NOT NULL,      -- CommentId hex string
+    user_id        TEXT NOT NULL,      -- UserId hex string
+    reaction_type  INTEGER NOT NULL,   -- reactionType
+    UNIQUE (comment_id, user_id, reaction_type)
+);

--- a/database/migrations/0048_create_commissioner_proposals.sql
+++ b/database/migrations/0048_create_commissioner_proposals.sql
@@ -1,0 +1,14 @@
+-- 0048_create_commissioner_proposals.sql
+-- The commissioner_proposal table, matching the CommissionerProposal record
+-- shape (model/commissioner_proposal.go).
+-- Table name equals record.Type() ("commissioner_proposal").
+--   id                -> RecordId hex TEXT primary key
+--   description       -> TEXT
+--   season_id         -> SeasonId hex TEXT
+--   must_be_unanimous -> INTEGER (bool: 0/1)
+CREATE TABLE commissioner_proposal (
+    id                TEXT PRIMARY KEY,   -- RecordId hex string
+    description       TEXT NOT NULL,
+    season_id         TEXT NOT NULL,      -- SeasonId hex string
+    must_be_unanimous INTEGER NOT NULL
+);

--- a/database/migrations/0049_create_commissioner_proposal_votes.sql
+++ b/database/migrations/0049_create_commissioner_proposal_votes.sql
@@ -1,0 +1,18 @@
+-- 0049_create_commissioner_proposal_votes.sql
+-- The commissioner_proposal_vote table, matching the CommissionerProposalVote
+-- record shape (model/commissioner_proposal.go).
+-- Table name equals record.Type() ("commissioner_proposal_vote").
+--   id          -> RecordId hex TEXT primary key
+--   proposal_id -> RecordId hex TEXT
+--   user_id     -> UserId hex TEXT
+--   vote        -> INTEGER (bool: 0/1)
+-- One vote per (proposal, user): UNIQUE(proposal_id, user_id) mirrors
+-- CommissionerProposalVote.UniquenessEquivalent (a voter may only cast one
+-- vote per proposal).
+CREATE TABLE commissioner_proposal_vote (
+    id          TEXT PRIMARY KEY,   -- RecordId hex string
+    proposal_id TEXT NOT NULL,      -- RecordId hex string
+    user_id     TEXT NOT NULL,      -- UserId hex string
+    vote        INTEGER NOT NULL,
+    UNIQUE (proposal_id, user_id)
+);

--- a/database/sqlite_communication_roundtrip_test.go
+++ b/database/sqlite_communication_roundtrip_test.go
@@ -1,0 +1,573 @@
+package database_test
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"intraclub/database"
+	"intraclub/model"
+)
+
+// This file implements the #61 (Communications & proposals) SQLite round-trip
+// tests: field-by-field losslessness across Create -> GetOne/GetAll -> Update
+// -> Delete on the SQLite provider for the photo, blurb, blurb_photo, comment,
+// blurb_reaction, comment_reaction, commissioner_proposal, and
+// commissioner_proposal_vote tables.
+//
+// The former inline Blurb.Photos / Blurb.Reactions and Comment.Reactions
+// slices were normalized into the blurb_photo / blurb_reaction /
+// comment_reaction child tables (migrations 0042-0049), so each of those
+// relationship records gets its own round-trip test alongside its parent.
+//
+// Comment.DynamicallyValid requires its owner to be a Season participant, so
+// the comment owner is registered as a Season commissioner (a participant)
+// before the comment is created.
+
+// createTestPhoto creates a Photo with random contents owned by the given user.
+func createTestPhoto(t *testing.T, p database.Provider, owner *model.User) *model.Photo {
+	t.Helper()
+	photo := model.NewPhoto()
+	photo.Owner = owner.ID
+	photo.AltText = "photo alt text"
+	photo.Contents = []byte{0x89, 0x50, 0x4e, 0x47, 0x00, 0x01, 0x02, 0xff}
+	photo.FileType = model.PhotoTypePng
+	v, err := database.CreateOne(context.Background(), p, photo)
+	if err != nil {
+		t.Fatalf("create photo: %v", err)
+	}
+	return v
+}
+
+// createTestBlurb creates a Blurb owned by the given user in the given season.
+func createTestBlurb(t *testing.T, p database.Provider, owner *model.User, season *model.Season) *model.Blurb {
+	t.Helper()
+	b := model.NewBlurb()
+	b.Owner = owner.ID
+	b.Season = season.ID
+	b.Title = "Welcome"
+	b.Content = "Welcome to the season"
+	v, err := database.CreateOne(context.Background(), p, b)
+	if err != nil {
+		t.Fatalf("create blurb: %v", err)
+	}
+	return v
+}
+
+// createTestSeasonCommissioner registers the given user as a commissioner
+// (and therefore a participant) of the given season.
+func createTestSeasonCommissioner(t *testing.T, p database.Provider, season *model.Season, user *model.User) {
+	t.Helper()
+	if _, err := database.CreateOne(context.Background(), p, &model.SeasonCommissioner{
+		SeasonId: season.ID,
+		UserId:   user.ID,
+	}); err != nil {
+		t.Fatalf("create season_commissioner: %v", err)
+	}
+}
+
+// createTestComment creates a Comment from the given user on the given blurb.
+func createTestComment(t *testing.T, p database.Provider, blurb *model.Blurb, owner *model.User) *model.Comment {
+	t.Helper()
+	c := model.NewComment()
+	c.Blurb = blurb.ID
+	c.Owner = owner.ID
+	c.Content = "Great blurb!"
+	v, err := database.CreateOne(context.Background(), p, c)
+	if err != nil {
+		t.Fatalf("create comment: %v", err)
+	}
+	return v
+}
+
+// createTestProposal creates a CommissionerProposal for the given season.
+func createTestProposal(t *testing.T, p database.Provider, season *model.Season) *model.CommissionerProposal {
+	t.Helper()
+	prop := model.NewCommissionerProposal()
+	prop.Description = "Add a player to a team"
+	prop.SeasonId = season.ID
+	prop.MustBeUnanimous = true
+	v, err := database.CreateOne(context.Background(), p, prop)
+	if err != nil {
+		t.Fatalf("create commissioner_proposal: %v", err)
+	}
+	return v
+}
+
+// ---- #61: Photos ----
+
+func TestPhotoRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	p := newSqliteProvider(t)
+	owner := createTestUser(t, p)
+
+	photo := model.NewPhoto()
+	photo.Owner = owner.ID
+	photo.AltText = "court layout"
+	photo.Contents = []byte{0x89, 0x50, 0x4e, 0x47, 0x00, 0x01, 0x02, 0xff}
+	photo.FileType = model.PhotoTypeJpeg
+	created, err := database.CreateOne(ctx, p, photo)
+	if err != nil {
+		t.Fatalf("CreateOne(photo): %v", err)
+	}
+	if created.GetId() == database.InvalidRecordId {
+		t.Fatal("CreateOne(photo) did not assign an ID")
+	}
+
+	got, exists, err := database.GetOneById(ctx, p, &model.Photo{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(photo): %v", err)
+	}
+	if !exists {
+		t.Fatal("GetOneById(photo): record not found")
+	}
+	if got.Owner != created.Owner || got.AltText != created.AltText ||
+		got.FileType != created.FileType || !bytes.Equal(got.Contents, created.Contents) {
+		t.Fatalf("photo round-trip mismatch:\n  got  %+v\n  want %+v", got, created)
+	}
+
+	all, err := database.GetAll[*model.Photo](ctx, p)
+	if err != nil {
+		t.Fatalf("GetAll(photo): %v", err)
+	}
+	if len(all) != 1 || all[0].ID != created.ID {
+		t.Fatalf("GetAll(photo): got %d records, want 1", len(all))
+	}
+
+	created.AltText = "renamed layout"
+	created.Contents = []byte{0xde, 0xad, 0xbe, 0xef}
+	created.FileType = model.PhotoTypeGif
+	if err := database.UpdateOne(ctx, p, created); err != nil {
+		t.Fatalf("UpdateOne(photo): %v", err)
+	}
+	got2, _, err := database.GetOneById(ctx, p, &model.Photo{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(photo) after update: %v", err)
+	}
+	if got2.AltText != "renamed layout" || got2.FileType != model.PhotoTypeGif ||
+		!bytes.Equal(got2.Contents, []byte{0xde, 0xad, 0xbe, 0xef}) {
+		t.Fatalf("photo update not persisted, got %+v", got2)
+	}
+
+	if _, _, err := database.DeleteOneById(ctx, p, &model.Photo{}, created.GetId()); err != nil {
+		t.Fatalf("DeleteOneById(photo): %v", err)
+	}
+	_, exists, err = database.GetOneById(ctx, p, &model.Photo{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(photo) after delete: %v", err)
+	}
+	if exists {
+		t.Fatal("photo should have been deleted")
+	}
+}
+
+// ---- #61: Blurbs ----
+
+func TestBlurbRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	p := newSqliteProvider(t)
+	owner := createTestUser(t, p)
+	season := createTestSeason(t, p)
+
+	blurb := createTestBlurb(t, p, owner, season)
+
+	got, exists, err := database.GetOneById(ctx, p, &model.Blurb{}, blurb.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(blurb): %v", err)
+	}
+	if !exists {
+		t.Fatal("GetOneById(blurb): record not found")
+	}
+	if got.Owner != blurb.Owner || got.Season != blurb.Season ||
+		got.Title != blurb.Title || got.Content != blurb.Content {
+		t.Fatalf("blurb round-trip mismatch:\n  got  %+v\n  want %+v", got, blurb)
+	}
+
+	all, err := database.GetAll[*model.Blurb](ctx, p)
+	if err != nil {
+		t.Fatalf("GetAll(blurb): %v", err)
+	}
+	if len(all) != 1 || all[0].ID != blurb.ID {
+		t.Fatalf("GetAll(blurb): got %d records, want 1", len(all))
+	}
+
+	blurb.Title = "Renamed"
+	blurb.Content = "Updated content"
+	if err := database.UpdateOne(ctx, p, blurb); err != nil {
+		t.Fatalf("UpdateOne(blurb): %v", err)
+	}
+	got2, _, err := database.GetOneById(ctx, p, &model.Blurb{}, blurb.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(blurb) after update: %v", err)
+	}
+	if got2.Title != "Renamed" || got2.Content != "Updated content" {
+		t.Fatalf("blurb update not persisted, got %+v", got2)
+	}
+
+	if _, _, err := database.DeleteOneById(ctx, p, &model.Blurb{}, blurb.GetId()); err != nil {
+		t.Fatalf("DeleteOneById(blurb): %v", err)
+	}
+	_, exists, err = database.GetOneById(ctx, p, &model.Blurb{}, blurb.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(blurb) after delete: %v", err)
+	}
+	if exists {
+		t.Fatal("blurb should have been deleted")
+	}
+}
+
+func TestBlurbPhotoRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	p := newSqliteProvider(t)
+	owner := createTestUser(t, p)
+	season := createTestSeason(t, p)
+	blurb := createTestBlurb(t, p, owner, season)
+	photo := createTestPhoto(t, p, owner)
+	photo2 := createTestPhoto(t, p, owner)
+
+	row := &model.BlurbPhoto{BlurbId: blurb.ID, PhotoId: photo.ID}
+	created, err := database.CreateOne(ctx, p, row)
+	if err != nil {
+		t.Fatalf("CreateOne(blurb_photo): %v", err)
+	}
+	if created.GetId() == database.InvalidRecordId {
+		t.Fatal("CreateOne(blurb_photo) did not assign an ID")
+	}
+
+	got, exists, err := database.GetOneById(ctx, p, &model.BlurbPhoto{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(blurb_photo): %v", err)
+	}
+	if !exists {
+		t.Fatal("GetOneById(blurb_photo): record not found")
+	}
+	if got.BlurbId != created.BlurbId || got.PhotoId != created.PhotoId {
+		t.Fatalf("blurb_photo round-trip mismatch:\n  got  %+v\n  want %+v", got, created)
+	}
+
+	all, err := database.GetAll[*model.BlurbPhoto](ctx, p)
+	if err != nil {
+		t.Fatalf("GetAll(blurb_photo): %v", err)
+	}
+	if len(all) != 1 || all[0].ID != created.ID {
+		t.Fatalf("GetAll(blurb_photo): got %d records, want 1", len(all))
+	}
+
+	created.PhotoId = photo2.ID
+	if err := database.UpdateOne(ctx, p, created); err != nil {
+		t.Fatalf("UpdateOne(blurb_photo): %v", err)
+	}
+	got2, _, err := database.GetOneById(ctx, p, &model.BlurbPhoto{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(blurb_photo) after update: %v", err)
+	}
+	if got2.PhotoId != photo2.ID {
+		t.Fatalf("blurb_photo update not persisted, got %+v", got2)
+	}
+
+	if _, _, err := database.DeleteOneById(ctx, p, &model.BlurbPhoto{}, created.GetId()); err != nil {
+		t.Fatalf("DeleteOneById(blurb_photo): %v", err)
+	}
+	_, exists, err = database.GetOneById(ctx, p, &model.BlurbPhoto{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(blurb_photo) after delete: %v", err)
+	}
+	if exists {
+		t.Fatal("blurb_photo should have been deleted")
+	}
+}
+
+func TestBlurbReactionRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	p := newSqliteProvider(t)
+	owner := createTestUser(t, p)
+	season := createTestSeason(t, p)
+	blurb := createTestBlurb(t, p, owner, season)
+	reactor := createTestUser(t, p)
+
+	row := &model.BlurbReaction{BlurbId: blurb.ID, UserId: reactor.ID, ReactionType: model.ThumbsUp}
+	created, err := database.CreateOne(ctx, p, row)
+	if err != nil {
+		t.Fatalf("CreateOne(blurb_reaction): %v", err)
+	}
+	if created.GetId() == database.InvalidRecordId {
+		t.Fatal("CreateOne(blurb_reaction) did not assign an ID")
+	}
+
+	got, exists, err := database.GetOneById(ctx, p, &model.BlurbReaction{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(blurb_reaction): %v", err)
+	}
+	if !exists {
+		t.Fatal("GetOneById(blurb_reaction): record not found")
+	}
+	if got.BlurbId != created.BlurbId || got.UserId != created.UserId ||
+		got.ReactionType != created.ReactionType {
+		t.Fatalf("blurb_reaction round-trip mismatch:\n  got  %+v\n  want %+v", got, created)
+	}
+
+	all, err := database.GetAll[*model.BlurbReaction](ctx, p)
+	if err != nil {
+		t.Fatalf("GetAll(blurb_reaction): %v", err)
+	}
+	if len(all) != 1 || all[0].ID != created.ID {
+		t.Fatalf("GetAll(blurb_reaction): got %d records, want 1", len(all))
+	}
+
+	created.ReactionType = model.Fire
+	if err := database.UpdateOne(ctx, p, created); err != nil {
+		t.Fatalf("UpdateOne(blurb_reaction): %v", err)
+	}
+	got2, _, err := database.GetOneById(ctx, p, &model.BlurbReaction{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(blurb_reaction) after update: %v", err)
+	}
+	if got2.ReactionType != model.Fire {
+		t.Fatalf("blurb_reaction update not persisted, got %+v", got2)
+	}
+
+	if _, _, err := database.DeleteOneById(ctx, p, &model.BlurbReaction{}, created.GetId()); err != nil {
+		t.Fatalf("DeleteOneById(blurb_reaction): %v", err)
+	}
+	_, exists, err = database.GetOneById(ctx, p, &model.BlurbReaction{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(blurb_reaction) after delete: %v", err)
+	}
+	if exists {
+		t.Fatal("blurb_reaction should have been deleted")
+	}
+}
+
+// ---- #61: Comments ----
+
+func TestCommentRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	p := newSqliteProvider(t)
+	owner := createTestUser(t, p)
+	season := createTestSeason(t, p)
+	// the comment owner must be a Season participant, so register them as a
+	// commissioner
+	createTestSeasonCommissioner(t, p, season, owner)
+	blurb := createTestBlurb(t, p, owner, season)
+
+	comment := createTestComment(t, p, blurb, owner)
+
+	got, exists, err := database.GetOneById(ctx, p, &model.Comment{}, comment.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(comment): %v", err)
+	}
+	if !exists {
+		t.Fatal("GetOneById(comment): record not found")
+	}
+	if got.Blurb != comment.Blurb || got.ReplyTo != comment.ReplyTo ||
+		got.Owner != comment.Owner || got.Content != comment.Content ||
+		!got.CreatedAt.Equal(comment.CreatedAt) {
+		t.Fatalf("comment round-trip mismatch:\n  got  %+v\n  want %+v", got, comment)
+	}
+
+	all, err := database.GetAll[*model.Comment](ctx, p)
+	if err != nil {
+		t.Fatalf("GetAll(comment): %v", err)
+	}
+	if len(all) != 1 || all[0].ID != comment.ID {
+		t.Fatalf("GetAll(comment): got %d records, want 1", len(all))
+	}
+
+	comment.Content = "Updated comment"
+	if err := database.UpdateOne(ctx, p, comment); err != nil {
+		t.Fatalf("UpdateOne(comment): %v", err)
+	}
+	got2, _, err := database.GetOneById(ctx, p, &model.Comment{}, comment.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(comment) after update: %v", err)
+	}
+	if got2.Content != "Updated comment" {
+		t.Fatalf("comment update not persisted, got %+v", got2)
+	}
+
+	if _, _, err := database.DeleteOneById(ctx, p, &model.Comment{}, comment.GetId()); err != nil {
+		t.Fatalf("DeleteOneById(comment): %v", err)
+	}
+	_, exists, err = database.GetOneById(ctx, p, &model.Comment{}, comment.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(comment) after delete: %v", err)
+	}
+	if exists {
+		t.Fatal("comment should have been deleted")
+	}
+}
+
+func TestCommentReactionRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	p := newSqliteProvider(t)
+	owner := createTestUser(t, p)
+	season := createTestSeason(t, p)
+	createTestSeasonCommissioner(t, p, season, owner)
+	blurb := createTestBlurb(t, p, owner, season)
+	comment := createTestComment(t, p, blurb, owner)
+	reactor := createTestUser(t, p)
+
+	row := &model.CommentReaction{CommentId: comment.ID, UserId: reactor.ID, ReactionType: model.Heart}
+	created, err := database.CreateOne(ctx, p, row)
+	if err != nil {
+		t.Fatalf("CreateOne(comment_reaction): %v", err)
+	}
+	if created.GetId() == database.InvalidRecordId {
+		t.Fatal("CreateOne(comment_reaction) did not assign an ID")
+	}
+
+	got, exists, err := database.GetOneById(ctx, p, &model.CommentReaction{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(comment_reaction): %v", err)
+	}
+	if !exists {
+		t.Fatal("GetOneById(comment_reaction): record not found")
+	}
+	if got.CommentId != created.CommentId || got.UserId != created.UserId ||
+		got.ReactionType != created.ReactionType {
+		t.Fatalf("comment_reaction round-trip mismatch:\n  got  %+v\n  want %+v", got, created)
+	}
+
+	all, err := database.GetAll[*model.CommentReaction](ctx, p)
+	if err != nil {
+		t.Fatalf("GetAll(comment_reaction): %v", err)
+	}
+	if len(all) != 1 || all[0].ID != created.ID {
+		t.Fatalf("GetAll(comment_reaction): got %d records, want 1", len(all))
+	}
+
+	created.ReactionType = model.Laughing
+	if err := database.UpdateOne(ctx, p, created); err != nil {
+		t.Fatalf("UpdateOne(comment_reaction): %v", err)
+	}
+	got2, _, err := database.GetOneById(ctx, p, &model.CommentReaction{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(comment_reaction) after update: %v", err)
+	}
+	if got2.ReactionType != model.Laughing {
+		t.Fatalf("comment_reaction update not persisted, got %+v", got2)
+	}
+
+	if _, _, err := database.DeleteOneById(ctx, p, &model.CommentReaction{}, created.GetId()); err != nil {
+		t.Fatalf("DeleteOneById(comment_reaction): %v", err)
+	}
+	_, exists, err = database.GetOneById(ctx, p, &model.CommentReaction{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(comment_reaction) after delete: %v", err)
+	}
+	if exists {
+		t.Fatal("comment_reaction should have been deleted")
+	}
+}
+
+// ---- #61: Commissioner proposals ----
+
+func TestCommissionerProposalRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	p := newSqliteProvider(t)
+	season := createTestSeason(t, p)
+
+	proposal := createTestProposal(t, p, season)
+
+	got, exists, err := database.GetOneById(ctx, p, &model.CommissionerProposal{}, proposal.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(commissioner_proposal): %v", err)
+	}
+	if !exists {
+		t.Fatal("GetOneById(commissioner_proposal): record not found")
+	}
+	if got.Description != proposal.Description || got.SeasonId != proposal.SeasonId ||
+		got.MustBeUnanimous != proposal.MustBeUnanimous {
+		t.Fatalf("commissioner_proposal round-trip mismatch:\n  got  %+v\n  want %+v", got, proposal)
+	}
+
+	all, err := database.GetAll[*model.CommissionerProposal](ctx, p)
+	if err != nil {
+		t.Fatalf("GetAll(commissioner_proposal): %v", err)
+	}
+	if len(all) != 1 || all[0].ID != proposal.ID {
+		t.Fatalf("GetAll(commissioner_proposal): got %d records, want 1", len(all))
+	}
+
+	proposal.Description = "Change the playoff structure"
+	if err := database.UpdateOne(ctx, p, proposal); err != nil {
+		t.Fatalf("UpdateOne(commissioner_proposal): %v", err)
+	}
+	got2, _, err := database.GetOneById(ctx, p, &model.CommissionerProposal{}, proposal.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(commissioner_proposal) after update: %v", err)
+	}
+	if got2.Description != "Change the playoff structure" {
+		t.Fatalf("commissioner_proposal update not persisted, got %+v", got2)
+	}
+
+	if _, _, err := database.DeleteOneById(ctx, p, &model.CommissionerProposal{}, proposal.GetId()); err != nil {
+		t.Fatalf("DeleteOneById(commissioner_proposal): %v", err)
+	}
+	_, exists, err = database.GetOneById(ctx, p, &model.CommissionerProposal{}, proposal.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(commissioner_proposal) after delete: %v", err)
+	}
+	if exists {
+		t.Fatal("commissioner_proposal should have been deleted")
+	}
+}
+
+func TestCommissionerProposalVoteRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	p := newSqliteProvider(t)
+	season := createTestSeason(t, p)
+	proposal := createTestProposal(t, p, season)
+	voter := createTestUser(t, p)
+
+	row := &model.CommissionerProposalVote{ProposalId: proposal.ID, UserId: voter.ID, Vote: true}
+	created, err := database.CreateOne(ctx, p, row)
+	if err != nil {
+		t.Fatalf("CreateOne(commissioner_proposal_vote): %v", err)
+	}
+	if created.GetId() == database.InvalidRecordId {
+		t.Fatal("CreateOne(commissioner_proposal_vote) did not assign an ID")
+	}
+
+	got, exists, err := database.GetOneById(ctx, p, &model.CommissionerProposalVote{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(commissioner_proposal_vote): %v", err)
+	}
+	if !exists {
+		t.Fatal("GetOneById(commissioner_proposal_vote): record not found")
+	}
+	if got.ProposalId != created.ProposalId || got.UserId != created.UserId || got.Vote != created.Vote {
+		t.Fatalf("commissioner_proposal_vote round-trip mismatch:\n  got  %+v\n  want %+v", got, created)
+	}
+
+	all, err := database.GetAll[*model.CommissionerProposalVote](ctx, p)
+	if err != nil {
+		t.Fatalf("GetAll(commissioner_proposal_vote): %v", err)
+	}
+	if len(all) != 1 || all[0].ID != created.ID {
+		t.Fatalf("GetAll(commissioner_proposal_vote): got %d records, want 1", len(all))
+	}
+
+	created.Vote = false
+	if err := database.UpdateOne(ctx, p, created); err != nil {
+		t.Fatalf("UpdateOne(commissioner_proposal_vote): %v", err)
+	}
+	got2, _, err := database.GetOneById(ctx, p, &model.CommissionerProposalVote{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(commissioner_proposal_vote) after update: %v", err)
+	}
+	if got2.Vote {
+		t.Fatalf("commissioner_proposal_vote update not persisted, got %+v", got2)
+	}
+
+	if _, _, err := database.DeleteOneById(ctx, p, &model.CommissionerProposalVote{}, created.GetId()); err != nil {
+		t.Fatalf("DeleteOneById(commissioner_proposal_vote): %v", err)
+	}
+	_, exists, err = database.GetOneById(ctx, p, &model.CommissionerProposalVote{}, created.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(commissioner_proposal_vote) after delete: %v", err)
+	}
+	if exists {
+		t.Fatal("commissioner_proposal_vote should have been deleted")
+	}
+}

--- a/database/sqlite_db.go
+++ b/database/sqlite_db.go
@@ -435,6 +435,13 @@ func encodeValue(field reflect.Value) (any, error) {
 			return n.Name(), nil
 		}
 		return nil, fmt.Errorf("unsupported interface field %s", field.Type())
+	case reflect.Slice, reflect.Array:
+		// []byte (and [N]byte) are stored as a SQLite BLOB column (e.g.
+		// Photo.Contents).
+		if field.Type().Elem().Kind() == reflect.Uint8 {
+			return field.Bytes(), nil
+		}
+		return nil, fmt.Errorf("unsupported slice/array field %s", field.Type())
 	default:
 		return nil, fmt.Errorf("unsupported field kind %s", field.Kind())
 	}
@@ -493,6 +500,17 @@ func setField(field reflect.Value, raw any) error {
 			return nil
 		}
 		return fmt.Errorf("unsupported struct field %s", field.Type())
+	case reflect.Slice, reflect.Array:
+		// []byte round-trips from a SQLite BLOB column (e.g. Photo.Contents).
+		if field.Type().Elem().Kind() == reflect.Uint8 {
+			if b, ok := raw.([]byte); ok {
+				field.SetBytes(b)
+			} else {
+				field.SetBytes([]byte(asString(raw)))
+			}
+			return nil
+		}
+		return fmt.Errorf("unsupported slice/array field %s", field.Type())
 	default:
 		return fmt.Errorf("unsupported field kind %s", field.Kind())
 	}

--- a/model/blurb.go
+++ b/model/blurb.go
@@ -21,13 +21,11 @@ func (id BlurbId) String() string {
 }
 
 type Blurb struct {
-	ID        BlurbId
-	Title     string
-	Content   string
-	Photos    []PhotoId
-	Owner     database.UserId
-	Season    SeasonId
-	Reactions ReactionList
+	ID      BlurbId `json:"id"`
+	Title   string
+	Content string
+	Owner   database.UserId
+	Season  SeasonId
 }
 
 func (b *Blurb) GetOwner() database.UserId {
@@ -77,19 +75,37 @@ func (b *Blurb) DynamicallyValid(ctx context.Context, db database.Provider) erro
 		return err
 	}
 
-	for _, id := range b.Photos {
-		v, exists, err := database.GetOneById(ctx, db, &Photo{}, id.RecordId())
+	// each attached photo (via the blurb_photo child table) must exist and be
+	// owned by the blurb's owner
+	photos, err := b.getPhotoRows(ctx, db)
+	if err != nil {
+		return err
+	}
+	for _, row := range photos {
+		v, exists, err := database.GetOneById(ctx, db, &Photo{}, row.PhotoId.RecordId())
 		if err != nil {
 			return err
 		}
 		if !exists {
-			return fmt.Errorf("photo with ID '%s' does not exist", id)
+			return fmt.Errorf("photo with ID '%s' does not exist", row.PhotoId)
 		}
 		if v.Owner != b.Owner {
-			return fmt.Errorf("photo with ID '%s' is not owned by user '%s'", id, b.Owner)
+			return fmt.Errorf("photo with ID '%s' is not owned by user '%s'", row.PhotoId, b.Owner)
 		}
 	}
-	return b.Reactions.DynamicallyValid(ctx, db)
+
+	// validate each reaction row (via the blurb_reaction child table)
+	reactions, err := b.getReactionRows(ctx, db)
+	if err != nil {
+		return err
+	}
+	for _, row := range reactions {
+		r := &Reaction{UserId: row.UserId, Type: row.ReactionType}
+		if err := r.DynamicallyValid(ctx, db); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (b *Blurb) Type() string {
@@ -110,7 +126,8 @@ func (b *Blurb) React(ctx context.Context, db database.Provider, u database.User
 		Type:   t,
 	}
 
-	err := b.Reactions.CanAddReaction(ctx, db, r)
+	// validate the reaction itself (static + dynamic)
+	err := database.Validate(ctx, db, r)
 	if err != nil {
 		return err
 	}
@@ -120,9 +137,24 @@ func (b *Blurb) React(ctx context.Context, db database.Provider, u database.User
 		return err
 	}
 
-	b.Reactions = append(b.Reactions, r)
+	// one reaction per (blurb, user, type); reject duplicates
+	rows, err := b.getReactionRows(ctx, db)
+	if err != nil {
+		return err
+	}
+	for _, row := range rows {
+		if row.UserId == u && row.ReactionType == t {
+			return fmt.Errorf("reaction already exists: %+v", r)
+		}
+	}
 
-	return database.UpdateOne(ctx, db, b)
+	row := &BlurbReaction{
+		BlurbId:      b.ID,
+		UserId:       u,
+		ReactionType: t,
+	}
+	_, err = database.CreateOne(ctx, db, row)
+	return err
 }
 
 func (b *Blurb) Unreact(ctx context.Context, db database.Provider, u database.UserId, t reactionType) error {
@@ -131,21 +163,17 @@ func (b *Blurb) Unreact(ctx context.Context, db database.Provider, u database.Us
 		Type:   t,
 	}
 
-	found := false
-	newList := make(ReactionList, 0)
-	for _, reaction := range b.Reactions {
-		if reaction.Equals(r) {
-			found = true
-		} else {
-			newList = append(newList, reaction)
+	rows, err := b.getReactionRows(ctx, db)
+	if err != nil {
+		return err
+	}
+	for _, row := range rows {
+		if row.UserId == u && row.ReactionType == t {
+			_, _, err := database.DeleteOneById(ctx, db, row, row.GetId())
+			return err
 		}
 	}
-	if !found {
-		return fmt.Errorf("reaction with values %+v does not exist", r)
-	}
-
-	b.Reactions = newList
-	return database.UpdateOne(ctx, db, b)
+	return fmt.Errorf("reaction with values %+v does not exist", r)
 }
 
 func (b *Blurb) CanUserCommentOrReact(ctx context.Context, db database.Provider, u database.UserId) error {
@@ -196,4 +224,154 @@ func (b *Blurb) GetComments(ctx context.Context, db database.Provider) ([]*Comme
 
 func (b *Blurb) NewRecord() database.CrudRecord {
 	return new(Blurb)
+}
+
+// BlurbPhoto is a child-table record that attaches a Photo to a Blurb. This is
+// the normalized replacement for the former inline `Blurb.Photos` slice,
+// enabling the relationship to be queried/indexed individually and stored in
+// its own table rather than as an embedded list.
+type BlurbPhoto struct {
+	ID      database.RecordId `json:"id"`
+	BlurbId BlurbId           `json:"blurb_id"`
+	PhotoId PhotoId           `json:"photo_id"`
+}
+
+func (p *BlurbPhoto) GetOwner() database.UserId {
+	return database.InvalidUserId
+}
+
+func (p *BlurbPhoto) SetOwner(userId database.UserId) {}
+
+func (p *BlurbPhoto) Type() string {
+	return "blurb_photo"
+}
+
+func (p *BlurbPhoto) GetId() database.RecordId {
+	return p.ID
+}
+
+func (p *BlurbPhoto) SetId(id database.RecordId) {
+	p.ID = id
+}
+
+func (p *BlurbPhoto) StaticallyValid() error {
+	return nil
+}
+
+func (p *BlurbPhoto) DynamicallyValid(ctx context.Context, db database.Provider) error {
+	if err := database.ExistsById(ctx, db, &Blurb{}, p.BlurbId.RecordId()); err != nil {
+		return err
+	}
+	return database.ExistsById(ctx, db, &Photo{}, p.PhotoId.RecordId())
+}
+
+func (p *BlurbPhoto) AccessibleTo(ctx context.Context, db database.Provider) []database.UserId {
+	return database.AccessibleToEveryone
+}
+
+func (p *BlurbPhoto) EditableBy(ctx context.Context, db database.Provider) []database.UserId {
+	return []database.UserId{database.SysAdminUserId}
+}
+
+func (p *BlurbPhoto) NewRecord() database.CrudRecord {
+	return new(BlurbPhoto)
+}
+
+// BlurbReaction is a child-table record that assigns a single Reaction from a
+// User to a Blurb. This is the normalized replacement for the former inline
+// `Blurb.Reactions` slice, enabling the relationship to be queried/indexed
+// individually and stored in its own table rather than as an embedded list.
+type BlurbReaction struct {
+	ID           database.RecordId `json:"id"`
+	BlurbId      BlurbId           `json:"blurb_id"`
+	UserId       database.UserId   `json:"user_id"`
+	ReactionType reactionType      `json:"reaction_type"`
+}
+
+func (r *BlurbReaction) GetOwner() database.UserId {
+	return r.UserId
+}
+
+func (r *BlurbReaction) SetOwner(userId database.UserId) {
+	r.UserId = userId
+}
+
+func (r *BlurbReaction) Type() string {
+	return "blurb_reaction"
+}
+
+func (r *BlurbReaction) GetId() database.RecordId {
+	return r.ID
+}
+
+func (r *BlurbReaction) SetId(id database.RecordId) {
+	r.ID = id
+}
+
+func (r *BlurbReaction) StaticallyValid() error {
+	return r.ReactionType.StaticallyValid()
+}
+
+func (r *BlurbReaction) DynamicallyValid(ctx context.Context, db database.Provider) error {
+	if err := database.ExistsById(ctx, db, &Blurb{}, r.BlurbId.RecordId()); err != nil {
+		return err
+	}
+	return database.ExistsById(ctx, db, &User{}, r.UserId.RecordId())
+}
+
+func (r *BlurbReaction) AccessibleTo(ctx context.Context, db database.Provider) []database.UserId {
+	return database.AccessibleToEveryone
+}
+
+func (r *BlurbReaction) EditableBy(ctx context.Context, db database.Provider) []database.UserId {
+	return []database.UserId{r.UserId}
+}
+
+func (r *BlurbReaction) NewRecord() database.CrudRecord {
+	return new(BlurbReaction)
+}
+
+// getPhotoRows returns all BlurbPhoto relationship rows assigned to this blurb.
+func (b *Blurb) getPhotoRows(ctx context.Context, db database.Provider) ([]*BlurbPhoto, error) {
+	filter := func(_ context.Context, p *BlurbPhoto) bool {
+		return p.BlurbId == b.ID
+	}
+	return database.GetAllWhere[*BlurbPhoto](ctx, db, filter)
+}
+
+// GetPhotos reassembles the blurb_photo child rows into the former inline
+// Blurb.Photos slice shape.
+func (b *Blurb) GetPhotos(ctx context.Context, db database.Provider) ([]PhotoId, error) {
+	rows, err := b.getPhotoRows(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]PhotoId, 0, len(rows))
+	for _, row := range rows {
+		ids = append(ids, row.PhotoId)
+	}
+	return ids, nil
+}
+
+// getReactionRows returns all BlurbReaction relationship rows assigned to this
+// blurb.
+func (b *Blurb) getReactionRows(ctx context.Context, db database.Provider) ([]*BlurbReaction, error) {
+	filter := func(_ context.Context, r *BlurbReaction) bool {
+		return r.BlurbId == b.ID
+	}
+	return database.GetAllWhere[*BlurbReaction](ctx, db, filter)
+}
+
+// GetReactions reassembles the blurb_reaction child rows into the former
+// inline Blurb.Reactions slice shape.
+func (b *Blurb) GetReactions(ctx context.Context, db database.Provider) (ReactionList, error) {
+	rows, err := b.getReactionRows(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+	reactions := make(ReactionList, 0, len(rows))
+	for _, row := range rows {
+		reactions = append(reactions, &Reaction{UserId: row.UserId, Type: row.ReactionType})
+	}
+	return reactions, nil
 }

--- a/model/blurb_test.go
+++ b/model/blurb_test.go
@@ -78,8 +78,12 @@ func TestBlurbSeasonIdDoesNotExist(t *testing.T) {
 func TestBlurbPhotoIdDoesNotExist(t *testing.T) {
 	db := database.NewUnitTestDBProvider()
 	season, commish := newDefaultSeason(t, db)
-	b := newValidBlurb(commish.ID, season.ID)
-	b.Photos = []PhotoId{0}
+	b := newStoredBlurb(t, db, commish.ID, season.ID)
+	// raw-insert a blurb_photo row referencing a nonexistent photo, bypassing
+	// BlurbPhoto.DynamicallyValid, so Blurb.DynamicallyValid is what rejects it
+	if _, err := db.Create(context.Background(), &BlurbPhoto{BlurbId: b.ID, PhotoId: 0}); err != nil {
+		t.Fatal(err)
+	}
 	assert.Error(t, b.DynamicallyValid(context.Background(), db), "expected error on invalid photo ID")
 	fmt.Println(b.DynamicallyValid(context.Background(), db))
 }
@@ -92,7 +96,9 @@ func TestBlurbPhotoDoesNotBelongToUser(t *testing.T) {
 	user2 := newStoredUser(t, db)
 	photo := newStoredPhoto(t, db, user2.ID)
 
-	b.Photos = []PhotoId{photo.ID}
+	if _, err := db.Create(context.Background(), &BlurbPhoto{BlurbId: b.ID, PhotoId: photo.ID}); err != nil {
+		t.Fatal(err)
+	}
 
 	assert.Error(t, b.DynamicallyValid(context.Background(), db), "expected error on non-owned photo ID")
 	fmt.Println(b.DynamicallyValid(context.Background(), db))

--- a/model/comment.go
+++ b/model/comment.go
@@ -22,13 +22,12 @@ func (id CommentId) String() string {
 
 type Comment struct {
 	ID        CommentId       `json:"id"`                           // unique ID for this comment
-	Blurb     BlurbId         `json:"references"`                   // ID of the Blurb that this comment is on
-	ReplyTo   CommentId       `json:"references_comment"`           // ID of the Comment that this is in reference to (if any)
+	Blurb     BlurbId         `json:"blurb"`                        // ID of the Blurb that this comment is on
+	ReplyTo   CommentId       `json:"reply_to"`                     // ID of the Comment that this is in reference to (if any)
 	Owner     database.UserId `json:"user_id" bson:"user_id"`       // ID of the User that created this comment
 	Content   string          `json:"content" bson:"content"`       // content of the comment itself
 	EditedAt  time.Time       `json:"edited_at" bson:"edited_at"`   // time that this Comment was edited (if applicable)
 	CreatedAt time.Time       `json:"created_at" bson:"created_at"` // when this comment was created
-	Reactions ReactionList    `json:"reactions" bson:"reactions"`   // list of user reactions to this comment, if any
 }
 
 func (c *Comment) GetOwner() database.UserId {
@@ -118,7 +117,7 @@ func (c *Comment) StaticallyValid() error {
 		return fmt.Errorf("comment created timestamp is zero")
 	}
 
-	return c.Reactions.StaticallyValid()
+	return nil
 }
 
 func (c *Comment) DynamicallyValid(ctx context.Context, db database.Provider) error {
@@ -155,9 +154,142 @@ func (c *Comment) DynamicallyValid(ctx context.Context, db database.Provider) er
 		}
 	}
 
-	return c.Reactions.DynamicallyValid(ctx, db)
+	// validate each reaction row (via the comment_reaction child table)
+	reactions, err := c.getReactionRows(ctx, db)
+	if err != nil {
+		return err
+	}
+	for _, row := range reactions {
+		r := &Reaction{UserId: row.UserId, Type: row.ReactionType}
+		if err := r.DynamicallyValid(ctx, db); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (c *Comment) NewRecord() database.CrudRecord {
 	return new(Comment)
+}
+
+// CommentReaction is a child-table record that assigns a single Reaction from
+// a User to a Comment. This is the normalized replacement for the former inline
+// `Comment.Reactions` slice, enabling the relationship to be queried/indexed
+// individually and stored in its own table rather than as an embedded list.
+type CommentReaction struct {
+	ID           database.RecordId `json:"id"`
+	CommentId    CommentId         `json:"comment_id"`
+	UserId       database.UserId   `json:"user_id"`
+	ReactionType reactionType      `json:"reaction_type"`
+}
+
+func (r *CommentReaction) GetOwner() database.UserId {
+	return r.UserId
+}
+
+func (r *CommentReaction) SetOwner(userId database.UserId) {
+	r.UserId = userId
+}
+
+func (r *CommentReaction) Type() string {
+	return "comment_reaction"
+}
+
+func (r *CommentReaction) GetId() database.RecordId {
+	return r.ID
+}
+
+func (r *CommentReaction) SetId(id database.RecordId) {
+	r.ID = id
+}
+
+func (r *CommentReaction) StaticallyValid() error {
+	return r.ReactionType.StaticallyValid()
+}
+
+func (r *CommentReaction) DynamicallyValid(ctx context.Context, db database.Provider) error {
+	if err := database.ExistsById(ctx, db, &Comment{}, r.CommentId.RecordId()); err != nil {
+		return err
+	}
+	return database.ExistsById(ctx, db, &User{}, r.UserId.RecordId())
+}
+
+func (r *CommentReaction) AccessibleTo(ctx context.Context, db database.Provider) []database.UserId {
+	return database.AccessibleToEveryone
+}
+
+func (r *CommentReaction) EditableBy(ctx context.Context, db database.Provider) []database.UserId {
+	return []database.UserId{r.UserId}
+}
+
+func (r *CommentReaction) NewRecord() database.CrudRecord {
+	return new(CommentReaction)
+}
+
+// getReactionRows returns all CommentReaction relationship rows assigned to
+// this comment.
+func (c *Comment) getReactionRows(ctx context.Context, db database.Provider) ([]*CommentReaction, error) {
+	filter := func(_ context.Context, r *CommentReaction) bool {
+		return r.CommentId == c.ID
+	}
+	return database.GetAllWhere[*CommentReaction](ctx, db, filter)
+}
+
+// GetReactions reassembles the comment_reaction child rows into the former
+// inline Comment.Reactions slice shape.
+func (c *Comment) GetReactions(ctx context.Context, db database.Provider) (ReactionList, error) {
+	rows, err := c.getReactionRows(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+	reactions := make(ReactionList, 0, len(rows))
+	for _, row := range rows {
+		reactions = append(reactions, &Reaction{UserId: row.UserId, Type: row.ReactionType})
+	}
+	return reactions, nil
+}
+
+// React adds a Reaction to this comment, storing it in the comment_reaction
+// child table. A duplicate (comment, user, type) reaction is rejected.
+func (c *Comment) React(ctx context.Context, db database.Provider, u database.UserId, t reactionType) error {
+	r := &Reaction{UserId: u, Type: t}
+
+	if err := database.Validate(ctx, db, r); err != nil {
+		return err
+	}
+
+	rows, err := c.getReactionRows(ctx, db)
+	if err != nil {
+		return err
+	}
+	for _, row := range rows {
+		if row.UserId == u && row.ReactionType == t {
+			return fmt.Errorf("reaction already exists: %+v", r)
+		}
+	}
+
+	row := &CommentReaction{
+		CommentId:    c.ID,
+		UserId:       u,
+		ReactionType: t,
+	}
+	_, err = database.CreateOne(ctx, db, row)
+	return err
+}
+
+// Unreact removes the Reaction matching (user, type) from this comment.
+func (c *Comment) Unreact(ctx context.Context, db database.Provider, u database.UserId, t reactionType) error {
+	r := &Reaction{UserId: u, Type: t}
+
+	rows, err := c.getReactionRows(ctx, db)
+	if err != nil {
+		return err
+	}
+	for _, row := range rows {
+		if row.UserId == u && row.ReactionType == t {
+			_, _, err := database.DeleteOneById(ctx, db, row, row.GetId())
+			return err
+		}
+	}
+	return fmt.Errorf("reaction with values %+v does not exist", r)
 }

--- a/model/comment_test.go
+++ b/model/comment_test.go
@@ -37,7 +37,6 @@ func copyComment(c *Comment) *Comment {
 		Content:   c.Content,
 		CreatedAt: c.CreatedAt,
 		EditedAt:  c.EditedAt,
-		Reactions: c.Reactions,
 	}
 }
 

--- a/model/commissioner_proposal.go
+++ b/model/commissioner_proposal.go
@@ -22,7 +22,7 @@ import (
 // field is not a breaking wire change; in-process reads can reassemble the
 // relationship rows into the old map shape via `CommissionerProposal.GetVotes`.
 type CommissionerProposal struct {
-	ID              database.RecordId // unique ID for this proposal
+	ID              database.RecordId `json:"id"` // unique ID for this proposal
 	Description     string            // description of the change or action
 	SeasonId        SeasonId          // season that this pertains to
 	MustBeUnanimous bool              // true if this proposal must get unanimous consent to pass
@@ -267,7 +267,7 @@ func (c *CommissionerProposal) NewRecord() database.CrudRecord {
 // provider lands, this becomes a `commissioner_proposal_votes` table with a
 // migration/backfill.
 type CommissionerProposalVote struct {
-	ID         database.RecordId
+	ID         database.RecordId `json:"id"`
 	ProposalId database.RecordId
 	UserId     database.UserId
 	Vote       bool

--- a/model/photo.go
+++ b/model/photo.go
@@ -60,7 +60,7 @@ func (id PhotoId) UnmarshalJSON(data []byte) error {
 }
 
 type Photo struct {
-	ID       PhotoId
+	ID       PhotoId `json:"id"`
 	Owner    database.UserId
 	AltText  string
 	Contents []byte


### PR DESCRIPTION
Part of #36. Fully-normalized SQLite schema + field-level round-trip tests for:

- blurb
- comment
- photo
- commissioner_proposal
- commissioner_proposal_vote

Closes #61.

## Changes
- **Migrations 0042–0049**: `photo`, `blurb`, `blurb_photo`, `comment`, `blurb_reaction`, `comment_reaction`, `commissioner_proposal`, `commissioner_proposal_vote`.
- **`database/sqlite_db.go`**: the reflection mapper now persists `[]byte` as a SQLite `BLOB` column (used by `Photo.Contents`).
- **Model normalization**: the inline `Blurb.Photos`/`Blurb.Reactions` and `Comment.Reactions` slices are normalized into the `blurb_photo` / `blurb_reaction` / `comment_reaction` child tables, per the schema-conventions doc. `GetPhotos`/`GetReactions`/`React`/`Unreact` preserve the prior public API.
- **Round-trip tests** (`database/sqlite_communication_roundtrip_test.go`): Create → GetOne/GetAll → Update → Delete losslessness for all eight tables.

## Verification
`go build ./...` and `go test ./...` pass across all packages.