### PR TITLE
fix: widen Rating.PreDelete in-use check to all rating-referencing tables

### DIFF
--- a/model/rating.go
+++ b/model/rating.go
@@ -65,6 +65,14 @@ func (r *Rating) GetOwner() database.UserId {
 }
 
 func (r *Rating) PreDelete(ctx context.Context, db database.Provider) error {
+	// ratingRef records how many rows in a referencing table still point at this rating.
+	type ratingRef struct {
+		table string
+		count int
+	}
+
+	refs := make([]ratingRef, 0, 6)
+
 	formatRatings, err := database.GetAllWhere[*FormatRating](ctx, db, func(_ context.Context, fr *FormatRating) bool {
 		return fr.RatingId == r.ID
 	})
@@ -72,9 +80,68 @@ func (r *Rating) PreDelete(ctx context.Context, db database.Provider) error {
 		return err
 	}
 	if len(formatRatings) > 0 {
-		return fmt.Errorf("rating with ID %s is in-use by %d formats", r.ID, len(formatRatings))
+		refs = append(refs, ratingRef{"format_rating", len(formatRatings)})
 	}
-	return nil
+
+	teamRatings, err := database.GetAllWhere[*TeamRating](ctx, db, func(_ context.Context, tr *TeamRating) bool {
+		return tr.RatingId == r.ID
+	})
+	if err != nil {
+		return err
+	}
+	if len(teamRatings) > 0 {
+		refs = append(refs, ratingRef{"team_rating", len(teamRatings)})
+	}
+
+	draftRatingCutoffs, err := database.GetAllWhere[*DraftRatingCutoff](ctx, db, func(_ context.Context, dc *DraftRatingCutoff) bool {
+		return dc.RatingId == r.ID
+	})
+	if err != nil {
+		return err
+	}
+	if len(draftRatingCutoffs) > 0 {
+		refs = append(refs, ratingRef{"draft_rating_cutoff", len(draftRatingCutoffs)})
+	}
+
+	draftPicks, err := database.GetAllWhere[*DraftPick](ctx, db, func(_ context.Context, dp *DraftPick) bool {
+		return dp.Rating == r.ID
+	})
+	if err != nil {
+		return err
+	}
+	if len(draftPicks) > 0 {
+		refs = append(refs, ratingRef{"draft_pick", len(draftPicks)})
+	}
+
+	preDraftGrades, err := database.GetAllWhere[*PreDraftGrade](ctx, db, func(_ context.Context, pg *PreDraftGrade) bool {
+		return pg.Rating == r.ID
+	})
+	if err != nil {
+		return err
+	}
+	if len(preDraftGrades) > 0 {
+		refs = append(refs, ratingRef{"pre_draft_grade", len(preDraftGrades)})
+	}
+
+	formatLines, err := database.GetAllWhere[*FormatLine](ctx, db, func(_ context.Context, fl *FormatLine) bool {
+		return fl.Player1Rating == r.ID || fl.Player2Rating == r.ID
+	})
+	if err != nil {
+		return err
+	}
+	if len(formatLines) > 0 {
+		refs = append(refs, ratingRef{"format_line", len(formatLines)})
+	}
+
+	if len(refs) == 0 {
+		return nil
+	}
+
+	parts := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		parts = append(parts, fmt.Sprintf("%d %s", ref.count, ref.table))
+	}
+	return fmt.Errorf("rating with ID %s is in-use by %s", r.ID, strings.Join(parts, ", "))
 }
 
 func (r *Rating) SetOwner(userId database.UserId) {

--- a/model/rating_test.go
+++ b/model/rating_test.go
@@ -6,6 +6,9 @@ import (
 	"testing"
 
 	"intraclub/database"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func newValidRating(u database.UserId) *Rating {
@@ -143,4 +146,103 @@ func TestRatingCannotBeDeletedWhenInUse(t *testing.T) {
 		t.Fatal("Expected rating not to have been deleted")
 	}
 
+}
+
+func TestRatingPreDeleteSucceedsWhenUnreferenced(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	rating := newStoredRating(t, db)
+
+	err := rating.PreDelete(context.Background(), db)
+	require.NoError(t, err)
+}
+
+func TestRatingPreDeleteBlockedByTeamRating(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	rating := newStoredRating(t, db)
+	team := newStoredTeam(t, db, newStoredUser(t, db).ID)
+	member := newStoredUser(t, db)
+
+	_, err := database.CreateOne(context.Background(), db, &TeamRating{
+		TeamId:   team.ID,
+		UserId:   member.ID,
+		RatingId: rating.ID,
+	})
+	require.NoError(t, err)
+
+	err = rating.PreDelete(context.Background(), db)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "team_rating")
+}
+
+func TestRatingPreDeleteBlockedByDraftRatingCutoff(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	rating := newStoredRating(t, db)
+	draft := newDefaultStoredDraft(t, db)
+
+	_, err := database.CreateOne(context.Background(), db, &DraftRatingCutoff{
+		DraftId:     draft.ID,
+		RatingId:    rating.ID,
+		CutoffIndex: 1,
+	})
+	require.NoError(t, err)
+
+	err = rating.PreDelete(context.Background(), db)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "draft_rating_cutoff")
+}
+
+func TestRatingPreDeleteBlockedByDraftPick(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	rating := newStoredRating(t, db)
+	draft := newDefaultStoredDraft(t, db)
+	team := newStoredTeam(t, db, newStoredUser(t, db).ID)
+	member := newStoredUser(t, db)
+
+	_, err := database.CreateOne(context.Background(), db, &DraftPick{
+		DraftId: draft.ID,
+		TeamId:  team.ID,
+		UserId:  member.ID,
+		Round:   1,
+		Pick:    1,
+		Rating:  rating.ID,
+	})
+	require.NoError(t, err)
+
+	err = rating.PreDelete(context.Background(), db)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "draft_pick")
+}
+
+func TestRatingPreDeleteBlockedByPreDraftGrade(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	grade := newStoredGrade(t, db)
+	rating, err := database.GetExistingRecordById(context.Background(), db, &Rating{}, grade.Rating.RecordId())
+	require.NoError(t, err)
+
+	err = rating.PreDelete(context.Background(), db)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "pre_draft_grade")
+}
+
+func TestRatingPreDeleteBlockedByFormatLine(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	rating := newStoredRating(t, db)
+	user := newStoredUser(t, db)
+	format := NewFormat()
+	format.UserId = user.ID
+	format.Name = "line test format"
+	created, err := database.CreateOne(context.Background(), db, format)
+	require.NoError(t, err)
+
+	_, err = database.CreateOne(context.Background(), db, &FormatLine{
+		FormatId:      created.ID,
+		FormatIndex:   0,
+		Player1Rating: rating.ID,
+		Player2Rating: rating.ID,
+	})
+	require.NoError(t, err)
+
+	err = rating.PreDelete(context.Background(), db)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "format_line")
 }


### PR DESCRIPTION
## Summary
Closes #98. `Rating.PreDelete` only consulted `format_rating`, so a rating referenced by `team_rating`, `draft_rating_cutoff`, `draft_pick`, `pre_draft_grade`, or `format_line` could be deleted, leaving dangling references.

## Changes
- Widen `Rating.PreDelete` (model/rating.go) to query all six rating-referencing tables.
- The error message now reports which table(s) hold references and how many rows each, e.g. `rating with ID <id> is in-use by 1 format_rating, 1 format_line`.
- Add a unit test per referencing table (asserts the table name appears in the error) plus a guard that an unreferenced rating still deletes.

## Verification
- `go test ./...` passes
- `go vet ./...` passes