### PR TITLE
UI: general-purpose Ruleset CRUD page (#83)

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"intraclub/database"
 	"intraclub/model"
 	"intraclub/route"
+	"intraclub/route/ruleset"
 	"intraclub/route/user"
 
 	"github.com/gin-gonic/gin"
@@ -82,6 +83,12 @@ func main() {
 
 	formats := api.NewCrudCommon(model.NewFormat, false, db)
 	formats.HandleRouteTypes(rg, api.CrudWrapperFunctionAll...)
+
+	rulesets := api.NewCrudCommon(model.NewRuleset, false, db)
+	rulesets.HandleRouteTypes(rg, api.CrudWrapperFunctionAll...)
+
+	amendRuleset := api.RouteFamily[*ruleset.AmendNameBody]{DatabaseProvider: db}
+	amendRuleset.Handle(rg, ruleset.AmendRulesetName{})
 
 	rg.GET("/draft_order_patterns", model.GetDraftOrderPatterns)
 

--- a/model/ruleset.go
+++ b/model/ruleset.go
@@ -291,6 +291,67 @@ func (r *Ruleset) Fork(ctx context.Context, db database.Provider, newUserId data
 	return newRuleset, nil
 }
 
+// EditName amends this Ruleset by producing a new revision with the given
+// name and marking this Ruleset as superseded by the new revision. The new
+// revision inherits this Ruleset's owner and sections. Returns the new
+// superseding Ruleset.
+func (r *Ruleset) EditName(ctx context.Context, db database.Provider, newName string) (*Ruleset, error) {
+	newName = strings.TrimSpace(newName)
+	if newName == "" {
+		return nil, fmt.Errorf("name must not be empty")
+	}
+	if newName == r.Name {
+		return nil, fmt.Errorf("new name must be different than the current name")
+	}
+
+	sectionRelations, err := r.GetSectionRelations(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+	newSectionIds := make([]RuleSectionId, 0, len(sectionRelations))
+	for _, sr := range sectionRelations {
+		newSectionIds = append(newSectionIds, sr.SectionId)
+	}
+
+	// copy the existing ruleset with an incremented revision, overriding the name
+	copied := r.Copy(newSectionIds)
+	copied.Name = newName
+	copied.Revision += 1
+
+	newRuleset, err := database.CreateOne(ctx, db, copied)
+	if err != nil {
+		return nil, err
+	}
+
+	// mark this ruleset as superseded by the new revision (raw provider update,
+	// which bypasses the PreUpdate hook that forbids direct modification)
+	r.SupersededBy = newRuleset.ID
+	err = db.Update(ctx, r)
+	if err != nil {
+		// revert the creation of the superseding ruleset
+		_, _, _ = database.DeleteOneById(ctx, db, &Ruleset{}, newRuleset.ID.RecordId())
+		return nil, err
+	}
+
+	// delete the old section relations and re-link them to the new revision
+	for _, oldRel := range sectionRelations {
+		_, _, _ = database.DeleteOneById(ctx, db, &RulesetSection{}, oldRel.ID)
+	}
+	for i, sr := range sectionRelations {
+		newRuleSectionRelation := &RulesetSection{
+			RulesetId:    newRuleset.ID,
+			SectionId:    sr.SectionId,
+			SectionIndex: i,
+		}
+		_, err = database.CreateOne(ctx, db, newRuleSectionRelation)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return newRuleset, nil
+}
+
 type RuleSectionId database.RecordId
 
 func (id RuleSectionId) UnmarshalJSON(bytes []byte) error {

--- a/model/ruleset_test.go
+++ b/model/ruleset_test.go
@@ -123,6 +123,55 @@ func TestRulesetCannotBeUpdatedWithoutAmendment(t *testing.T) {
 	}
 	fmt.Println(err)
 }
+
+func TestRulesetEditNameCreatesSupersedingRevision(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	ruleset := newValidStoredRuleset(t, db)
+
+	newRevision, err := ruleset.EditName(context.Background(), db, "Amended Name")
+	if err != nil {
+		t.Fatalf("unexpected error amending ruleset name: %s", err)
+	}
+
+	// the new revision supersedes the old and keeps the owner
+	if newRevision.Name != "Amended Name" {
+		t.Fatalf("expected new revision name %q, got %q", "Amended Name", newRevision.Name)
+	}
+	if newRevision.Revision != ruleset.Revision+1 {
+		t.Fatalf("expected revision %d, got %d", ruleset.Revision+1, newRevision.Revision)
+	}
+	if newRevision.Owner != ruleset.Owner {
+		t.Fatalf("expected owner %s to be preserved, got %s", ruleset.Owner, newRevision.Owner)
+	}
+
+	// the original ruleset is now marked as superseded
+	reloaded, err := database.GetExistingRecordById(context.Background(), db, &Ruleset{}, ruleset.ID.RecordId())
+	if err != nil {
+		t.Fatalf("unexpected error reloading original ruleset: %s", err)
+	}
+	if reloaded.SupersededBy != newRevision.ID {
+		t.Fatalf("expected original ruleset to be superseded by %s, got %s", newRevision.ID, reloaded.SupersededBy)
+	}
+
+	// the original ruleset cannot be directly updated even after amending
+	err = database.UpdateOne(context.Background(), db, ruleset)
+	if err == nil {
+		t.Fatal("expected error updating existing ruleset after amend")
+	}
+}
+
+func TestRulesetEditNameRequiresDifferentNonEmptyName(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	ruleset := newValidStoredRuleset(t, db)
+
+	if _, err := ruleset.EditName(context.Background(), db, ""); err == nil {
+		t.Fatal("expected error amending ruleset with empty name")
+	}
+	if _, err := ruleset.EditName(context.Background(), db, ruleset.Name); err == nil {
+		t.Fatal("expected error amending ruleset with unchanged name")
+	}
+}
+
 func TestRulesetDateIsAfterSupersedingRuleset(t *testing.T) {
 	// Date value for this Ruleset must be before the Date value
 	// for the superseding Ruleset (date value isn't very meaningful

--- a/route/ruleset/amend.go
+++ b/route/ruleset/amend.go
@@ -1,0 +1,66 @@
+package ruleset
+
+import (
+	"errors"
+	"net/http"
+
+	"intraclub/api"
+	"intraclub/database"
+	"intraclub/model"
+
+	"github.com/gin-gonic/gin"
+)
+
+// BaseRoute is the base API route for Ruleset records.
+var BaseRoute = "/ruleset"
+
+// AmendNameBody is the request body for amending a Ruleset's name.
+type AmendNameBody struct {
+	Name string `json:"name"`
+}
+
+// StaticallyValid ensures the request body has the fields required to amend a Ruleset.
+func (b *AmendNameBody) StaticallyValid() error {
+	if b.Name == "" {
+		return errors.New("name must not be empty")
+	}
+	return nil
+}
+
+// AmendRulesetName is a custom route that amends a Ruleset by producing a new
+// revision with a new name (see model.Ruleset.EditName). Rulesets may not be
+// directly modified (Ruleset.PreUpdate forbids it), so an update is expressed
+// as an amend that creates a superseding revision.
+type AmendRulesetName struct{}
+
+func (c AmendRulesetName) Path() (api.HttpMethod, string) {
+	return api.HttpMethodPut, api.AppendPathId(BaseRoute) + "/amend"
+}
+
+func (c AmendRulesetName) RequestBody() (*AmendNameBody, bool) {
+	return &AmendNameBody{}, true
+}
+
+func (c AmendRulesetName) Handler(req api.Request[*AmendNameBody]) (any, int, error) {
+	if req.Token == nil {
+		return nil, http.StatusUnauthorized, errors.New("token is required to amend a ruleset")
+	}
+
+	ruleset, err := database.GetExistingRecordById(req.Context, req.DatabaseProvider, &model.Ruleset{}, req.PathId)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+
+	// enforce per-record edit authorization (owner / sysadmin)
+	wac := database.NewWithAccessControl[*model.Ruleset](req.Context, req.DatabaseProvider, req.Token.UserId)
+	if !wac.CanUserEdit(ruleset) {
+		return nil, http.StatusForbidden, errors.New("not authorized to amend this ruleset")
+	}
+
+	newRuleset, err := ruleset.EditName(req.Context, req.DatabaseProvider, req.Body.Name)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+
+	return gin.H{api.ResourceKey: newRuleset}, http.StatusOK, nil
+}

--- a/ui/e2e/facility.spec.ts
+++ b/ui/e2e/facility.spec.ts
@@ -11,7 +11,7 @@ async function login(page: Page) {
 	await page.waitForLoadState('networkidle');
 	await page.getByLabel('Email').fill('jdarthur@gatech.edu');
 	await page.getByRole('button', { name: 'Send login link' }).click();
-	const link = page.getByRole('link', { name: 'Log in' });
+	const link = page.getByRole('main').getByRole('link', { name: 'Log in' });
 	await expect(link).toBeVisible();
 	await link.click();
 	await expect(page).toHaveURL('/');

--- a/ui/e2e/format.spec.ts
+++ b/ui/e2e/format.spec.ts
@@ -11,7 +11,7 @@ async function login(page: Page) {
 	await page.waitForLoadState('networkidle');
 	await page.getByLabel('Email').fill('jdarthur@gatech.edu');
 	await page.getByRole('button', { name: 'Send login link' }).click();
-	const link = page.getByRole('link', { name: 'Log in' });
+	const link = page.getByRole('main').getByRole('link', { name: 'Log in' });
 	await expect(link).toBeVisible();
 	await link.click();
 	await expect(page).toHaveURL('/');

--- a/ui/e2e/login.spec.ts
+++ b/ui/e2e/login.spec.ts
@@ -20,7 +20,7 @@ test('dev-mode login renders a magic link and completes the token→JWT exchange
 	// annotation and a clickable magic link instead of "check your email".
 	await expect(page.getByText(/DEV MODE ONLY/)).toBeVisible();
 
-	const link = page.getByRole('link', { name: 'Log in' });
+	const link = page.getByRole('main').getByRole('link', { name: 'Log in' });
 	await expect(link).toHaveAttribute('href', /^\/auth\/callback\?token=/);
 
 	// Clicking the link runs the existing token→JWT exchange and lands on "/".

--- a/ui/e2e/rating.spec.ts
+++ b/ui/e2e/rating.spec.ts
@@ -11,7 +11,7 @@ async function login(page: Page) {
 	await page.waitForLoadState('networkidle');
 	await page.getByLabel('Email').fill('jdarthur@gatech.edu');
 	await page.getByRole('button', { name: 'Send login link' }).click();
-	const link = page.getByRole('link', { name: 'Log in' });
+	const link = page.getByRole('main').getByRole('link', { name: 'Log in' });
 	await expect(link).toBeVisible();
 	await link.click();
 	await expect(page).toHaveURL('/');

--- a/ui/e2e/ruleset.spec.ts
+++ b/ui/e2e/ruleset.spec.ts
@@ -1,0 +1,62 @@
+import { expect, test, type Page } from '@playwright/test';
+
+// The Go backend runs with --dev-token from the repo root (see
+// playwright.config.ts), so POST /api/one_time_password returns the magic-link
+// token in the response body. Login with the user seeded by SeedDevData.
+async function login(page: Page) {
+	await page.goto('/login');
+	await page.waitForLoadState('networkidle');
+	await page.getByLabel('Email').fill('jdarthur@gatech.edu');
+	await page.getByRole('button', { name: 'Send login link' }).click();
+	const link = page.getByRole('main').getByRole('link', { name: 'Log in' });
+	await expect(link).toBeVisible();
+	await link.click();
+	await expect(page).toHaveURL('/');
+}
+
+test('ruleset CRUD: create, view, amend (update), delete', async ({ page }) => {
+	await login(page);
+
+	const unique = Date.now();
+
+	// Create
+	await page.goto('/rulesets');
+	await page.getByRole('link', { name: 'New ruleset' }).click();
+	await expect(page).toHaveURL(/\/rulesets\/new$/);
+	await page.getByLabel('Name').fill(`Test Ruleset ${unique}`);
+	await page.getByRole('button', { name: 'Create ruleset' }).click();
+
+	// View: lands on the detail page as revision 0
+	await expect(page).toHaveURL(/\/rulesets\/[0-9a-f]+$/);
+	await expect(page.getByRole('heading', { name: `Test Ruleset ${unique}` })).toBeVisible();
+	await expect(page.getByText('0', { exact: true })).toBeVisible();
+	await expect(page.getByText('— (current revision)')).toBeVisible();
+	const originalId = page.url().match(/\/rulesets\/([0-9a-f]+)$/)![1];
+
+	// Amend (edit): editing produces a new superseding revision with an
+	// incremented revision number and navigates to the new revision.
+	await page.getByLabel('Name').fill(`Test Ruleset ${unique} Amended`);
+	await page.getByRole('button', { name: 'Save changes' }).click();
+	await expect(page.getByRole('heading', { name: `Test Ruleset ${unique} Amended` })).toBeVisible();
+	await expect(page.getByText('1', { exact: true })).toBeVisible();
+	await expect(page.getByText('— (current revision)')).toBeVisible();
+	const amendedId = page.url().match(/\/rulesets\/([0-9a-f]+)$/)![1];
+
+	// The original revision is now superseded by the amended revision.
+	await page.goto(`/rulesets/${originalId}`);
+	await expect(page.getByRole('heading', { name: `Test Ruleset ${unique}` })).toBeVisible();
+	await expect(page.getByRole('link', { name: amendedId })).toBeVisible();
+
+	// The list reflects the amendment
+	await page.goto('/rulesets');
+	const row = page.getByRole('link', { name: `Test Ruleset ${unique} Amended` });
+	await expect(row).toBeVisible();
+
+	// Delete (accept the confirm dialog)
+	await row.click();
+	await expect(page.getByRole('heading', { name: `Test Ruleset ${unique} Amended` })).toBeVisible();
+	page.on('dialog', (d) => d.accept());
+	await page.getByRole('button', { name: 'Delete ruleset' }).click();
+	await expect(page).toHaveURL('/rulesets');
+	await expect(page.getByRole('link', { name: `Test Ruleset ${unique} Amended` })).toHaveCount(0);
+});

--- a/ui/src/lib/components/NavBar.svelte
+++ b/ui/src/lib/components/NavBar.svelte
@@ -17,6 +17,7 @@
 		<a href="/facilities">Facilities</a>
 		<a href="/formats">Formats</a>
 		<a href="/ratings">Ratings</a>
+		<a href="/rulesets">Rulesets</a>
 	</div>
 	<div class="actions">
 		{#if loggedIn}

--- a/ui/src/lib/ruleset.ts
+++ b/ui/src/lib/ruleset.ts
@@ -1,0 +1,86 @@
+// Ruleset API client. Ruleset records are backed by the REST CRUD routes
+// generated from `model.Ruleset` (see main.go) plus a custom amend route:
+//
+//	GET    /api/ruleset            -> { resource: Ruleset[] }
+//	GET    /api/ruleset/:id        -> { resource: Ruleset }
+//	POST   /api/ruleset            -> { resource: Ruleset }   (owner = token user)
+//	PUT    /api/ruleset/:id/amend  -> { resource: Ruleset }   (new superseding revision)
+//	DELETE /api/ruleset/:id        -> { resource: Ruleset }
+//
+// A Ruleset is the club rulebook. Direct modification is forbidden by the
+// model (use Ruleset.Amend instead), so editing a name produces a NEW revision
+// that supersedes the current one. Record IDs are 16-char hex strings; an
+// empty string represents "not set" (InvalidRecordId).
+import { authFetch } from '$lib/auth';
+
+export interface Ruleset {
+	id: string;
+	name: string;
+	revision: number;
+	superseded_by: string;
+	date: string;
+	owner: string;
+}
+
+const BASE = '/api/ruleset';
+
+// unwrap parses a CrudCommon response (`{ resource: ... }`) and throws the
+// backend error message on non-2xx responses so callers can surface it.
+async function unwrap(res: Response): Promise<any> {
+	if (!res.ok) {
+		let message = `Request failed (${res.status})`;
+		try {
+			const body = await res.json();
+			if (body?.error) message = body.error;
+		} catch {
+			// non-JSON error body; fall back to the status message
+		}
+		throw new Error(message);
+	}
+	const body = await res.json();
+	return body?.resource;
+}
+
+export async function listRulesets(): Promise<Ruleset[]> {
+	return unwrap(await authFetch(BASE));
+}
+
+export async function getRuleset(id: string): Promise<Ruleset> {
+	return unwrap(await authFetch(`${BASE}/${id}`));
+}
+
+export async function createRuleset(name: string): Promise<Ruleset> {
+	return unwrap(
+		await authFetch(BASE, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ name })
+		})
+	);
+}
+
+// amendRulesetName edits a Ruleset's name by producing a new revision that
+// supersedes the current one; it returns the NEW superseding Ruleset.
+export async function amendRulesetName(id: string, name: string): Promise<Ruleset> {
+	return unwrap(
+		await authFetch(`${BASE}/${id}/amend`, {
+			method: 'PUT',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ name })
+		})
+	);
+}
+
+export async function deleteRuleset(id: string): Promise<void> {
+	const res = await authFetch(`${BASE}/${id}`, { method: 'DELETE' });
+	if (!res.ok) {
+		let message = `Delete failed (${res.status})`;
+		try {
+			const body = await res.json();
+			if (body?.error) message = body.error;
+		} catch {
+			// non-JSON error body; fall back to the status message
+		}
+		throw new Error(message);
+	}
+}

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -11,7 +11,7 @@
 
 {#if loggedIn}
 	<h1>Welcome to IntraClub</h1>
-	<p>Head to <a href="/facilities">Facilities</a>, <a href="/formats">Formats</a>, or <a href="/ratings">Ratings</a> to get started.</p>
+	<p>Head to <a href="/facilities">Facilities</a>, <a href="/formats">Formats</a>, <a href="/ratings">Ratings</a>, or <a href="/rulesets">Rulesets</a> to get started.</p>
 {:else}
 	<h1>IntraClub</h1>
 	<p>Welcome! Log in to manage your club.</p>

--- a/ui/src/routes/rulesets/+page.svelte
+++ b/ui/src/routes/rulesets/+page.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { listRulesets } from '$lib/ruleset';
+	import type { Ruleset } from '$lib/ruleset';
+
+	let rulesets = $state<Ruleset[]>([]);
+	let loading = $state(true);
+	let error = $state('');
+
+	onMount(async () => {
+		try {
+			rulesets = await listRulesets();
+		} catch (e) {
+			error = e instanceof Error ? e.message : 'Failed to load rulesets';
+		} finally {
+			loading = false;
+		}
+	});
+</script>
+
+<svelte:head>
+	<title>Rulesets</title>
+</svelte:head>
+
+<h1>Rulesets</h1>
+<a href="/rulesets/new">New ruleset</a>
+
+{#if loading}
+	<p>Loading...</p>
+{:else if error}
+	<p class="error">{error}</p>
+{:else if rulesets.length === 0}
+	<p>No rulesets yet.</p>
+{:else}
+	<table>
+		<thead>
+			<tr>
+				<th>Name</th>
+				<th>Revision</th>
+			</tr>
+		</thead>
+		<tbody>
+			{#each rulesets as ruleset}
+				<tr>
+					<td><a href={`/rulesets/${ruleset.id}`}>{ruleset.name}</a></td>
+					<td>{ruleset.revision}</td>
+				</tr>
+			{/each}
+		</tbody>
+	</table>
+{/if}
+
+<style>
+	.error {
+		color: #c00;
+	}
+	table {
+		border-collapse: collapse;
+		margin-top: 1rem;
+	}
+	th,
+	td {
+		border: 1px solid #ccc;
+		padding: 0.4rem 0.8rem;
+		text-align: left;
+	}
+</style>

--- a/ui/src/routes/rulesets/[id]/+page.svelte
+++ b/ui/src/routes/rulesets/[id]/+page.svelte
@@ -1,0 +1,157 @@
+<script lang="ts">
+	import { page } from '$app/state';
+	import { goto } from '$app/navigation';
+	import { getRuleset, amendRulesetName, deleteRuleset } from '$lib/ruleset';
+	import type { Ruleset } from '$lib/ruleset';
+
+	// Derived from the route param so the page re-loads when navigating between
+	// ruleset revisions (same [id] route, different id).
+	const currentId = $derived(page.params.id as string);
+
+	let ruleset = $state<Ruleset | null>(null);
+	let loadError = $state('');
+	let name = $state('');
+	let error = $state('');
+	let saving = $state(false);
+	let deleting = $state(false);
+
+	$effect(() => {
+		load(currentId);
+	});
+
+	async function load(idToLoad: string) {
+		loadError = '';
+		ruleset = null;
+		try {
+			const r = await getRuleset(idToLoad);
+			ruleset = r;
+			name = r.name;
+		} catch (e) {
+			loadError = e instanceof Error ? e.message : 'Failed to load ruleset';
+		}
+	}
+
+	// Editing a Ruleset's name amends it: the backend creates a new revision
+	// that supersedes this one, so we navigate to the new revision.
+	async function handleSave(e: Event) {
+		e.preventDefault();
+		error = '';
+		saving = true;
+		try {
+			const amended = await amendRulesetName(currentId, name.trim());
+			await goto(`/rulesets/${amended.id}`);
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Failed to update ruleset';
+		} finally {
+			saving = false;
+		}
+	}
+
+	async function handleDelete() {
+		if (!confirm('Delete this ruleset?')) return;
+		error = '';
+		deleting = true;
+		try {
+			await deleteRuleset(currentId);
+			await goto('/rulesets');
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Failed to delete ruleset';
+			deleting = false;
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>{ruleset ? ruleset.name : 'Ruleset'}</title>
+</svelte:head>
+
+{#if loadError}
+	<h1>Ruleset</h1>
+	<p class="error">{loadError}</p>
+	<a href="/rulesets">&larr; Back to rulesets</a>
+{:else if !ruleset}
+	<h1>Ruleset</h1>
+	<p>Loading...</p>
+{:else}
+	<h1>{ruleset.name}</h1>
+	<a href="/rulesets">&larr; Back to rulesets</a>
+
+	<dl class="meta">
+		<div>
+			<dt>Revision</dt>
+			<dd>{ruleset.revision}</dd>
+		</div>
+		<div>
+			<dt>Date</dt>
+			<dd>{new Date(ruleset.date).toLocaleString()}</dd>
+		</div>
+		<div>
+			<dt>Superseded by</dt>
+			<dd>
+				{#if ruleset.superseded_by}
+					<a href={`/rulesets/${ruleset.superseded_by}`}>{ruleset.superseded_by}</a>
+				{:else}
+					— (current revision)
+				{/if}
+			</dd>
+		</div>
+	</dl>
+
+	<h2>Edit</h2>
+	<p class="hint">Saving edits amends this ruleset and creates a new revision.</p>
+	<form onsubmit={handleSave}>
+		<label>
+			Name
+			<input type="text" bind:value={name} required />
+		</label>
+		<button type="submit" disabled={saving}>{saving ? 'Saving...' : 'Save changes'}</button>
+	</form>
+
+	<button type="button" onclick={handleDelete} disabled={deleting} class="danger">
+		{deleting ? 'Deleting...' : 'Delete ruleset'}
+	</button>
+
+	{#if error}
+		<p class="error">{error}</p>
+	{/if}
+{/if}
+
+<style>
+	.error {
+		color: #c00;
+	}
+	.hint {
+		color: #666;
+	}
+	.meta {
+		display: flex;
+		gap: 1.5rem;
+		margin: 1rem 0;
+	}
+	.meta dt {
+		font-size: 0.85rem;
+		color: #666;
+	}
+	.meta dd {
+		margin: 0;
+	}
+	form {
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+		max-width: 24rem;
+		margin-top: 0.5rem;
+	}
+	label {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+	}
+	input {
+		padding: 0.35rem;
+	}
+	.danger {
+		margin-top: 1rem;
+		color: #c00;
+	}
+</style>

--- a/ui/src/routes/rulesets/new/+page.svelte
+++ b/ui/src/routes/rulesets/new/+page.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+	import { createRuleset } from '$lib/ruleset';
+	import { goto } from '$app/navigation';
+
+	let name = $state('');
+	let error = $state('');
+	let submitting = $state(false);
+
+	async function handleSubmit(e: Event) {
+		e.preventDefault();
+		error = '';
+		submitting = true;
+		try {
+			const created = await createRuleset(name.trim());
+			await goto(`/rulesets/${created.id}`);
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Failed to create ruleset';
+		} finally {
+			submitting = false;
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>New ruleset</title>
+</svelte:head>
+
+<h1>New ruleset</h1>
+<a href="/rulesets">&larr; Back to rulesets</a>
+
+<form onsubmit={handleSubmit}>
+	<label>
+		Name
+		<input type="text" bind:value={name} required />
+	</label>
+	<button type="submit" disabled={submitting}>{submitting ? 'Creating...' : 'Create ruleset'}</button>
+</form>
+
+{#if error}
+	<p class="error">{error}</p>
+{/if}
+
+<style>
+	.error {
+		color: #c00;
+	}
+	form {
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+		max-width: 24rem;
+		margin-top: 1rem;
+	}
+	label {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+	}
+	input {
+		padding: 0.35rem;
+	}
+</style>


### PR DESCRIPTION
Implements #83.

## Backend
- Register Ruleset CRUD routes in `main.go`: `GET/POST /api/ruleset`, `GET/PUT/DELETE /api/ruleset/:id`.
- Add `Ruleset.EditName` amend method: direct modification is forbidden by `Ruleset.PreUpdate` (`use Ruleset.Amend instead`), so editing a name produces a **new superseding revision** and marks the old one as superseded.
- Add `PUT /api/ruleset/:id/amend` handler (`route/ruleset/amend.go`) with auth + per-record edit authorization (owner/sysadmin).
- Model tests for `EditName`.

## Frontend (`ui/`)
- `ruleset.ts` API client (list/get/create/amend/delete).
- List page, detail page (revision/date/superseded-by metadata + Amend-based edit + delete), and create page. Nav + landing-page links added.
- Detail page reloads on same-route id changes via `$effect` (so navigating to a new revision re-fetches).

## Tests
- Playwright `ruleset.spec.ts`: create → view → amend (new revision) → verify superseded-by → delete.
- Fixed a pre-existing e2e breakage: the always-shown navbar's `Log in` link collided with the magic-link `Log in` (strict-mode violation) in facility/format/login/rating specs — scoped to `main`.

## Verification
- `go vet ./...` and `go test ./...` pass; `svelte-check` 0 errors; full Playwright suite passes serially (9 tests).