### PR TITLE
UI: root route landing page with always-shown nav-bar

### DIFF
--- a/ui/e2e/login.spec.ts
+++ b/ui/e2e/login.spec.ts
@@ -26,7 +26,7 @@ test('dev-mode login renders a magic link and completes the token→JWT exchange
 	// Clicking the link runs the existing token→JWT exchange and lands on "/".
 	await link.click();
 	await expect(page).toHaveURL('/');
-	await expect(page.getByRole('heading', { name: 'Welcome to SvelteKit' })).toBeVisible();
+	await expect(page.getByRole('heading', { name: 'Welcome to IntraClub' })).toBeVisible();
 
 	// The exchanged JWT should be persisted.
 	const jwt = await page.evaluate(() => localStorage.getItem('intraclub_jwt'));

--- a/ui/e2e/smoke.spec.ts
+++ b/ui/e2e/smoke.spec.ts
@@ -1,8 +1,13 @@
 import { expect, test } from '@playwright/test';
 
-test('homepage renders basic content', async ({ page }) => {
+test('homepage renders a landing page with nav and login form', async ({ page }) => {
 	await page.goto('/');
 
-	await expect(page.getByRole('heading', { name: 'Welcome to SvelteKit' })).toBeVisible();
-	await expect(page.getByRole('link', { name: /svelte.dev\/docs\/kit/i })).toBeVisible();
+	// Nav-bar is always shown.
+	await expect(page.getByRole('navigation')).toBeVisible();
+	await expect(page.getByRole('link', { name: 'Facilities' })).toBeVisible();
+
+	// Not logged in, so the login form is displayed on the root route.
+	await expect(page.getByRole('heading', { name: 'IntraClub' })).toBeVisible();
+	await expect(page.getByLabel('Email')).toBeVisible();
 });

--- a/ui/src/lib/components/LoginForm.svelte
+++ b/ui/src/lib/components/LoginForm.svelte
@@ -1,0 +1,82 @@
+<script lang="ts">
+	let email = $state('');
+	let message = $state('');
+	let error = $state('');
+	let devLink = $state('');
+
+	async function handleSubmit(e: Event) {
+		e.preventDefault();
+		message = '';
+		error = '';
+		devLink = '';
+
+		const res = await fetch('/api/one_time_password', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ email })
+		});
+
+		if (!res.ok) {
+			const body = await res.json();
+			error = body.error ?? 'Failed to send login link';
+			return;
+		}
+
+		const body = await res.json();
+		if (body?.token) {
+			// DEV MODE ONLY: the API returned the magic-link token in the response
+			// instead of emailing it. Render it as a clickable link.
+			devLink = `/auth/callback?token=${encodeURIComponent(body.token)}`;
+			message = 'DEV MODE ONLY — no email was sent. Use the magic link below to log in.';
+		} else {
+			message = 'Check your email for the login link.';
+		}
+	}
+</script>
+
+<form onsubmit={handleSubmit}>
+	<label>
+		Email
+		<input type="email" bind:value={email} required />
+	</label>
+	<button type="submit">Send login link</button>
+</form>
+
+{#if message}
+	<p>{message}</p>
+{/if}
+
+{#if devLink}
+	<p>
+		<a href={devLink}>Log in</a>
+	</p>
+{/if}
+
+{#if error}
+	<p class="error">{error}</p>
+{/if}
+
+<style>
+	.error {
+		color: #c00;
+	}
+	form {
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+		max-width: 24rem;
+		margin-top: 1rem;
+	}
+	label {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+	}
+	input {
+		padding: 0.35rem;
+	}
+	button {
+		padding: 0.35rem 0.6rem;
+		width: fit-content;
+	}
+</style>

--- a/ui/src/lib/components/NavBar.svelte
+++ b/ui/src/lib/components/NavBar.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+	import { isLoggedIn, clearToken } from '$lib/auth';
+	import { goto } from '$app/navigation';
+
+	let loggedIn = $state(isLoggedIn());
+
+	function logout() {
+		clearToken();
+		loggedIn = false;
+		goto('/');
+	}
+</script>
+
+<nav class="navbar">
+	<a href="/" class="brand">IntraClub</a>
+	<div class="links">
+		<a href="/facilities">Facilities</a>
+		<a href="/formats">Formats</a>
+		<a href="/ratings">Ratings</a>
+	</div>
+	<div class="actions">
+		{#if loggedIn}
+			<button type="button" onclick={logout}>Log out</button>
+		{:else}
+			<a href="/login" class="login">Log in</a>
+		{/if}
+	</div>
+</nav>
+
+<style>
+	.navbar {
+		display: flex;
+		align-items: center;
+		gap: 1.5rem;
+		padding: 0.75rem 1.25rem;
+		background: #1f2937;
+		color: #f9fafb;
+	}
+	.brand {
+		color: #fff;
+		font-weight: 700;
+		text-decoration: none;
+	}
+	.links {
+		display: flex;
+		gap: 1rem;
+	}
+	.links a {
+		color: #d1d5db;
+		text-decoration: none;
+	}
+	.links a:hover {
+		color: #fff;
+	}
+	.actions {
+		margin-left: auto;
+	}
+	.login {
+		color: #d1d5db;
+		text-decoration: none;
+	}
+	.login:hover {
+		color: #fff;
+	}
+	.actions button {
+		background: transparent;
+		border: 1px solid #d1d5db;
+		color: #d1d5db;
+		padding: 0.25rem 0.6rem;
+		border-radius: 4px;
+		cursor: pointer;
+	}
+	.actions button:hover {
+		color: #fff;
+		border-color: #fff;
+	}
+</style>

--- a/ui/src/routes/+layout.svelte
+++ b/ui/src/routes/+layout.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import favicon from '$lib/assets/favicon.svg';
+	import NavBar from '$lib/components/NavBar.svelte';
 
 	let { children } = $props();
 </script>
@@ -8,4 +9,13 @@
 	<link rel="icon" href={favicon} />
 </svelte:head>
 
-{@render children()}
+<NavBar />
+<main class="content">
+	{@render children()}
+</main>
+
+<style>
+	.content {
+		padding: 1.25rem;
+	}
+</style>

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -1,2 +1,19 @@
-<h1>Welcome to SvelteKit</h1>
-<p>Visit <a href="https://svelte.dev/docs/kit">svelte.dev/docs/kit</a> to read the documentation</p>
+<script lang="ts">
+	import { isLoggedIn } from '$lib/auth';
+	import LoginForm from '$lib/components/LoginForm.svelte';
+
+	let loggedIn = $state(isLoggedIn());
+</script>
+
+<svelte:head>
+	<title>IntraClub</title>
+</svelte:head>
+
+{#if loggedIn}
+	<h1>Welcome to IntraClub</h1>
+	<p>Head to <a href="/facilities">Facilities</a>, <a href="/formats">Formats</a>, or <a href="/ratings">Ratings</a> to get started.</p>
+{:else}
+	<h1>IntraClub</h1>
+	<p>Welcome! Log in to manage your club.</p>
+	<LoginForm />
+{/if}

--- a/ui/src/routes/login/+page.svelte
+++ b/ui/src/routes/login/+page.svelte
@@ -1,37 +1,5 @@
 <script lang="ts">
-	let email = $state('');
-	let message = $state('');
-	let error = $state('');
-	let devLink = $state('');
-
-	async function handleSubmit(e: Event) {
-		e.preventDefault();
-		message = '';
-		error = '';
-		devLink = '';
-
-		const res = await fetch('/api/one_time_password', {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify({ email })
-		});
-
-		if (!res.ok) {
-			const body = await res.json();
-			error = body.error ?? 'Failed to send login link';
-			return;
-		}
-
-		const body = await res.json();
-		if (body?.token) {
-			// DEV MODE ONLY: the API returned the magic-link token in the response
-			// instead of emailing it. Render it as a clickable link.
-			devLink = `/auth/callback?token=${encodeURIComponent(body.token)}`;
-			message = 'DEV MODE ONLY — no email was sent. Use the magic link below to log in.';
-		} else {
-			message = 'Check your email for the login link.';
-		}
-	}
+	import LoginForm from '$lib/components/LoginForm.svelte';
 </script>
 
 <svelte:head>
@@ -40,24 +8,4 @@
 
 <h1>Log in</h1>
 
-<form onsubmit={handleSubmit}>
-	<label>
-		Email
-		<input type="email" bind:value={email} required />
-	</label>
-	<button type="submit">Send login link</button>
-</form>
-
-{#if message}
-	<p>{message}</p>
-{/if}
-
-{#if devLink}
-	<p>
-		<a href={devLink}>Log in</a>
-	</p>
-{/if}
-
-{#if error}
-	<p>{error}</p>
-{/if}
+<LoginForm />


### PR DESCRIPTION
## Summary

Replaces the SvelteKit default homepage at `/` with a real landing page.

- **Nav-bar always shown** via the root `+layout.svelte`: brand, links to Facilities / Formats / Ratings, and a Log in / Log out action that reflects auth state.
- **Landing page** (`+page.svelte`): shows a welcome message when logged in, and the **login form when not logged in**.
- Extracts the login form into a shared `LoginForm` component reused by both the root route and `/login`.

## Tests
- Updated e2e specs (`smoke.spec.ts`, `login.spec.ts`) to assert the nav-bar and landing-page/login-form content.
- `cd ui && npm run check` passes (0 errors, 0 warnings).