### PR TITLE
UI: general-purpose Rating CRUD page (#86)

### DIFF
--- a/ui/e2e/rating.spec.ts
+++ b/ui/e2e/rating.spec.ts
@@ -1,0 +1,106 @@
+import { expect, test, type Page } from '@playwright/test';
+import { DatabaseSync } from 'node:sqlite';
+import crypto from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+
+// The Go backend runs with --dev-token from the repo root (see
+// playwright.config.ts), so POST /api/one_time_password returns the magic-link
+// token in the response body. Login with the user seeded by SeedDevData.
+async function login(page: Page) {
+	await page.goto('/login');
+	await page.waitForLoadState('networkidle');
+	await page.getByLabel('Email').fill('jdarthur@gatech.edu');
+	await page.getByRole('button', { name: 'Send login link' }).click();
+	const link = page.getByRole('link', { name: 'Log in' });
+	await expect(link).toBeVisible();
+	await link.click();
+	await expect(page).toHaveURL('/');
+}
+
+// The Playwright test process runs with cwd = ui/, while the Go backend
+// (spawned from the repo root) keeps its SQLite db at <repo>/intraclub.db.
+const dbPath = fileURLToPath(new URL('../../intraclub.db', import.meta.url));
+
+test('rating CRUD: create, view, update, delete', async ({ page }) => {
+	await login(page);
+
+	const unique = Date.now();
+
+	// Create
+	await page.goto('/ratings');
+	await page.getByRole('link', { name: 'New rating' }).click();
+	await expect(page).toHaveURL(/\/ratings\/new$/);
+	await page.getByLabel('Name').fill(`Test Rating ${unique}`);
+	await page.getByLabel('Description').fill(`Description ${unique}`);
+	await page.getByRole('button', { name: 'Create rating' }).click();
+
+	// View: lands on the detail page
+	await expect(page).toHaveURL(/\/ratings\/[0-9a-f]+$/);
+	await expect(page.getByRole('heading', { name: `Test Rating ${unique}` })).toBeVisible();
+	await expect(page.getByLabel('Description')).toHaveValue(`Description ${unique}`);
+
+	// Update
+	await page.getByLabel('Name').fill(`Test Rating ${unique} Updated`);
+	await page.getByLabel('Description').fill(`Description ${unique} Updated`);
+	await page.getByRole('button', { name: 'Save changes' }).click();
+	await expect(page.getByRole('heading', { name: `Test Rating ${unique} Updated` })).toBeVisible();
+
+	// The list reflects the update
+	await page.goto('/ratings');
+	const row = page.getByRole('link', { name: `Test Rating ${unique} Updated` });
+	await expect(row).toBeVisible();
+
+	// Delete (accept the confirm dialog)
+	await row.click();
+	await expect(page.getByRole('heading', { name: `Test Rating ${unique} Updated` })).toBeVisible();
+	page.on('dialog', (d) => d.accept());
+	await page.getByRole('button', { name: 'Delete rating' }).click();
+	await expect(page).toHaveURL('/ratings');
+	await expect(page.getByRole('link', { name: `Test Rating ${unique} Updated` })).toHaveCount(0);
+});
+
+test('rating delete is blocked when the rating is assigned to a format', async ({ page }) => {
+	await login(page);
+
+	// Both delete attempts below use window.confirm; accept every dialog.
+	page.on('dialog', (d) => d.accept());
+
+	// Create a rating to attempt deletion of.
+	const unique = Date.now();
+	await page.goto('/ratings/new');
+	await page.getByLabel('Name').fill(`In Use Rating ${unique}`);
+	await page.getByLabel('Description').fill(`Description ${unique}`);
+	await page.getByRole('button', { name: 'Create rating' }).click();
+	await expect(page).toHaveURL(/\/ratings\/([0-9a-f]+)$/);
+	const ratingId = page.url().match(/\/ratings\/([0-9a-f]+)$/)![1];
+
+	// Insert a FormatRating referencing this rating directly into the SQLite db
+	// (there is no FormatRating CRUD API yet). The `format_id` below points at a
+	// non-existent format: that's fine because Rating.PreDelete only counts
+	// format_rating rows (it does not resolve each format), so this reliably
+	// blocks the delete.
+	const formatRatingId = crypto.randomBytes(8).toString('hex');
+	const formatId = crypto.randomBytes(8).toString('hex');
+	const db = new DatabaseSync(dbPath);
+	// The Go backend holds this SQLite file open; wait out any transient lock
+	// instead of failing immediately with "database is locked".
+	db.exec('PRAGMA busy_timeout = 10000');
+	try {
+		db.prepare(
+			`INSERT INTO format_rating (id, format_id, rating_id, rating_index) VALUES (?, ?, ?, ?)`
+		).run(formatRatingId, formatId, ratingId, 0);
+
+		// Attempt to delete -> PreDelete blocks it and the page surfaces the error.
+		await page.getByRole('button', { name: 'Delete rating' }).click();
+		await expect(page.getByText(/in-use by/)).toBeVisible();
+	} finally {
+		// Clean up the format_rating row so it can't affect other tests.
+		db.prepare('DELETE FROM format_rating WHERE id = ?').run(formatRatingId);
+		db.close();
+	}
+
+	// With the format_rating gone, the rating can now be deleted.
+	await page.getByRole('button', { name: 'Delete rating' }).click();
+	await expect(page).toHaveURL('/ratings');
+	await expect(page.getByRole('link', { name: `In Use Rating ${unique}` })).toHaveCount(0);
+});

--- a/ui/src/lib/rating.ts
+++ b/ui/src/lib/rating.ts
@@ -1,0 +1,86 @@
+// Rating API client. Rating records are backed by the existing REST CRUD
+// routes generated from `model.Rating` (see main.go):
+//
+//	GET    /api/rating        -> { resource: Rating[] }
+//	GET    /api/rating/:id    -> { resource: Rating }
+//	POST   /api/rating        -> { resource: Rating }   (owner = token user)
+//	PUT    /api/rating/:id    -> { resource: Rating }
+//	DELETE /api/rating/:id    -> { resource: Rating }
+//
+// A Rating is a skill rating (e.g. "2.5") with a name and description, owned
+// by a User. Record IDs are 16-char hex strings; an empty string represents
+// "not set" (InvalidRecordId).
+import { authFetch } from '$lib/auth';
+
+export interface Rating {
+	id: string;
+	user_id: string;
+	name: string;
+	description: string;
+}
+
+const BASE = '/api/rating';
+
+// unwrap parses a CrudCommon response (`{ resource: ... }`) and throws the
+// backend error message on non-2xx responses so callers can surface it.
+async function unwrap(res: Response): Promise<any> {
+	if (!res.ok) {
+		let message = `Request failed (${res.status})`;
+		try {
+			const body = await res.json();
+			if (body?.error) message = body.error;
+		} catch {
+			// non-JSON error body; fall back to the status message
+		}
+		throw new Error(message);
+	}
+	const body = await res.json();
+	return body?.resource;
+}
+
+export async function listRatings(): Promise<Rating[]> {
+	return unwrap(await authFetch(BASE));
+}
+
+export async function getRating(id: string): Promise<Rating> {
+	return unwrap(await authFetch(`${BASE}/${id}`));
+}
+
+export interface RatingInput {
+	name: string;
+	description: string;
+}
+
+export async function createRating(input: RatingInput): Promise<Rating> {
+	return unwrap(
+		await authFetch(BASE, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(input)
+		})
+	);
+}
+
+export async function updateRating(id: string, input: RatingInput): Promise<Rating> {
+	return unwrap(
+		await authFetch(`${BASE}/${id}`, {
+			method: 'PUT',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(input)
+		})
+	);
+}
+
+export async function deleteRating(id: string): Promise<void> {
+	const res = await authFetch(`${BASE}/${id}`, { method: 'DELETE' });
+	if (!res.ok) {
+		let message = `Delete failed (${res.status})`;
+		try {
+			const body = await res.json();
+			if (body?.error) message = body.error;
+		} catch {
+			// non-JSON error body; fall back to the status message
+		}
+		throw new Error(message);
+	}
+}

--- a/ui/src/routes/ratings/+page.svelte
+++ b/ui/src/routes/ratings/+page.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { listRatings } from '$lib/rating';
+	import type { Rating } from '$lib/rating';
+
+	let ratings = $state<Rating[]>([]);
+	let loading = $state(true);
+	let error = $state('');
+
+	onMount(async () => {
+		try {
+			ratings = await listRatings();
+		} catch (e) {
+			error = e instanceof Error ? e.message : 'Failed to load ratings';
+		} finally {
+			loading = false;
+		}
+	});
+</script>
+
+<svelte:head>
+	<title>Ratings</title>
+</svelte:head>
+
+<h1>Ratings</h1>
+<a href="/ratings/new">New rating</a>
+
+{#if loading}
+	<p>Loading...</p>
+{:else if error}
+	<p class="error">{error}</p>
+{:else if ratings.length === 0}
+	<p>No ratings yet.</p>
+{:else}
+	<table>
+		<thead>
+			<tr>
+				<th>Name</th>
+				<th>Description</th>
+			</tr>
+		</thead>
+		<tbody>
+			{#each ratings as rating}
+				<tr>
+					<td><a href={`/ratings/${rating.id}`}>{rating.name}</a></td>
+					<td>{rating.description}</td>
+				</tr>
+			{/each}
+		</tbody>
+	</table>
+{/if}
+
+<style>
+	.error {
+		color: #c00;
+	}
+	table {
+		border-collapse: collapse;
+		margin-top: 1rem;
+	}
+	th,
+	td {
+		border: 1px solid #ccc;
+		padding: 0.4rem 0.8rem;
+		text-align: left;
+	}
+</style>

--- a/ui/src/routes/ratings/[id]/+page.svelte
+++ b/ui/src/routes/ratings/[id]/+page.svelte
@@ -1,0 +1,125 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { page } from '$app/state';
+	import { goto } from '$app/navigation';
+	import { getRating, updateRating, deleteRating } from '$lib/rating';
+	import type { Rating } from '$lib/rating';
+
+	const id = () => page.params.id as string;
+
+	let rating = $state<Rating | null>(null);
+	let loadError = $state('');
+	let name = $state('');
+	let description = $state('');
+	let error = $state('');
+	let saving = $state(false);
+	let deleting = $state(false);
+
+	onMount(load);
+
+	async function load() {
+		loadError = '';
+		try {
+			const r = await getRating(id());
+			rating = r;
+			name = r.name;
+			description = r.description;
+		} catch (e) {
+			loadError = e instanceof Error ? e.message : 'Failed to load rating';
+		}
+	}
+
+	async function handleSave(e: Event) {
+		e.preventDefault();
+		error = '';
+		saving = true;
+		try {
+			const updated = await updateRating(id(), { name: name.trim(), description: description.trim() });
+			rating = updated;
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Failed to update rating';
+		} finally {
+			saving = false;
+		}
+	}
+
+	async function handleDelete() {
+		if (!confirm('Delete this rating?')) return;
+		error = '';
+		deleting = true;
+		try {
+			await deleteRating(id());
+			await goto('/ratings');
+		} catch (err) {
+			// e.g. the rating is assigned to a Format and PreDelete blocks it
+			error = err instanceof Error ? err.message : 'Failed to delete rating';
+			deleting = false;
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>{rating ? rating.name : 'Rating'}</title>
+</svelte:head>
+
+{#if loadError}
+	<h1>Rating</h1>
+	<p class="error">{loadError}</p>
+	<a href="/ratings">&larr; Back to ratings</a>
+{:else if !rating}
+	<h1>Rating</h1>
+	<p>Loading...</p>
+{:else}
+	<h1>{rating.name}</h1>
+	<a href="/ratings">&larr; Back to ratings</a>
+
+	<form onsubmit={handleSave}>
+		<label>
+			Name
+			<input type="text" bind:value={name} required />
+		</label>
+		<label>
+			Description
+			<textarea bind:value={description} required></textarea>
+		</label>
+		<button type="submit" disabled={saving}>{saving ? 'Saving...' : 'Save changes'}</button>
+	</form>
+
+	<button type="button" onclick={handleDelete} disabled={deleting} class="danger">
+		{deleting ? 'Deleting...' : 'Delete rating'}
+	</button>
+
+	{#if error}
+		<p class="error">{error}</p>
+	{/if}
+{/if}
+
+<style>
+	.error {
+		color: #c00;
+	}
+	form {
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+		max-width: 24rem;
+		margin-top: 1rem;
+	}
+	label {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+	}
+	input,
+	textarea {
+		padding: 0.35rem;
+	}
+	textarea {
+		min-height: 5rem;
+		resize: vertical;
+	}
+	.danger {
+		margin-top: 1rem;
+		color: #c00;
+	}
+</style>

--- a/ui/src/routes/ratings/new/+page.svelte
+++ b/ui/src/routes/ratings/new/+page.svelte
@@ -1,0 +1,72 @@
+<script lang="ts">
+	import { createRating } from '$lib/rating';
+	import { goto } from '$app/navigation';
+
+	let name = $state('');
+	let description = $state('');
+	let error = $state('');
+	let submitting = $state(false);
+
+	async function handleSubmit(e: Event) {
+		e.preventDefault();
+		error = '';
+		submitting = true;
+		try {
+			const created = await createRating({ name: name.trim(), description: description.trim() });
+			await goto(`/ratings/${created.id}`);
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Failed to create rating';
+		} finally {
+			submitting = false;
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>New rating</title>
+</svelte:head>
+
+<h1>New rating</h1>
+<a href="/ratings">&larr; Back to ratings</a>
+
+<form onsubmit={handleSubmit}>
+	<label>
+		Name
+		<input type="text" bind:value={name} required />
+	</label>
+	<label>
+		Description
+		<textarea bind:value={description} required></textarea>
+	</label>
+	<button type="submit" disabled={submitting}>{submitting ? 'Creating...' : 'Create rating'}</button>
+</form>
+
+{#if error}
+	<p class="error">{error}</p>
+{/if}
+
+<style>
+	.error {
+		color: #c00;
+	}
+	form {
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+		max-width: 24rem;
+		margin-top: 1rem;
+	}
+	label {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+	}
+	input,
+	textarea {
+		padding: 0.35rem;
+	}
+	textarea {
+		min-height: 5rem;
+		resize: vertical;
+	}
+</style>


### PR DESCRIPTION
Closes #86

Implements a general-purpose CRUD page for the `Rating` record in the SvelteKit UI, backed by the existing REST API.

- `ui/src/lib/rating.ts` — Rating API client (`listRatings` / `getRating` / `createRating` / `updateRating` / `deleteRating`)
- `ui/src/routes/ratings/+page.svelte` — list page
- `ui/src/routes/ratings/[id]/+page.svelte` — detail view + edit form + delete
- `ui/src/routes/ratings/new/+page.svelte` — create form
- `ui/e2e/rating.spec.ts` — Playwright e2e: create → view → update → delete, plus delete-blocked-when-in-use

Verified: `npm run check` (0 errors) and `npx playwright test e2e/rating.spec.ts` (2 passed).