### PR TITLE
test(db): parameterize contract tests against SQLite + WAL concurrency test (#62, #63)

### DIFF
--- a/database/contract_test_helpers_test.go
+++ b/database/contract_test_helpers_test.go
@@ -1,0 +1,132 @@
+package database
+
+import (
+	"fmt"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+)
+
+// This file implements the provider-parameterization harness for the
+// database.Provider contract tests (issue #62). The contract tests in
+// database_provider_test.go, db_with_access_control_test.go,
+// validatable_test.go, and unique_constraint_test.go each exercise the same
+// CRUD / access-control / validation / uniqueness behavior; this harness lets
+// a single test body run against every supported provider: the in-memory
+// map-backed provider, SQLite in-memory, and SQLite on-disk.
+
+// testProviderKind identifies a database.Provider backend the contract tests
+// run against.
+type testProviderKind string
+
+const (
+	testProviderMemory       testProviderKind = "memory"
+	testProviderSqliteMemory testProviderKind = "sqlite-memory"
+	testProviderSqliteDisk   testProviderKind = "sqlite-disk"
+)
+
+// contractTestKinds returns every provider kind the contract tests run against.
+func contractTestKinds() []testProviderKind {
+	return []testProviderKind{
+		testProviderMemory,
+		testProviderSqliteMemory,
+		testProviderSqliteDisk,
+	}
+}
+
+// contractTestSchema creates the tables needed by the contract-test record
+// types (testRecord, testUnique, staticFailRecord, dynamicFailRecord,
+// PrivateTestRecord). Table names equal record.Type() and column names/types
+// follow the reflection-based column mapping in sqlite_db.go (see
+// docs/schema-conventions.md). The private_record.shared_to column stores the
+// []UserId slice as JSON TEXT.
+const contractTestSchema = `
+CREATE TABLE test_record (
+	id         TEXT PRIMARY KEY,
+	owner      TEXT,
+	created_at TEXT,
+	updated_at TEXT
+);
+CREATE TABLE test_unique (
+	id            TEXT PRIMARY KEY,
+	reference_id1 TEXT,
+	reference_id2 TEXT
+);
+CREATE TABLE static_fail (
+	id    TEXT PRIMARY KEY,
+	value TEXT
+);
+CREATE TABLE dynamic_fail (
+	id    TEXT PRIMARY KEY,
+	value TEXT
+);
+CREATE TABLE private_record (
+	id        TEXT PRIMARY KEY,
+	owner     TEXT,
+	shared_to TEXT,
+	value     TEXT
+);
+`
+
+// contractSqliteMemorySeq ensures each SQLite in-memory contract-test provider
+// gets a unique shared-cache database name, keeping provider instances isolated.
+var contractSqliteMemorySeq int64
+
+// newContractTestDB returns a fresh, isolated database.Provider of the given
+// kind with the contract-test schema applied (SQLite kinds) and disconnected
+// when the test completes. Each call returns an independent provider, so no
+// records leak between contract tests.
+func newContractTestDB(t *testing.T, kind testProviderKind) Provider {
+	t.Helper()
+	switch kind {
+	case testProviderMemory:
+		return NewUnitTestDBProvider()
+	case testProviderSqliteMemory, testProviderSqliteDisk:
+		var path string
+		if kind == testProviderSqliteMemory {
+			// A uniquely-named shared-cache in-memory database: cache=shared
+			// makes every connection in the provider's pool observe the same
+			// data, and the unique name keeps each provider instance isolated
+			// (an unnamed ":memory:" shared cache is process-wide and would
+			// leak records between tests).
+			path = fmt.Sprintf("contract-mem-%d?mode=memory&cache=shared", atomic.AddInt64(&contractSqliteMemorySeq, 1))
+		} else {
+			path = filepath.Join(t.TempDir(), "contract.db")
+		}
+		p, err := newSqliteDbProvider(path, []Migration{
+			{Name: "001_contract_tests", SQL: contractTestSchema},
+		})
+		if err != nil {
+			t.Fatalf("newSqliteDbProvider: %v", err)
+		}
+		t.Cleanup(func() { p.Disconnect() })
+		return p
+	default:
+		t.Fatalf("unknown contract provider kind %q", kind)
+		return nil
+	}
+}
+
+// contractTest pairs a contract-test name with its body. The body takes the
+// provider to run against, so it can be shared across every provider kind.
+type contractTest struct {
+	name string
+	fn   func(t *testing.T, db Provider)
+}
+
+// runContractTests runs every contract test body against every provider kind,
+// giving each (kind, test) a fresh, isolated provider. This is the driver that
+// makes the database.Provider contract tests run against memory, SQLite
+// in-memory, and SQLite on-disk (issue #62).
+func runContractTests(t *testing.T, tests []contractTest) {
+	t.Helper()
+	for _, kind := range contractTestKinds() {
+		t.Run(string(kind), func(t *testing.T) {
+			for _, tc := range tests {
+				t.Run(tc.name, func(t *testing.T) {
+					tc.fn(t, newContractTestDB(t, kind))
+				})
+			}
+		})
+	}
+}

--- a/database/database_provider_test.go
+++ b/database/database_provider_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 type testRecord struct {
-	ID        RecordId
+	ID        RecordId `json:"id"`
 	Owner     UserId
 	CreatedAt time.Time
 	UpdatedAt time.Time
@@ -34,7 +34,7 @@ func (t *testRecord) Copy() *testRecord {
 }
 
 func (t *testRecord) Type() string {
-	return "test record"
+	return "test_record"
 }
 
 func (t *testRecord) GetId() RecordId {
@@ -85,8 +85,7 @@ func (t *testRecord) NewRecord() CrudRecord {
 	return new(testRecord)
 }
 
-func TestCreateDataIsSetOnCreate(t *testing.T) {
-	db := NewUnitTestDBProvider()
+func testCreateDataIsSetOnCreate(t *testing.T, db Provider) {
 	v := newTestRecord()
 	created, err := CreateOne(context.Background(), db, v)
 	if err != nil {
@@ -99,8 +98,7 @@ func TestCreateDataIsSetOnCreate(t *testing.T) {
 	fmt.Println(created)
 }
 
-func TestCreateDateIsImmutable(t *testing.T) {
-	db := NewUnitTestDBProvider()
+func testCreateDateIsImmutable(t *testing.T, db Provider) {
 	v := newTestRecord()
 	created, err := CreateOne(context.Background(), db, v)
 	if err != nil {
@@ -113,13 +111,12 @@ func TestCreateDateIsImmutable(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if copied.CreatedAt != created.CreatedAt {
+	if !copied.CreatedAt.Equal(created.CreatedAt) {
 		t.Error("Created timestamp is not immutable")
 	}
 }
 
-func TestGetOneByIdSuccess(t *testing.T) {
-	db := NewUnitTestDBProvider()
+func testGetOneByIdSuccess(t *testing.T, db Provider) {
 	v := newTestRecord()
 	created, err := CreateOne(context.Background(), db, v)
 	if err != nil {
@@ -138,8 +135,7 @@ func TestGetOneByIdSuccess(t *testing.T) {
 	}
 }
 
-func TestGetOneByIdNotFound(t *testing.T) {
-	db := NewUnitTestDBProvider()
+func testGetOneByIdNotFound(t *testing.T, db Provider) {
 	nonExistentId := NewRecordId()
 
 	result, exists, err := GetOneById(context.Background(), db, &testRecord{}, nonExistentId)
@@ -154,8 +150,7 @@ func TestGetOneByIdNotFound(t *testing.T) {
 	}
 }
 
-func TestGetExistingRecordByIdSuccess(t *testing.T) {
-	db := NewUnitTestDBProvider()
+func testGetExistingRecordByIdSuccess(t *testing.T, db Provider) {
 	v := newTestRecord()
 	created, err := CreateOne(context.Background(), db, v)
 	if err != nil {
@@ -171,8 +166,7 @@ func TestGetExistingRecordByIdSuccess(t *testing.T) {
 	}
 }
 
-func TestGetExistingRecordByIdNotFound(t *testing.T) {
-	db := NewUnitTestDBProvider()
+func testGetExistingRecordByIdNotFound(t *testing.T, db Provider) {
 	nonExistentId := NewRecordId()
 
 	_, err := GetExistingRecordById(context.Background(), db, &testRecord{}, nonExistentId)
@@ -181,8 +175,7 @@ func TestGetExistingRecordByIdNotFound(t *testing.T) {
 	}
 }
 
-func TestExistsByIdExists(t *testing.T) {
-	db := NewUnitTestDBProvider()
+func testExistsByIdExists(t *testing.T, db Provider) {
 	v := newTestRecord()
 	created, err := CreateOne(context.Background(), db, v)
 	if err != nil {
@@ -195,8 +188,7 @@ func TestExistsByIdExists(t *testing.T) {
 	}
 }
 
-func TestExistsByIdNotFound(t *testing.T) {
-	db := NewUnitTestDBProvider()
+func testExistsByIdNotFound(t *testing.T, db Provider) {
 	nonExistentId := NewRecordId()
 
 	err := ExistsById(context.Background(), db, &testRecord{}, nonExistentId)
@@ -205,8 +197,7 @@ func TestExistsByIdNotFound(t *testing.T) {
 	}
 }
 
-func TestGetAllEmpty(t *testing.T) {
-	db := NewUnitTestDBProvider()
+func testGetAllEmpty(t *testing.T, db Provider) {
 
 	results, err := GetAll[*testRecord](context.Background(), db)
 	if err != nil {
@@ -217,8 +208,7 @@ func TestGetAllEmpty(t *testing.T) {
 	}
 }
 
-func TestGetAllWithRecords(t *testing.T) {
-	db := NewUnitTestDBProvider()
+func testGetAllWithRecords(t *testing.T, db Provider) {
 
 	for i := 0; i < 5; i++ {
 		_, err := CreateOne(context.Background(), db, newTestRecord())
@@ -236,8 +226,7 @@ func TestGetAllWithRecords(t *testing.T) {
 	}
 }
 
-func TestGetAllWhereWithFilter(t *testing.T) {
-	db := NewUnitTestDBProvider()
+func testGetAllWhereWithFilter(t *testing.T, db Provider) {
 
 	ownerId1 := UserId(NewRecordId())
 	ownerId2 := UserId(NewRecordId())
@@ -270,8 +259,7 @@ func TestGetAllWhereWithFilter(t *testing.T) {
 	}
 }
 
-func TestGetAllWhereNoResults(t *testing.T) {
-	db := NewUnitTestDBProvider()
+func testGetAllWhereNoResults(t *testing.T, db Provider) {
 
 	_, err := CreateOne(context.Background(), db, newTestRecord())
 	if err != nil {
@@ -289,8 +277,7 @@ func TestGetAllWhereNoResults(t *testing.T) {
 	}
 }
 
-func TestGetAllWhereNilFilter(t *testing.T) {
-	db := NewUnitTestDBProvider()
+func testGetAllWhereNilFilter(t *testing.T, db Provider) {
 
 	for i := 0; i < 3; i++ {
 		_, err := CreateOne(context.Background(), db, newTestRecord())
@@ -308,8 +295,7 @@ func TestGetAllWhereNilFilter(t *testing.T) {
 	}
 }
 
-func TestDeleteOneByIdSuccess(t *testing.T) {
-	db := NewUnitTestDBProvider()
+func testDeleteOneByIdSuccess(t *testing.T, db Provider) {
 	v := newTestRecord()
 	created, err := CreateOne(context.Background(), db, v)
 	if err != nil {
@@ -334,8 +320,7 @@ func TestDeleteOneByIdSuccess(t *testing.T) {
 	}
 }
 
-func TestDeleteOneByIdNotFound(t *testing.T) {
-	db := NewUnitTestDBProvider()
+func testDeleteOneByIdNotFound(t *testing.T, db Provider) {
 	nonExistentId := NewRecordId()
 
 	result, exists, err := DeleteOneById(context.Background(), db, &testRecord{}, nonExistentId)
@@ -350,8 +335,7 @@ func TestDeleteOneByIdNotFound(t *testing.T) {
 	}
 }
 
-func TestDeleteOneByIdDoubleDelete(t *testing.T) {
-	db := NewUnitTestDBProvider()
+func testDeleteOneByIdDoubleDelete(t *testing.T, db Provider) {
 	v := newTestRecord()
 	created, err := CreateOne(context.Background(), db, v)
 	if err != nil {
@@ -377,8 +361,7 @@ func TestDeleteOneByIdDoubleDelete(t *testing.T) {
 	}
 }
 
-func TestUpdateOneBasic(t *testing.T) {
-	db := NewUnitTestDBProvider()
+func testUpdateOneBasic(t *testing.T, db Provider) {
 	v := newTestRecord()
 	v.Owner = UserId(NewRecordId())
 	created, err := CreateOne(context.Background(), db, v)
@@ -407,8 +390,7 @@ func TestUpdateOneBasic(t *testing.T) {
 	}
 }
 
-func TestUpdateOneNotFound(t *testing.T) {
-	db := NewUnitTestDBProvider()
+func testUpdateOneNotFound(t *testing.T, db Provider) {
 
 	nonExistent := &testRecord{
 		ID:    NewRecordId(),
@@ -420,8 +402,7 @@ func TestUpdateOneNotFound(t *testing.T) {
 	}
 }
 
-func TestCreateOneWithPreSetId(t *testing.T) {
-	db := NewUnitTestDBProvider()
+func testCreateOneWithPreSetId(t *testing.T, db Provider) {
 	v := newTestRecord()
 	v.ID = NewRecordId()
 	created, err := CreateOne(context.Background(), db, v)
@@ -433,8 +414,7 @@ func TestCreateOneWithPreSetId(t *testing.T) {
 	}
 }
 
-func TestCreateOneGeneratesNewId(t *testing.T) {
-	db := NewUnitTestDBProvider()
+func testCreateOneGeneratesNewId(t *testing.T, db Provider) {
 	id := NewRecordId()
 
 	v := newTestRecord()
@@ -449,8 +429,7 @@ func TestCreateOneGeneratesNewId(t *testing.T) {
 	}
 }
 
-func TestGetAllDifferentTypes(t *testing.T) {
-	db := NewUnitTestDBProvider()
+func testGetAllDifferentTypes(t *testing.T, db Provider) {
 
 	_, err := CreateOne(context.Background(), db, newTestRecord())
 	if err != nil {
@@ -497,4 +476,32 @@ func TestCrudRecordBlankRecord(t *testing.T) {
 	if blankTestRecord.ID != InvalidRecordId {
 		t.Fatal("BlankRecord should have invalid ID")
 	}
+}
+
+// TestDatabaseProviderContract runs every TestDatabaseProviderContract test body against every database.Provider kind
+// (memory, SQLite in-memory, SQLite on-disk) via runContractTests (issue #62).
+func TestDatabaseProviderContract(t *testing.T) {
+	runContractTests(t, []contractTest{
+		{name: "TestCreateDataIsSetOnCreate", fn: testCreateDataIsSetOnCreate},
+		{name: "TestCreateDateIsImmutable", fn: testCreateDateIsImmutable},
+		{name: "TestGetOneByIdSuccess", fn: testGetOneByIdSuccess},
+		{name: "TestGetOneByIdNotFound", fn: testGetOneByIdNotFound},
+		{name: "TestGetExistingRecordByIdSuccess", fn: testGetExistingRecordByIdSuccess},
+		{name: "TestGetExistingRecordByIdNotFound", fn: testGetExistingRecordByIdNotFound},
+		{name: "TestExistsByIdExists", fn: testExistsByIdExists},
+		{name: "TestExistsByIdNotFound", fn: testExistsByIdNotFound},
+		{name: "TestGetAllEmpty", fn: testGetAllEmpty},
+		{name: "TestGetAllWithRecords", fn: testGetAllWithRecords},
+		{name: "TestGetAllWhereWithFilter", fn: testGetAllWhereWithFilter},
+		{name: "TestGetAllWhereNoResults", fn: testGetAllWhereNoResults},
+		{name: "TestGetAllWhereNilFilter", fn: testGetAllWhereNilFilter},
+		{name: "TestDeleteOneByIdSuccess", fn: testDeleteOneByIdSuccess},
+		{name: "TestDeleteOneByIdNotFound", fn: testDeleteOneByIdNotFound},
+		{name: "TestDeleteOneByIdDoubleDelete", fn: testDeleteOneByIdDoubleDelete},
+		{name: "TestUpdateOneBasic", fn: testUpdateOneBasic},
+		{name: "TestUpdateOneNotFound", fn: testUpdateOneNotFound},
+		{name: "TestCreateOneWithPreSetId", fn: testCreateOneWithPreSetId},
+		{name: "TestCreateOneGeneratesNewId", fn: testCreateOneGeneratesNewId},
+		{name: "TestGetAllDifferentTypes", fn: testGetAllDifferentTypes},
+	})
 }

--- a/database/db_with_access_control_test.go
+++ b/database/db_with_access_control_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 type PrivateTestRecord struct {
-	ID       RecordId
+	ID       RecordId `json:"id"`
 	Owner    UserId
 	SharedTo []UserId
 	Value    string
@@ -82,8 +82,7 @@ func newStoredPrivateTestRecord(t *testing.T, db Provider, owner UserId) *Privat
 	return v
 }
 
-func TestGetOneViaOwner(t *testing.T) {
-	db := NewUnitTestDBProvider()
+func testGetOneViaOwner(t *testing.T, db Provider) {
 	userId := UserId(NewRecordId())
 	r := newStoredPrivateTestRecord(t, db, userId)
 
@@ -98,8 +97,7 @@ func TestGetOneViaOwner(t *testing.T) {
 	fmt.Printf("%+v\n", v)
 }
 
-func TestGetOneViaSharedTo(t *testing.T) {
-	db := NewUnitTestDBProvider()
+func testGetOneViaSharedTo(t *testing.T, db Provider) {
 	ownerId := UserId(NewRecordId())
 	r := newStoredPrivateTestRecord(t, db, ownerId)
 
@@ -120,8 +118,7 @@ func TestGetOneViaSharedTo(t *testing.T) {
 	fmt.Printf("%+v\n", v)
 }
 
-func TestGetOneUnauthorized(t *testing.T) {
-	db := NewUnitTestDBProvider()
+func testGetOneUnauthorized(t *testing.T, db Provider) {
 	ownerId := UserId(NewRecordId())
 	r := newStoredPrivateTestRecord(t, db, ownerId)
 
@@ -137,8 +134,7 @@ func TestGetOneUnauthorized(t *testing.T) {
 	}
 }
 
-func TestDeleteOneByOwner(t *testing.T) {
-	db := NewUnitTestDBProvider()
+func testDeleteOneByOwner(t *testing.T, db Provider) {
 	ownerId := UserId(NewRecordId())
 	r := newStoredPrivateTestRecord(t, db, ownerId)
 
@@ -153,8 +149,7 @@ func TestDeleteOneByOwner(t *testing.T) {
 	fmt.Printf("%+v\n", v)
 }
 
-func TestDeleteOneByUnauthorized(t *testing.T) {
-	db := NewUnitTestDBProvider()
+func testDeleteOneByUnauthorized(t *testing.T, db Provider) {
 	ownerId := UserId(NewRecordId())
 	r := newStoredPrivateTestRecord(t, db, ownerId)
 
@@ -169,8 +164,7 @@ func TestDeleteOneByUnauthorized(t *testing.T) {
 	}
 }
 
-func TestUpdateOneByOwner(t *testing.T) {
-	db := NewUnitTestDBProvider()
+func testUpdateOneByOwner(t *testing.T, db Provider) {
 	ownerId := UserId(NewRecordId())
 	r := newStoredPrivateTestRecord(t, db, ownerId)
 
@@ -209,9 +203,8 @@ func updateRecordAndReQuery(t *testing.T, db Provider, r *PrivateTestRecord, new
 	return v, err
 }
 
-func TestUpdateOneByUnauthorized(t *testing.T) {
+func testUpdateOneByUnauthorized(t *testing.T, db Provider) {
 	// create a record in the database
-	db := NewUnitTestDBProvider()
 	ownerId := UserId(NewRecordId())
 	r := newStoredPrivateTestRecord(t, db, ownerId)
 
@@ -225,9 +218,8 @@ func TestUpdateOneByUnauthorized(t *testing.T) {
 	}
 }
 
-func TestAccessibleByEveryone(t *testing.T) {
+func testAccessibleByEveryone(t *testing.T, db Provider) {
 	// create a record in the database
-	db := NewUnitTestDBProvider()
 	ownerId := UserId(NewRecordId())
 	r := newStoredPrivateTestRecord(t, db, ownerId)
 	err := r.ShareTo(context.Background(), db, EveryoneUserId, ownerId)
@@ -248,8 +240,7 @@ func TestAccessibleByEveryone(t *testing.T) {
 	fmt.Printf("%+v\n", v)
 }
 
-func TestAccessibleBySysAdmin(t *testing.T) {
-	db := NewUnitTestDBProvider()
+func testAccessibleBySysAdmin(t *testing.T, db Provider) {
 	ownerId := UserId(NewRecordId())
 	r := newStoredPrivateTestRecord(t, db, ownerId)
 
@@ -268,8 +259,7 @@ func TestAccessibleBySysAdmin(t *testing.T) {
 	fmt.Printf("%+v\n", v)
 }
 
-func TestEditableBySysAdmin(t *testing.T) {
-	db := NewUnitTestDBProvider()
+func testEditableBySysAdmin(t *testing.T, db Provider) {
 	ownerId := UserId(NewRecordId())
 	r := newStoredPrivateTestRecord(t, db, ownerId)
 	fmt.Printf("%+v\n", r)
@@ -288,8 +278,7 @@ func TestEditableBySysAdmin(t *testing.T) {
 	fmt.Printf("%+v\n", v)
 }
 
-func TestGetAllByOwner(t *testing.T) {
-	db := NewUnitTestDBProvider()
+func testGetAllByOwner(t *testing.T, db Provider) {
 	ownerId := UserId(NewRecordId())
 	otherId := UserId(NewRecordId())
 
@@ -309,8 +298,7 @@ func TestGetAllByOwner(t *testing.T) {
 	}
 }
 
-func TestGetAllByUnauthorizedUser(t *testing.T) {
-	db := NewUnitTestDBProvider()
+func testGetAllByUnauthorizedUser(t *testing.T, db Provider) {
 	ownerId := UserId(NewRecordId())
 	unauthorizedId := UserId(NewRecordId())
 
@@ -326,8 +314,7 @@ func TestGetAllByUnauthorizedUser(t *testing.T) {
 	}
 }
 
-func TestGetAllBySysAdmin(t *testing.T) {
-	db := NewUnitTestDBProvider()
+func testGetAllBySysAdmin(t *testing.T, db Provider) {
 	ownerId := UserId(NewRecordId())
 	adminId := UserId(NewRecordId())
 
@@ -347,8 +334,7 @@ func TestGetAllBySysAdmin(t *testing.T) {
 	}
 }
 
-func TestDeleteOneByIdNotFoundNonOwner(t *testing.T) {
-	db := NewUnitTestDBProvider()
+func testDeleteOneByIdNotFoundNonOwner(t *testing.T, db Provider) {
 	ownerId := UserId(NewRecordId())
 	newStoredPrivateTestRecord(t, db, ownerId)
 
@@ -363,8 +349,7 @@ func TestDeleteOneByIdNotFoundNonOwner(t *testing.T) {
 	}
 }
 
-func TestUpdateOneByIdNotFound(t *testing.T) {
-	db := NewUnitTestDBProvider()
+func testUpdateOneByIdNotFound(t *testing.T, db Provider) {
 	ownerId := UserId(NewRecordId())
 	newStoredPrivateTestRecord(t, db, ownerId)
 
@@ -379,8 +364,7 @@ func TestUpdateOneByIdNotFound(t *testing.T) {
 	}
 }
 
-func TestDeleteBySharedToUser(t *testing.T) {
-	db := NewUnitTestDBProvider()
+func testDeleteBySharedToUser(t *testing.T, db Provider) {
 	ownerId := UserId(NewRecordId())
 	r := newStoredPrivateTestRecord(t, db, ownerId)
 
@@ -411,8 +395,7 @@ func TestDeleteBySharedToUser(t *testing.T) {
 	}
 }
 
-func TestUpdateBySharedToUser(t *testing.T) {
-	db := NewUnitTestDBProvider()
+func testUpdateBySharedToUser(t *testing.T, db Provider) {
 	ownerId := UserId(NewRecordId())
 	r := newStoredPrivateTestRecord(t, db, ownerId)
 
@@ -435,8 +418,7 @@ func TestUpdateBySharedToUser(t *testing.T) {
 	}
 }
 
-func TestGetOneBySharedToUser(t *testing.T) {
-	db := NewUnitTestDBProvider()
+func testGetOneBySharedToUser(t *testing.T, db Provider) {
 	ownerId := UserId(NewRecordId())
 	r := newStoredPrivateTestRecord(t, db, ownerId)
 
@@ -457,8 +439,7 @@ func TestGetOneBySharedToUser(t *testing.T) {
 	fmt.Printf("%+v\n", v)
 }
 
-func TestUpdateOneBySharedToUser(t *testing.T) {
-	db := NewUnitTestDBProvider()
+func testUpdateOneBySharedToUser(t *testing.T, db Provider) {
 	ownerId := UserId(NewRecordId())
 	r := newStoredPrivateTestRecord(t, db, ownerId)
 
@@ -482,8 +463,7 @@ func TestUpdateOneBySharedToUser(t *testing.T) {
 	}
 }
 
-func TestGetOneIdDoesNotExist(t *testing.T) {
-	db := NewUnitTestDBProvider()
+func testGetOneIdDoesNotExist(t *testing.T, db Provider) {
 	ownerId := UserId(NewRecordId())
 	newStoredPrivateTestRecord(t, db, ownerId)
 
@@ -497,8 +477,7 @@ func TestGetOneIdDoesNotExist(t *testing.T) {
 	}
 }
 
-func TestGetAllWithMultipleOwners(t *testing.T) {
-	db := NewUnitTestDBProvider()
+func testGetAllWithMultipleOwners(t *testing.T, db Provider) {
 	owner1 := UserId(NewRecordId())
 	owner2 := UserId(NewRecordId())
 	owner3 := UserId(NewRecordId())
@@ -518,8 +497,7 @@ func TestGetAllWithMultipleOwners(t *testing.T) {
 	}
 }
 
-func TestDeleteBySysAdmin(t *testing.T) {
-	db := NewUnitTestDBProvider()
+func testDeleteBySysAdmin(t *testing.T, db Provider) {
 	ownerId := UserId(NewRecordId())
 	r := newStoredPrivateTestRecord(t, db, ownerId)
 
@@ -537,4 +515,33 @@ func TestDeleteBySysAdmin(t *testing.T) {
 		t.Fatal("sys admin should be able to delete")
 	}
 	fmt.Printf("%+v\n", v)
+}
+
+// TestDbWithAccessControlContract runs every TestDbWithAccessControlContract test body against every database.Provider kind
+// (memory, SQLite in-memory, SQLite on-disk) via runContractTests (issue #62).
+func TestDbWithAccessControlContract(t *testing.T) {
+	runContractTests(t, []contractTest{
+		{name: "TestGetOneViaOwner", fn: testGetOneViaOwner},
+		{name: "TestGetOneViaSharedTo", fn: testGetOneViaSharedTo},
+		{name: "TestGetOneUnauthorized", fn: testGetOneUnauthorized},
+		{name: "TestDeleteOneByOwner", fn: testDeleteOneByOwner},
+		{name: "TestDeleteOneByUnauthorized", fn: testDeleteOneByUnauthorized},
+		{name: "TestUpdateOneByOwner", fn: testUpdateOneByOwner},
+		{name: "TestUpdateOneByUnauthorized", fn: testUpdateOneByUnauthorized},
+		{name: "TestAccessibleByEveryone", fn: testAccessibleByEveryone},
+		{name: "TestAccessibleBySysAdmin", fn: testAccessibleBySysAdmin},
+		{name: "TestEditableBySysAdmin", fn: testEditableBySysAdmin},
+		{name: "TestGetAllByOwner", fn: testGetAllByOwner},
+		{name: "TestGetAllByUnauthorizedUser", fn: testGetAllByUnauthorizedUser},
+		{name: "TestGetAllBySysAdmin", fn: testGetAllBySysAdmin},
+		{name: "TestDeleteOneByIdNotFoundNonOwner", fn: testDeleteOneByIdNotFoundNonOwner},
+		{name: "TestUpdateOneByIdNotFound", fn: testUpdateOneByIdNotFound},
+		{name: "TestDeleteBySharedToUser", fn: testDeleteBySharedToUser},
+		{name: "TestUpdateBySharedToUser", fn: testUpdateBySharedToUser},
+		{name: "TestGetOneBySharedToUser", fn: testGetOneBySharedToUser},
+		{name: "TestUpdateOneBySharedToUser", fn: testUpdateOneBySharedToUser},
+		{name: "TestGetOneIdDoesNotExist", fn: testGetOneIdDoesNotExist},
+		{name: "TestGetAllWithMultipleOwners", fn: testGetAllWithMultipleOwners},
+		{name: "TestDeleteBySysAdmin", fn: testDeleteBySysAdmin},
+	})
 }

--- a/database/sqlite_concurrency_test.go
+++ b/database/sqlite_concurrency_test.go
@@ -1,0 +1,84 @@
+package database
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// TestSqliteProviderConcurrentCRUD exercises parallel CRUD against the SQLite
+// provider (issue #63). The provider opens the database in WAL mode with a
+// busy timeout (see newSqliteDbProvider), which allows concurrent readers
+// while writes are serialized on the single writer lock. This test drives
+// Create/Read/Update/Delete from many goroutines at once to catch
+// "database is locked" failures that could surface from concurrent Gin
+// handlers.
+func TestSqliteProviderConcurrentCRUD(t *testing.T) {
+	ctx := context.Background()
+	p := newTestSqliteProvider(t)
+
+	const workers = 16
+	const opsPerWorker = 30
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, workers*opsPerWorker)
+	start := make(chan struct{})
+
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			<-start
+			for i := 0; i < opsPerWorker; i++ {
+				rec := &sqliteTestRecord{
+					Name:    fmt.Sprintf("w%d-%d", w, i),
+					Age:     w + i,
+					Enabled: i%2 == 0,
+				}
+				created, err := CreateOne(ctx, p, rec)
+				if err != nil {
+					errCh <- fmt.Errorf("create: %w", err)
+					continue
+				}
+
+				if _, exists, err := GetOneById(ctx, p, &sqliteTestRecord{}, created.GetId()); err != nil || !exists {
+					errCh <- fmt.Errorf("get: exists=%v err=%v", exists, err)
+					continue
+				}
+
+				created.Age++
+				if err := UpdateOne(ctx, p, created); err != nil {
+					errCh <- fmt.Errorf("update: %w", err)
+					continue
+				}
+
+				if _, exists, err := DeleteOneById(ctx, p, &sqliteTestRecord{}, created.GetId()); err != nil || !exists {
+					errCh <- fmt.Errorf("delete: exists=%v err=%v", exists, err)
+					continue
+				}
+			}
+		}(w)
+	}
+
+	close(start)
+	wg.Wait()
+	close(errCh)
+
+	var firstErr error
+	for err := range errCh {
+		if err == nil {
+			continue
+		}
+		if strings.Contains(err.Error(), "database is locked") {
+			t.Fatalf("SQLite returned 'database is locked' during concurrent CRUD: %v", err)
+		}
+		if firstErr == nil {
+			firstErr = err
+		}
+	}
+	if firstErr != nil {
+		t.Fatalf("concurrent CRUD failed: %v", firstErr)
+	}
+}

--- a/database/sqlite_db.go
+++ b/database/sqlite_db.go
@@ -3,6 +3,7 @@ package database
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
@@ -55,8 +56,15 @@ func newSqliteDbProvider(path string, migrations []Migration) (*SqliteDbProvider
 		path = "intraclub.db"
 	}
 
-	dsn := "file:" + path +
-		"?_pragma=busy_timeout(5000)" + // concurrent reads from Gin handlers
+	// Append pragmas to the path. A path may already carry a query string (e.g.
+	// a shared-cache in-memory database ":memory:?cache=shared"), in which case
+	// the pragmas are joined with "&" rather than a second "?".
+	querySep := "?"
+	if strings.Contains(path, "?") {
+		querySep = "&"
+	}
+	dsn := "file:" + path + querySep +
+		"_pragma=busy_timeout(5000)" + // concurrent reads from Gin handlers
 		"&_pragma=journal_mode(WAL)" + // single-writer, concurrent readers
 		"&_txlock=immediate" // acquire the write lock up front
 	db, err := sql.Open("sqlite", dsn)
@@ -437,11 +445,17 @@ func encodeValue(field reflect.Value) (any, error) {
 		return nil, fmt.Errorf("unsupported interface field %s", field.Type())
 	case reflect.Slice, reflect.Array:
 		// []byte (and [N]byte) are stored as a SQLite BLOB column (e.g.
-		// Photo.Contents).
+		// Photo.Contents). Any other slice/array (e.g. a []UserId on the
+		// access-control test record) is stored as a JSON TEXT column so the
+		// elements round-trip losslessly.
 		if field.Type().Elem().Kind() == reflect.Uint8 {
 			return field.Bytes(), nil
 		}
-		return nil, fmt.Errorf("unsupported slice/array field %s", field.Type())
+		b, err := json.Marshal(field.Interface())
+		if err != nil {
+			return nil, fmt.Errorf("marshal slice field %s: %w", field.Type(), err)
+		}
+		return string(b), nil
 	default:
 		return nil, fmt.Errorf("unsupported field kind %s", field.Kind())
 	}
@@ -510,7 +524,16 @@ func setField(field reflect.Value, raw any) error {
 			}
 			return nil
 		}
-		return fmt.Errorf("unsupported slice/array field %s", field.Type())
+		// Other slices/arrays are stored as a JSON TEXT column (see
+		// encodeValue); decode it back into the slice.
+		s := asString(raw)
+		if s == "" {
+			return nil
+		}
+		if err := json.Unmarshal([]byte(s), field.Addr().Interface()); err != nil {
+			return fmt.Errorf("unmarshal slice field %s: %w", field.Type(), err)
+		}
+		return nil
 	default:
 		return fmt.Errorf("unsupported field kind %s", field.Kind())
 	}

--- a/database/sqlite_db_test.go
+++ b/database/sqlite_db_test.go
@@ -159,3 +159,54 @@ func TestSqliteProviderNoOpUpdateSucceeds(t *testing.T) {
 		t.Fatalf("no-op Update should succeed, got: %v", err)
 	}
 }
+
+// sqliteSliceTestRecord carries a []UserId field to exercise the JSON TEXT
+// column mapping for non-[]byte slices.
+type sqliteSliceTestRecord struct {
+	ID       RecordId `json:"id"`
+	Owner    UserId   `json:"owner"`
+	SharedTo []UserId `json:"shared_to"`
+}
+
+func (r *sqliteSliceTestRecord) Type() string                        { return "test_slice_record" }
+func (r *sqliteSliceTestRecord) GetId() RecordId                     { return r.ID }
+func (r *sqliteSliceTestRecord) SetId(id RecordId)                   { r.ID = id }
+func (r *sqliteSliceTestRecord) GetOwner() UserId                    { return r.Owner }
+func (r *sqliteSliceTestRecord) SetOwner(UserId)                     {}
+func (r *sqliteSliceTestRecord) EditableBy(context.Context, Provider) []UserId { return []UserId{r.Owner} }
+func (r *sqliteSliceTestRecord) AccessibleTo(context.Context, Provider) []UserId { return []UserId{r.Owner} }
+func (r *sqliteSliceTestRecord) StaticallyValid() error              { return nil }
+func (r *sqliteSliceTestRecord) DynamicallyValid(context.Context, Provider) error { return nil }
+func (r *sqliteSliceTestRecord) NewRecord() CrudRecord               { return &sqliteSliceTestRecord{} }
+
+const testSliceRecordMigration = "CREATE TABLE test_slice_record (id TEXT PRIMARY KEY, owner TEXT, shared_to TEXT);"
+
+func TestSqliteProviderSliceRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	p, err := newSqliteDbProvider(filepath.Join(t.TempDir(), "slice.db"), []Migration{
+		{Name: "001_test_slice_record", SQL: testSliceRecordMigration},
+	})
+	if err != nil {
+		t.Fatalf("newSqliteDbProvider: %v", err)
+	}
+	t.Cleanup(func() { p.Disconnect() })
+
+	sharedTo := []UserId{UserId(NewRecordId()), EveryoneUserId}
+	created, err := p.Create(ctx, &sqliteSliceTestRecord{Owner: UserId(NewRecordId()), SharedTo: sharedTo})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	rec := created.(*sqliteSliceTestRecord)
+
+	got, exists, err := p.GetOne(ctx, &sqliteSliceTestRecord{ID: rec.GetId()})
+	if err != nil {
+		t.Fatalf("GetOne: %v", err)
+	}
+	if !exists {
+		t.Fatal("record not found")
+	}
+	g := got.(*sqliteSliceTestRecord)
+	if len(g.SharedTo) != len(sharedTo) || g.SharedTo[0] != sharedTo[0] || g.SharedTo[1] != sharedTo[1] {
+		t.Fatalf("slice round-trip mismatch, got %+v", g.SharedTo)
+	}
+}

--- a/database/unique_constraint_test.go
+++ b/database/unique_constraint_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 type testUnique struct {
-	RecordId     RecordId
+	RecordId     RecordId `json:"id"`
 	ReferenceId1 RecordId
 	ReferenceId2 RecordId
 }
@@ -57,8 +57,7 @@ func (t *testUnique) NewRecord() CrudRecord {
 	return new(testUnique)
 }
 
-func TestValidateUniqueConstraintOnCreate(t *testing.T) {
-	db := NewUnitTestDBProvider()
+func testValidateUniqueConstraintOnCreate(t *testing.T, db Provider) {
 	record1 := testUnique{
 		RecordId:     1,
 		ReferenceId1: 2,
@@ -81,8 +80,7 @@ func TestValidateUniqueConstraintOnCreate(t *testing.T) {
 	fmt.Println(err)
 }
 
-func TestValidateUniqueConstraintOnUpdate(t *testing.T) {
-	db := NewUnitTestDBProvider()
+func testValidateUniqueConstraintOnUpdate(t *testing.T, db Provider) {
 	record1 := testUnique{
 		RecordId:     1,
 		ReferenceId1: 2,
@@ -116,8 +114,7 @@ func TestValidateUniqueConstraintOnUpdate(t *testing.T) {
 	fmt.Println(err)
 }
 
-func TestSelfUpdateWithUniqueConstraint(t *testing.T) {
-	db := NewUnitTestDBProvider()
+func testSelfUpdateWithUniqueConstraint(t *testing.T, db Provider) {
 	record1 := testUnique{
 		RecordId:     1,
 		ReferenceId1: 2,
@@ -139,8 +136,7 @@ func TestSelfUpdateWithUniqueConstraint(t *testing.T) {
 	}
 }
 
-func TestUniqueConstraintNoExistingRecords(t *testing.T) {
-	db := NewUnitTestDBProvider()
+func testUniqueConstraintNoExistingRecords(t *testing.T, db Provider) {
 
 	record1 := testUnique{
 		RecordId:     1,
@@ -153,8 +149,7 @@ func TestUniqueConstraintNoExistingRecords(t *testing.T) {
 	}
 }
 
-func TestUniqueConstraintSameRecordUpdate(t *testing.T) {
-	db := NewUnitTestDBProvider()
+func testUniqueConstraintSameRecordUpdate(t *testing.T, db Provider) {
 	record1 := testUnique{
 		RecordId:     1,
 		ReferenceId1: 2,
@@ -177,8 +172,7 @@ func TestUniqueConstraintSameRecordUpdate(t *testing.T) {
 	}
 }
 
-func TestUniqueConstraintPartialMatch(t *testing.T) {
-	db := NewUnitTestDBProvider()
+func testUniqueConstraintPartialMatch(t *testing.T, db Provider) {
 
 	record1 := testUnique{
 		RecordId:     1,
@@ -213,8 +207,7 @@ func TestUniqueConstraintPartialMatch(t *testing.T) {
 	}
 }
 
-func TestUniqueConstraintMultipleDuplicates(t *testing.T) {
-	db := NewUnitTestDBProvider()
+func testUniqueConstraintMultipleDuplicates(t *testing.T, db Provider) {
 
 	record1 := testUnique{
 		RecordId:     1,
@@ -249,8 +242,7 @@ func TestUniqueConstraintMultipleDuplicates(t *testing.T) {
 	}
 }
 
-func TestUniqueConstraintUpdateToSelfUnique(t *testing.T) {
-	db := NewUnitTestDBProvider()
+func testUniqueConstraintUpdateToSelfUnique(t *testing.T, db Provider) {
 
 	record1 := testUnique{
 		RecordId:     1,
@@ -282,4 +274,19 @@ func TestUniqueConstraintUpdateToSelfUnique(t *testing.T) {
 	if err == nil {
 		t.Fatal("updating to match another record's unique values should fail")
 	}
+}
+
+// TestUniqueConstraintContract runs every TestUniqueConstraintContract test body against every database.Provider kind
+// (memory, SQLite in-memory, SQLite on-disk) via runContractTests (issue #62).
+func TestUniqueConstraintContract(t *testing.T) {
+	runContractTests(t, []contractTest{
+		{name: "TestValidateUniqueConstraintOnCreate", fn: testValidateUniqueConstraintOnCreate},
+		{name: "TestValidateUniqueConstraintOnUpdate", fn: testValidateUniqueConstraintOnUpdate},
+		{name: "TestSelfUpdateWithUniqueConstraint", fn: testSelfUpdateWithUniqueConstraint},
+		{name: "TestUniqueConstraintNoExistingRecords", fn: testUniqueConstraintNoExistingRecords},
+		{name: "TestUniqueConstraintSameRecordUpdate", fn: testUniqueConstraintSameRecordUpdate},
+		{name: "TestUniqueConstraintPartialMatch", fn: testUniqueConstraintPartialMatch},
+		{name: "TestUniqueConstraintMultipleDuplicates", fn: testUniqueConstraintMultipleDuplicates},
+		{name: "TestUniqueConstraintUpdateToSelfUnique", fn: testUniqueConstraintUpdateToSelfUnique},
+	})
 }

--- a/database/validatable_test.go
+++ b/database/validatable_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 type staticFailRecord struct {
-	ID    RecordId
+	ID    RecordId `json:"id"`
 	Value string
 }
 
@@ -53,7 +53,7 @@ func (s *staticFailRecord) NewRecord() CrudRecord {
 }
 
 type dynamicFailRecord struct {
-	ID    RecordId
+	ID    RecordId `json:"id"`
 	Value string
 }
 
@@ -98,8 +98,7 @@ func (d *dynamicFailRecord) NewRecord() CrudRecord {
 	return new(dynamicFailRecord)
 }
 
-func TestValidateStaticFails(t *testing.T) {
-	db := NewUnitTestDBProvider()
+func testValidateStaticFails(t *testing.T, db Provider) {
 	record := &staticFailRecord{
 		Value: "",
 	}
@@ -110,8 +109,7 @@ func TestValidateStaticFails(t *testing.T) {
 	}
 }
 
-func TestValidateDynamicFails(t *testing.T) {
-	db := NewUnitTestDBProvider()
+func testValidateDynamicFails(t *testing.T, db Provider) {
 	record := &dynamicFailRecord{
 		Value: "invalid",
 	}
@@ -122,8 +120,7 @@ func TestValidateDynamicFails(t *testing.T) {
 	}
 }
 
-func TestValidateBothPass(t *testing.T) {
-	db := NewUnitTestDBProvider()
+func testValidateBothPass(t *testing.T, db Provider) {
 	record := &staticFailRecord{
 		Value: "good",
 	}
@@ -134,8 +131,7 @@ func TestValidateBothPass(t *testing.T) {
 	}
 }
 
-func TestValidateDynamicFailsAfterStaticPasses(t *testing.T) {
-	db := NewUnitTestDBProvider()
+func testValidateDynamicFailsAfterStaticPasses(t *testing.T, db Provider) {
 	record := &dynamicFailRecord{
 		Value: "invalid",
 	}
@@ -144,4 +140,15 @@ func TestValidateDynamicFailsAfterStaticPasses(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected validation error for 'invalid' value")
 	}
+}
+
+// TestValidatableContract runs every TestValidatableContract test body against every database.Provider kind
+// (memory, SQLite in-memory, SQLite on-disk) via runContractTests (issue #62).
+func TestValidatableContract(t *testing.T) {
+	runContractTests(t, []contractTest{
+		{name: "TestValidateStaticFails", fn: testValidateStaticFails},
+		{name: "TestValidateDynamicFails", fn: testValidateDynamicFails},
+		{name: "TestValidateBothPass", fn: testValidateBothPass},
+		{name: "TestValidateDynamicFailsAfterStaticPasses", fn: testValidateDynamicFailsAfterStaticPasses},
+	})
 }


### PR DESCRIPTION
Closes #62 and #63 (part of #36).

## #62 — Contract tests parameterized against SQLite
The four `database.Provider` contract tests now run against **memory**, **SQLite in-memory**, and **SQLite on-disk**:

- `database/database_provider_test.go`
- `database/db_with_access_control_test.go`
- `database/validatable_test.go`
- `database/unique_constraint_test.go`

Each `Test*` body was renamed to `test*(t, db Provider)` and registered in a per-file driver; a new `runContractTests` harness (`database/contract_test_helpers_test.go`) gives every (kind, test) a fresh, isolated provider and applies the contract-test schema.

Supporting changes:
- `database/sqlite_db.go`: DSN builder now joins pragmas with `&` when the path already carries a `?query`; non-`[]byte` slice/array fields (e.g. `PrivateTestRecord.SharedTo []UserId`) are persisted as JSON TEXT and decoded on read.
- Contract-test record types carry `json:"id"` on their ID field (matching the codebase convention); `testRecord.Type()` changed `"test record"` → `"test_record"` (valid SQL table name).
- `TestCreateDateIsImmutable` compares timestamps with `.Equal()` (instant-based, matching existing round-trip tests).
- SQLite in-memory uses a uniquely-named shared-cache DB per provider so instances stay isolated (the unnamed `:memory:` shared cache is process-wide).

## #63 — SQLite concurrency test (WAL)
- New `database/sqlite_concurrency_test.go`: `TestSqliteProviderConcurrentCRUD` drives parallel Create/Read/Update/Delete from 16 goroutines against the WAL provider and fails explicitly on `database is locked`.

## Verification
- `go test ./...` — all packages pass
- `go test -race ./database/` — passes
- `go vet ./...` — clean