### PR TITLE
Fix missing delete-cascade for format join records (#94)

### DIFF
--- a/model/format.go
+++ b/model/format.go
@@ -76,6 +76,36 @@ func (f *Format) PreDelete(ctx context.Context, db database.Provider) error {
 	return f.CheckHasAssignedDrafts(ctx, db, false)
 }
 
+// PostDelete cascades deletion to this format's format_rating and format_line
+// join rows. Without this, deleting a format would orphan those rows, keeping
+// the referenced Ratings permanently "in-use" (see #94).
+func (f *Format) PostDelete(ctx context.Context, db database.Provider) error {
+	formatRatings, err := database.GetAllWhere[*FormatRating](ctx, db, func(_ context.Context, fr *FormatRating) bool {
+		return fr.FormatId == f.ID
+	})
+	if err != nil {
+		return err
+	}
+	for _, fr := range formatRatings {
+		if _, _, err := database.DeleteOneById(ctx, db, fr, fr.ID); err != nil {
+			return err
+		}
+	}
+
+	formatLines, err := database.GetAllWhere[*FormatLine](ctx, db, func(_ context.Context, fl *FormatLine) bool {
+		return fl.FormatId == f.ID
+	})
+	if err != nil {
+		return err
+	}
+	for _, fl := range formatLines {
+		if _, _, err := database.DeleteOneById(ctx, db, fl, fl.ID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (f *Format) SetOwner(userId database.UserId) {
 	f.UserId = userId
 }

--- a/model/format_test.go
+++ b/model/format_test.go
@@ -390,3 +390,68 @@ func TestFormatRatingInvalidRatingId(t *testing.T) {
 	}
 	fmt.Println(err)
 }
+
+func TestFormatDeleteCascadesJoinRows(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	ctx := context.Background()
+
+	format := newDefaultStoredFormat(t, db)
+
+	formatRatings, err := database.GetAllWhere[*FormatRating](ctx, db, func(_ context.Context, fr *FormatRating) bool {
+		return fr.FormatId == format.ID
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	formatLines, err := database.GetAllWhere[*FormatLine](ctx, db, func(_ context.Context, fl *FormatLine) bool {
+		return fl.FormatId == format.ID
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(formatRatings) == 0 || len(formatLines) == 0 {
+		t.Fatalf("Expected format to have join rows, got %d format_ratings and %d format_lines", len(formatRatings), len(formatLines))
+	}
+
+	// The ratings referenced by the format's join rows must be deletable
+	// after the format is deleted (they should no longer be "in-use").
+	referenced := map[RatingId]bool{}
+	for _, fr := range formatRatings {
+		referenced[fr.RatingId] = true
+	}
+	for _, fl := range formatLines {
+		referenced[fl.Player1Rating] = true
+		referenced[fl.Player2Rating] = true
+	}
+
+	_, _, err = database.DeleteOneById(ctx, db, &Format{}, format.ID.RecordId())
+	if err != nil {
+		t.Fatalf("Expected format delete to succeed: %v", err)
+	}
+
+	remainingRatings, err := database.GetAllWhere[*FormatRating](ctx, db, func(_ context.Context, fr *FormatRating) bool {
+		return fr.FormatId == format.ID
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(remainingRatings) != 0 {
+		t.Fatalf("Expected 0 remaining format_rating rows, got %d", len(remainingRatings))
+	}
+	remainingLines, err := database.GetAllWhere[*FormatLine](ctx, db, func(_ context.Context, fl *FormatLine) bool {
+		return fl.FormatId == format.ID
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(remainingLines) != 0 {
+		t.Fatalf("Expected 0 remaining format_line rows, got %d", len(remainingLines))
+	}
+
+	for ratingId := range referenced {
+		_, _, err = database.DeleteOneById(ctx, db, &Rating{}, ratingId.RecordId())
+		if err != nil {
+			t.Fatalf("Expected rating %s to be deletable after format delete: %v", ratingId, err)
+		}
+	}
+}

--- a/ui/e2e/format-ratings.spec.ts
+++ b/ui/e2e/format-ratings.spec.ts
@@ -1,6 +1,4 @@
 import { expect, test, type Page } from '@playwright/test';
-import { DatabaseSync } from 'node:sqlite';
-import { fileURLToPath } from 'node:url';
 
 // The Go backend runs with --dev-token from the repo root (see
 // playwright.config.ts), so POST /api/one_time_password returns the magic-link
@@ -15,10 +13,6 @@ async function login(page: Page) {
 	await link.click();
 	await expect(page).toHaveURL('/');
 }
-
-// The Playwright test process runs with cwd = ui/, while the Go backend
-// (spawned from the repo root) keeps its SQLite db at <repo>/intraclub.db.
-const dbPath = fileURLToPath(new URL('../../intraclub.db', import.meta.url));
 
 test('assign ratings to a format: add, list, remove', async ({ page }) => {
 	await login(page);
@@ -42,7 +36,6 @@ test('assign ratings to a format: add, list, remove', async ({ page }) => {
 	await page.getByLabel('Name').fill(formatName);
 	await page.getByRole('button', { name: 'Create format' }).click();
 	await expect(page).toHaveURL(/\/formats\/[0-9a-f]+$/);
-	const formatId = page.url().match(/\/formats\/([0-9a-f]+)$/)![1];
 
 	// No ratings assigned yet.
 	await expect(page.getByText('No ratings assigned yet.')).toBeVisible();
@@ -73,24 +66,13 @@ test('assign ratings to a format: add, list, remove', async ({ page }) => {
 	await expect(secondItem.getByRole('button', { name: 'Remove' })).toBeDisabled();
 	await expect(page.getByText('A format must keep at least one rating.')).toBeVisible();
 
-	// Clean up. Deleting a format does not cascade-delete its format_rating join
-	// rows, and Rating.PreDelete blocks deleting a rating that is still in use —
-	// so after deleting the format we remove its orphan format_rating rows
-	// directly, then delete both ratings to keep the shared dev db clean.
+	// Clean up. Deleting a format now cascades to its format_rating / format_line
+	// join rows, so the ratings are no longer "in-use" and can be deleted to
+	// keep the shared dev db clean.
 	page.on('dialog', (d) => d.accept());
 	await page.getByRole('button', { name: 'Delete format' }).click();
 	await expect(page).toHaveURL('/formats');
 	await expect(page.getByRole('link', { name: formatName })).toHaveCount(0);
-
-	const db = new DatabaseSync(dbPath);
-	// The Go backend holds this SQLite file open; wait out any transient lock
-	// instead of failing immediately with "database is locked".
-	db.exec('PRAGMA busy_timeout = 10000');
-	try {
-		db.prepare('DELETE FROM format_rating WHERE format_id = ?').run(formatId);
-	} finally {
-		db.close();
-	}
 
 	for (const ratingName of [ratingName1, ratingName2]) {
 		await page.goto('/ratings');


### PR DESCRIPTION
Fixes #94.

## Summary
Deleting a `Format` now cleans up its `format_rating` and `format_line` join rows, so referenced `Rating`s are no longer left permanently "in-use" and can be deleted through the app afterward.

## Changes
- **`model/format.go`**: added a `PostDelete` hook on `Format` (Option A from the issue) that cascades deletion to its `format_rating` and `format_line` rows, following the same pattern as `Schedule.PreDelete`.
- **`model/format_test.go`**: added `TestFormatDeleteCascadesJoinRows` verifying the join rows are removed and the referenced ratings become deletable.
- **`ui/e2e/format-ratings.spec.ts`**: removed the direct `DELETE FROM format_rating` workaround now that the backend handles the cascade.

## Verification
- `go build ./...` ✓
- `go vet ./...` ✓
- `go test ./...` ✓ (all pass)
- `npx tsc --noEmit` in `ui/` ✓