### PR TITLE
UI: general-purpose Format CRUD page (#82)

### DIFF
--- a/ui/e2e/format.spec.ts
+++ b/ui/e2e/format.spec.ts
@@ -1,0 +1,105 @@
+import { expect, test, type Page } from '@playwright/test';
+import { DatabaseSync } from 'node:sqlite';
+import crypto from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+
+// The Go backend runs with --dev-token from the repo root (see
+// playwright.config.ts), so POST /api/one_time_password returns the magic-link
+// token in the response body. Login with the user seeded by SeedDevData.
+async function login(page: Page) {
+	await page.goto('/login');
+	await page.waitForLoadState('networkidle');
+	await page.getByLabel('Email').fill('jdarthur@gatech.edu');
+	await page.getByRole('button', { name: 'Send login link' }).click();
+	const link = page.getByRole('link', { name: 'Log in' });
+	await expect(link).toBeVisible();
+	await link.click();
+	await expect(page).toHaveURL('/');
+}
+
+// The Playwright test process runs with cwd = ui/, while the Go backend
+// (spawned from the repo root) keeps its SQLite db at <repo>/intraclub.db.
+const dbPath = fileURLToPath(new URL('../../intraclub.db', import.meta.url));
+
+test('format CRUD: create, view, update, delete', async ({ page }) => {
+	await login(page);
+
+	const unique = Date.now();
+
+	// Create
+	await page.goto('/formats');
+	await page.getByRole('link', { name: 'New format' }).click();
+	await expect(page).toHaveURL(/\/formats\/new$/);
+	await page.getByLabel('Name').fill(`Test Format ${unique}`);
+	await page.getByRole('button', { name: 'Create format' }).click();
+
+	// View: lands on the detail page
+	await expect(page).toHaveURL(/\/formats\/[0-9a-f]+$/);
+	await expect(page.getByRole('heading', { name: `Test Format ${unique}` })).toBeVisible();
+
+	// Update
+	await page.getByLabel('Name').fill(`Test Format ${unique} Updated`);
+	await page.getByRole('button', { name: 'Save changes' }).click();
+	await expect(page.getByRole('heading', { name: `Test Format ${unique} Updated` })).toBeVisible();
+
+	// The list reflects the update
+	await page.goto('/formats');
+	const row = page.getByRole('link', { name: `Test Format ${unique} Updated` });
+	await expect(row).toBeVisible();
+
+	// Delete (accept the confirm dialog)
+	await row.click();
+	await expect(page.getByRole('heading', { name: `Test Format ${unique} Updated` })).toBeVisible();
+	page.on('dialog', (d) => d.accept());
+	await page.getByRole('button', { name: 'Delete format' }).click();
+	await expect(page).toHaveURL('/formats');
+	await expect(page.getByRole('link', { name: `Test Format ${unique} Updated` })).toHaveCount(0);
+});
+
+test('format delete is blocked when the format is assigned to a draft', async ({ page }) => {
+	await login(page);
+
+	// Both delete attempts below use window.confirm; accept every dialog.
+	page.on('dialog', (d) => d.accept());
+
+	// Create a format to attempt deletion of.
+	const unique = Date.now();
+	await page.goto('/formats/new');
+	await page.getByLabel('Name').fill(`In Use Format ${unique}`);
+	await page.getByRole('button', { name: 'Create format' }).click();
+	await expect(page).toHaveURL(/\/formats\/([0-9a-f]+)$/);
+	const formatId = page.url().match(/\/formats\/([0-9a-f]+)$/)![1];
+
+	// Insert a DraftFormat referencing this format directly into the SQLite db
+	// (there is no Draft CRUD API yet). The `draft_id` below points at a
+	// non-existent draft: that's fine because Format.PreDelete ->
+	// CheckHasAssignedDrafts only counts draft_format rows (it does not resolve
+	// each draft), so this reliably blocks the delete. If PreDelete ever switches
+	// to resolving drafts via GetAssignedDrafts, a real draft row would be needed.
+	const draftId = crypto.randomBytes(8).toString('hex');
+	const draftFormatId = crypto.randomBytes(8).toString('hex');
+	const db = new DatabaseSync(dbPath);
+	// The Go backend holds this SQLite file open; wait out any transient lock
+	// instead of failing immediately with "database is locked".
+	db.exec('PRAGMA busy_timeout = 10000');
+	try {
+		db.prepare(`INSERT INTO draft_format (id, draft_id, format_id) VALUES (?, ?, ?)`).run(
+			draftFormatId,
+			draftId,
+			formatId
+		);
+
+		// Attempt to delete -> PreDelete blocks it and the page surfaces the error.
+		await page.getByRole('button', { name: 'Delete format' }).click();
+		await expect(page.getByText(/assigned drafts/)).toBeVisible();
+	} finally {
+		// Clean up the draft_format row so it can't affect other tests.
+		db.prepare('DELETE FROM draft_format WHERE id = ?').run(draftFormatId);
+		db.close();
+	}
+
+	// With the draft gone, the format can now be deleted.
+	await page.getByRole('button', { name: 'Delete format' }).click();
+	await expect(page).toHaveURL('/formats');
+	await expect(page.getByRole('link', { name: `In Use Format ${unique}` })).toHaveCount(0);
+});

--- a/ui/src/lib/format.ts
+++ b/ui/src/lib/format.ts
@@ -1,0 +1,85 @@
+// Format API client. Format records are backed by the existing REST CRUD
+// routes generated from `model.Format` (see main.go):
+//
+//	GET    /api/format        -> { resource: Format[] }
+//	GET    /api/format/:id    -> { resource: Format }
+//	POST   /api/format        -> { resource: Format }   (owner = token user)
+//	PUT    /api/format/:id    -> { resource: Format }
+//	DELETE /api/format/:id    -> { resource: Format }
+//
+// A Format is just a name owned by a User; the possible ratings and lines live
+// in separate join records (FormatRating / FormatLine) and are future work for
+// this page. Record IDs are 16-char hex strings; an empty string represents
+// "not set" (InvalidRecordId).
+import { authFetch } from '$lib/auth';
+
+export interface Format {
+	id: string;
+	user_id: string;
+	name: string;
+}
+
+const BASE = '/api/format';
+
+// unwrap parses a CrudCommon response (`{ resource: ... }`) and throws the
+// backend error message on non-2xx responses so callers can surface it.
+async function unwrap(res: Response): Promise<any> {
+	if (!res.ok) {
+		let message = `Request failed (${res.status})`;
+		try {
+			const body = await res.json();
+			if (body?.error) message = body.error;
+		} catch {
+			// non-JSON error body; fall back to the status message
+		}
+		throw new Error(message);
+	}
+	const body = await res.json();
+	return body?.resource;
+}
+
+export async function listFormats(): Promise<Format[]> {
+	return unwrap(await authFetch(BASE));
+}
+
+export async function getFormat(id: string): Promise<Format> {
+	return unwrap(await authFetch(`${BASE}/${id}`));
+}
+
+export interface FormatInput {
+	name: string;
+}
+
+export async function createFormat(input: FormatInput): Promise<Format> {
+	return unwrap(
+		await authFetch(BASE, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(input)
+		})
+	);
+}
+
+export async function updateFormat(id: string, input: FormatInput): Promise<Format> {
+	return unwrap(
+		await authFetch(`${BASE}/${id}`, {
+			method: 'PUT',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(input)
+		})
+	);
+}
+
+export async function deleteFormat(id: string): Promise<void> {
+	const res = await authFetch(`${BASE}/${id}`, { method: 'DELETE' });
+	if (!res.ok) {
+		let message = `Delete failed (${res.status})`;
+		try {
+			const body = await res.json();
+			if (body?.error) message = body.error;
+		} catch {
+			// non-JSON error body; fall back to the status message
+		}
+		throw new Error(message);
+	}
+}

--- a/ui/src/routes/formats/+page.svelte
+++ b/ui/src/routes/formats/+page.svelte
@@ -1,0 +1,65 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { listFormats } from '$lib/format';
+	import type { Format } from '$lib/format';
+
+	let formats = $state<Format[]>([]);
+	let loading = $state(true);
+	let error = $state('');
+
+	onMount(async () => {
+		try {
+			formats = await listFormats();
+		} catch (e) {
+			error = e instanceof Error ? e.message : 'Failed to load formats';
+		} finally {
+			loading = false;
+		}
+	});
+</script>
+
+<svelte:head>
+	<title>Formats</title>
+</svelte:head>
+
+<h1>Formats</h1>
+<a href="/formats/new">New format</a>
+
+{#if loading}
+	<p>Loading...</p>
+{:else if error}
+	<p class="error">{error}</p>
+{:else if formats.length === 0}
+	<p>No formats yet.</p>
+{:else}
+	<table>
+		<thead>
+			<tr>
+				<th>Name</th>
+			</tr>
+		</thead>
+		<tbody>
+			{#each formats as format}
+				<tr>
+					<td><a href={`/formats/${format.id}`}>{format.name}</a></td>
+				</tr>
+			{/each}
+		</tbody>
+	</table>
+{/if}
+
+<style>
+	.error {
+		color: #c00;
+	}
+	table {
+		border-collapse: collapse;
+		margin-top: 1rem;
+	}
+	th,
+	td {
+		border: 1px solid #ccc;
+		padding: 0.4rem 0.8rem;
+		text-align: left;
+	}
+</style>

--- a/ui/src/routes/formats/[id]/+page.svelte
+++ b/ui/src/routes/formats/[id]/+page.svelte
@@ -1,0 +1,114 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { page } from '$app/state';
+	import { goto } from '$app/navigation';
+	import { getFormat, updateFormat, deleteFormat } from '$lib/format';
+	import type { Format } from '$lib/format';
+
+	const id = () => page.params.id as string;
+
+	let format = $state<Format | null>(null);
+	let loadError = $state('');
+	let name = $state('');
+	let error = $state('');
+	let saving = $state(false);
+	let deleting = $state(false);
+
+	onMount(load);
+
+	async function load() {
+		loadError = '';
+		try {
+			const f = await getFormat(id());
+			format = f;
+			name = f.name;
+		} catch (e) {
+			loadError = e instanceof Error ? e.message : 'Failed to load format';
+		}
+	}
+
+	async function handleSave(e: Event) {
+		e.preventDefault();
+		error = '';
+		saving = true;
+		try {
+			const updated = await updateFormat(id(), { name: name.trim() });
+			format = updated;
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Failed to update format';
+		} finally {
+			saving = false;
+		}
+	}
+
+	async function handleDelete() {
+		if (!confirm('Delete this format?')) return;
+		error = '';
+		deleting = true;
+		try {
+			await deleteFormat(id());
+			await goto('/formats');
+		} catch (err) {
+			// e.g. the format is assigned to a Draft and PreDelete blocks it
+			error = err instanceof Error ? err.message : 'Failed to delete format';
+			deleting = false;
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>{format ? format.name : 'Format'}</title>
+</svelte:head>
+
+{#if loadError}
+	<h1>Format</h1>
+	<p class="error">{loadError}</p>
+	<a href="/formats">&larr; Back to formats</a>
+{:else if !format}
+	<h1>Format</h1>
+	<p>Loading...</p>
+{:else}
+	<h1>{format.name}</h1>
+	<a href="/formats">&larr; Back to formats</a>
+
+	<form onsubmit={handleSave}>
+		<label>
+			Name
+			<input type="text" bind:value={name} required />
+		</label>
+		<button type="submit" disabled={saving}>{saving ? 'Saving...' : 'Save changes'}</button>
+	</form>
+
+	<button type="button" onclick={handleDelete} disabled={deleting} class="danger">
+		{deleting ? 'Deleting...' : 'Delete format'}
+	</button>
+
+	{#if error}
+		<p class="error">{error}</p>
+	{/if}
+{/if}
+
+<style>
+	.error {
+		color: #c00;
+	}
+	form {
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+		max-width: 24rem;
+		margin-top: 1rem;
+	}
+	label {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+	}
+	input {
+		padding: 0.35rem;
+	}
+	.danger {
+		margin-top: 1rem;
+		color: #c00;
+	}
+</style>

--- a/ui/src/routes/formats/new/+page.svelte
+++ b/ui/src/routes/formats/new/+page.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+	import { createFormat } from '$lib/format';
+	import { goto } from '$app/navigation';
+
+	let name = $state('');
+	let error = $state('');
+	let submitting = $state(false);
+
+	async function handleSubmit(e: Event) {
+		e.preventDefault();
+		error = '';
+		submitting = true;
+		try {
+			const created = await createFormat({ name: name.trim() });
+			await goto(`/formats/${created.id}`);
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Failed to create format';
+		} finally {
+			submitting = false;
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>New format</title>
+</svelte:head>
+
+<h1>New format</h1>
+<a href="/formats">&larr; Back to formats</a>
+
+<form onsubmit={handleSubmit}>
+	<label>
+		Name
+		<input type="text" bind:value={name} required />
+	</label>
+	<button type="submit" disabled={submitting}>{submitting ? 'Creating...' : 'Create format'}</button>
+</form>
+
+{#if error}
+	<p class="error">{error}</p>
+{/if}
+
+<style>
+	.error {
+		color: #c00;
+	}
+	form {
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+		max-width: 24rem;
+		margin-top: 1rem;
+	}
+	label {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+	}
+	input {
+		padding: 0.35rem;
+	}
+</style>


### PR DESCRIPTION
Closes #82

Adds a general-purpose CRUD page for the `Format` record, mirroring the existing Facility CRUD UI (#80). The backend `/api/format` routes already exist; UI work only.

## Changes
- `ui/src/lib/format.ts` — API client (`listFormats` / `getFormat` / `createFormat` / `updateFormat` / `deleteFormat`). A minimal create only needs `name`; the owner is set from the JWT token by the backend.
- `ui/src/routes/formats/+page.svelte` — list page.
- `ui/src/routes/formats/[id]/+page.svelte` — detail / edit / delete page.
- `ui/src/routes/formats/new/+page.svelte` — create page.
- `ui/e2e/format.spec.ts` — Playwright e2e covering create → view → update → delete, plus the delete-blocked case (format assigned to a draft).

## Verification
- `npm run check` (svelte-check + typecheck): 0 errors, 0 warnings.
- Full Playwright e2e suite: 6 passed (2 new format tests + existing facility/login/smoke), no regressions.