### PR TITLE
Fix missing delete-cascade for assignment-style child tables (#97)

### DIFF
--- a/model/blurb.go
+++ b/model/blurb.go
@@ -222,6 +222,36 @@ func (b *Blurb) GetComments(ctx context.Context, db database.Provider) ([]*Comme
 	return v, nil
 }
 
+// PostDelete cascades deletion to this blurb's blurb_photo and blurb_reaction
+// child rows. Without this, deleting a blurb would orphan those rows (see #97).
+func (b *Blurb) PostDelete(ctx context.Context, db database.Provider) error {
+	photos, err := database.GetAllWhere[*BlurbPhoto](ctx, db, func(_ context.Context, p *BlurbPhoto) bool {
+		return p.BlurbId == b.ID
+	})
+	if err != nil {
+		return err
+	}
+	for _, p := range photos {
+		if _, _, err := database.DeleteOneById(ctx, db, p, p.ID); err != nil {
+			return err
+		}
+	}
+
+	reactions, err := database.GetAllWhere[*BlurbReaction](ctx, db, func(_ context.Context, r *BlurbReaction) bool {
+		return r.BlurbId == b.ID
+	})
+	if err != nil {
+		return err
+	}
+	for _, r := range reactions {
+		if _, _, err := database.DeleteOneById(ctx, db, r, r.ID); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (b *Blurb) NewRecord() database.CrudRecord {
 	return new(Blurb)
 }

--- a/model/blurb_test.go
+++ b/model/blurb_test.go
@@ -154,3 +154,39 @@ func TestUnreactWhereNotPresent(t *testing.T) {
 	assert.Error(t, b.Unreact(context.Background(), db, commish.ID, ThumbsUp), "expected error on unreact where existing reaction doesn't exist")
 	fmt.Println(b.Unreact(context.Background(), db, commish.ID, ThumbsUp))
 }
+
+func TestBlurbPostDeleteCascadesChildren(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	blurb, season := newDefaultBlurb(t, db)
+	participant := getAnyTeamCaptain(t, db, season)
+
+	photo := newStoredPhoto(t, db, participant)
+	_, err := database.CreateOne(context.Background(), db, &BlurbPhoto{BlurbId: blurb.ID, PhotoId: photo.ID})
+	require.NoError(t, err)
+
+	err = blurb.React(context.Background(), db, participant, ThumbsUp)
+	require.NoError(t, err)
+
+	counts := func() (int, int) {
+		photos, err := database.GetAllWhere[*BlurbPhoto](context.Background(), db, func(_ context.Context, p *BlurbPhoto) bool {
+			return p.BlurbId == blurb.ID
+		})
+		require.NoError(t, err)
+		reactions, err := database.GetAllWhere[*BlurbReaction](context.Background(), db, func(_ context.Context, r *BlurbReaction) bool {
+			return r.BlurbId == blurb.ID
+		})
+		require.NoError(t, err)
+		return len(photos), len(reactions)
+	}
+
+	photos, reactions := counts()
+	require.Equal(t, 1, photos)
+	require.Equal(t, 1, reactions)
+
+	_, _, err = database.DeleteOneById(context.Background(), db, &Blurb{}, blurb.ID.RecordId())
+	require.NoError(t, err)
+
+	photos, reactions = counts()
+	require.Equal(t, 0, photos)
+	require.Equal(t, 0, reactions)
+}

--- a/model/comment.go
+++ b/model/comment.go
@@ -168,6 +168,23 @@ func (c *Comment) DynamicallyValid(ctx context.Context, db database.Provider) er
 	return nil
 }
 
+// PostDelete cascades deletion to this comment's comment_reaction child rows.
+// Without this, deleting a comment would orphan those rows (see #97).
+func (c *Comment) PostDelete(ctx context.Context, db database.Provider) error {
+	reactions, err := database.GetAllWhere[*CommentReaction](ctx, db, func(_ context.Context, r *CommentReaction) bool {
+		return r.CommentId == c.ID
+	})
+	if err != nil {
+		return err
+	}
+	for _, r := range reactions {
+		if _, _, err := database.DeleteOneById(ctx, db, r, r.ID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (c *Comment) NewRecord() database.CrudRecord {
 	return new(Comment)
 }

--- a/model/comment_test.go
+++ b/model/comment_test.go
@@ -233,3 +233,36 @@ func TestCommentByNonSeasonParticipant(t *testing.T) {
 	}
 	fmt.Println(err)
 }
+
+func TestCommentPostDeleteCascadesReactions(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	blurb, season := newDefaultBlurb(t, db)
+	owner := getAnyTeamCaptain(t, db, season)
+	comment := newStoredComment(t, db, owner, blurb)
+
+	err := comment.React(context.Background(), db, owner, ThumbsUp)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	count := func() int {
+		rows, err := database.GetAllWhere[*CommentReaction](context.Background(), db, func(_ context.Context, r *CommentReaction) bool {
+			return r.CommentId == comment.ID
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return len(rows)
+	}
+	if count() == 0 {
+		t.Fatal("expected comment to have reactions")
+	}
+
+	_, _, err = database.DeleteOneById(context.Background(), db, &Comment{}, comment.ID.RecordId())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count() != 0 {
+		t.Fatal("expected 0 reactions after delete")
+	}
+}

--- a/model/commissioner_proposal.go
+++ b/model/commissioner_proposal.go
@@ -252,6 +252,23 @@ func (c *CommissionerProposal) Status(ctx context.Context, db database.Provider)
 	return false, false, nil
 }
 
+// PostDelete cascades deletion to this proposal's commissioner_proposal_vote
+// child rows. Without this, deleting a proposal would orphan those rows (see #97).
+func (c *CommissionerProposal) PostDelete(ctx context.Context, db database.Provider) error {
+	votes, err := database.GetAllWhere[*CommissionerProposalVote](ctx, db, func(_ context.Context, v *CommissionerProposalVote) bool {
+		return v.ProposalId == c.ID
+	})
+	if err != nil {
+		return err
+	}
+	for _, v := range votes {
+		if _, _, err := database.DeleteOneById(ctx, db, v, v.ID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (c *CommissionerProposal) NewRecord() database.CrudRecord {
 	return new(CommissionerProposal)
 }

--- a/model/commissioner_proposal_test.go
+++ b/model/commissioner_proposal_test.go
@@ -316,3 +316,26 @@ func TestCommissionerProposalGetVotesEmpty(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, votes, 0)
 }
+
+func TestCommissionerProposalPostDeleteCascadesVotes(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	season, proposal := newStoredCommissionerProposal(t, db, false)
+
+	voter := getAnyTeamCaptain(t, db, season)
+	err := proposal.Vote(context.Background(), db, voter, true)
+	require.NoError(t, err)
+
+	count := func() int {
+		rows, err := database.GetAllWhere[*CommissionerProposalVote](context.Background(), db, func(_ context.Context, v *CommissionerProposalVote) bool {
+			return v.ProposalId == proposal.ID
+		})
+		require.NoError(t, err)
+		return len(rows)
+	}
+	require.Equal(t, 1, count())
+
+	_, _, err = database.DeleteOneById(context.Background(), db, &CommissionerProposal{}, proposal.ID)
+	require.NoError(t, err)
+
+	require.Equal(t, 0, count())
+}

--- a/model/draft.go
+++ b/model/draft.go
@@ -209,6 +209,85 @@ func (d *Draft) PostUpdate(ctx context.Context, db database.Provider) error {
 	return d.syncDraftFormat(ctx, db)
 }
 
+// PostDelete cascades deletion to all of this draft's join rows: available
+// players, captains, formats, picks, rating cutoffs, and pre-draft grades.
+// Without this, deleting a draft would orphan those rows (see #97).
+func (d *Draft) PostDelete(ctx context.Context, db database.Provider) error {
+	availablePlayers, err := database.GetAllWhere[*DraftAvailablePlayer](ctx, db, func(_ context.Context, r *DraftAvailablePlayer) bool {
+		return r.DraftId == d.ID
+	})
+	if err != nil {
+		return err
+	}
+	for _, r := range availablePlayers {
+		if _, _, err := database.DeleteOneById(ctx, db, r, r.ID); err != nil {
+			return err
+		}
+	}
+
+	captains, err := database.GetAllWhere[*DraftCaptain](ctx, db, func(_ context.Context, r *DraftCaptain) bool {
+		return r.DraftId == d.ID
+	})
+	if err != nil {
+		return err
+	}
+	for _, r := range captains {
+		if _, _, err := database.DeleteOneById(ctx, db, r, r.ID); err != nil {
+			return err
+		}
+	}
+
+	formats, err := database.GetAllWhere[*DraftFormat](ctx, db, func(_ context.Context, r *DraftFormat) bool {
+		return r.DraftId == d.ID
+	})
+	if err != nil {
+		return err
+	}
+	for _, r := range formats {
+		if _, _, err := database.DeleteOneById(ctx, db, r, r.ID); err != nil {
+			return err
+		}
+	}
+
+	picks, err := database.GetAllWhere[*DraftPick](ctx, db, func(_ context.Context, r *DraftPick) bool {
+		return r.DraftId == d.ID
+	})
+	if err != nil {
+		return err
+	}
+	for _, r := range picks {
+		if _, _, err := database.DeleteOneById(ctx, db, r, r.ID); err != nil {
+			return err
+		}
+	}
+
+	ratingCutoffs, err := database.GetAllWhere[*DraftRatingCutoff](ctx, db, func(_ context.Context, r *DraftRatingCutoff) bool {
+		return r.DraftId == d.ID
+	})
+	if err != nil {
+		return err
+	}
+	for _, r := range ratingCutoffs {
+		if _, _, err := database.DeleteOneById(ctx, db, r, r.ID); err != nil {
+			return err
+		}
+	}
+
+	preDraftGrades, err := database.GetAllWhere[*PreDraftGrade](ctx, db, func(_ context.Context, r *PreDraftGrade) bool {
+		return r.DraftId == d.ID
+	})
+	if err != nil {
+		return err
+	}
+	for _, r := range preDraftGrades {
+		if _, _, err := database.DeleteOneById(ctx, db, r, r.ID); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (d *Draft) syncDraftFormat(ctx context.Context, db database.Provider) error {
 	existing, err := database.GetAllWhere[*DraftFormat](ctx, db, func(_ context.Context, df *DraftFormat) bool {
 		return df.DraftId == d.ID

--- a/model/draft_test.go
+++ b/model/draft_test.go
@@ -724,3 +724,87 @@ func TestDraftAssignAndGetRatingCutoffs(t *testing.T) {
 	assert.Equal(t, 20, cutoffs[rating1.ID])
 	assert.Equal(t, 40, cutoffs[rating2.ID])
 }
+
+func TestDraftPostDeleteCascadesChildren(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	commissioner := newStoredUser(t, db)
+	draft := newStoredDraft(t, db, commissioner.ID) // draft_format (PostCreate) + one available player
+
+	captain := newStoredUser(t, db)
+	team := newStoredTeam(t, db, captain.ID)
+
+	_, err := database.CreateOne(context.Background(), db, &DraftCaptain{
+		DraftId: draft.ID, TeamId: team.ID, CaptainId: captain.ID, DraftOrder: 0,
+	})
+	require.NoError(t, err)
+
+	format, err := database.GetExistingRecordById(context.Background(), db, &Format{}, draft.Format.RecordId())
+	require.NoError(t, err)
+	possibleRatings, err := format.GetPossibleRatings(context.Background(), db)
+	require.NoError(t, err)
+	rating := possibleRatings[0]
+
+	// create the pre-draft grade before any picks so the draft is not yet "completed"
+	_, err = database.CreateOne(context.Background(), db, &PreDraftGrade{
+		DraftId: draft.ID, PlayerId: commissioner.ID, GraderId: commissioner.ID,
+		Modifier: AverageModifier, Rating: rating,
+	})
+	require.NoError(t, err)
+
+	_, err = database.CreateOne(context.Background(), db, &DraftPick{
+		DraftId: draft.ID, TeamId: team.ID, UserId: captain.ID, Round: 1, Pick: 1,
+	})
+	require.NoError(t, err)
+
+	_, err = database.CreateOne(context.Background(), db, &DraftRatingCutoff{
+		DraftId: draft.ID, RatingId: rating, CutoffIndex: 1,
+	})
+	require.NoError(t, err)
+
+	countRows := func() (int, int, int, int, int, int) {
+		avail, err := database.GetAllWhere[*DraftAvailablePlayer](context.Background(), db, func(_ context.Context, r *DraftAvailablePlayer) bool {
+			return r.DraftId == draft.ID
+		})
+		require.NoError(t, err)
+		caps, err := database.GetAllWhere[*DraftCaptain](context.Background(), db, func(_ context.Context, r *DraftCaptain) bool {
+			return r.DraftId == draft.ID
+		})
+		require.NoError(t, err)
+		formats, err := database.GetAllWhere[*DraftFormat](context.Background(), db, func(_ context.Context, r *DraftFormat) bool {
+			return r.DraftId == draft.ID
+		})
+		require.NoError(t, err)
+		picks, err := database.GetAllWhere[*DraftPick](context.Background(), db, func(_ context.Context, r *DraftPick) bool {
+			return r.DraftId == draft.ID
+		})
+		require.NoError(t, err)
+		cutoffs, err := database.GetAllWhere[*DraftRatingCutoff](context.Background(), db, func(_ context.Context, r *DraftRatingCutoff) bool {
+			return r.DraftId == draft.ID
+		})
+		require.NoError(t, err)
+		grades, err := database.GetAllWhere[*PreDraftGrade](context.Background(), db, func(_ context.Context, r *PreDraftGrade) bool {
+			return r.DraftId == draft.ID
+		})
+		require.NoError(t, err)
+		return len(avail), len(caps), len(formats), len(picks), len(cutoffs), len(grades)
+	}
+
+	a, c, f, p, co, g := countRows()
+	require.Equal(t, 1, a)
+	require.Equal(t, 1, c)
+	require.Equal(t, 1, f)
+	require.Equal(t, 1, p)
+	require.Equal(t, 1, co)
+	require.Equal(t, 1, g)
+
+	_, _, err = database.DeleteOneById(context.Background(), db, &Draft{}, draft.ID.RecordId())
+	require.NoError(t, err)
+
+	a, c, f, p, co, g = countRows()
+	require.Equal(t, 0, a)
+	require.Equal(t, 0, c)
+	require.Equal(t, 0, f)
+	require.Equal(t, 0, p)
+	require.Equal(t, 0, co)
+	require.Equal(t, 0, g)
+}

--- a/model/individual_match.go
+++ b/model/individual_match.go
@@ -310,6 +310,23 @@ func (s *IndividualMatch) GetSecondaryPointTotal() int {
 	return output
 }
 
+// PostDelete cascades deletion to this match's match_editor child rows.
+// Without this, deleting a match would orphan those rows (see #97).
+func (s *IndividualMatch) PostDelete(ctx context.Context, db database.Provider) error {
+	editors, err := database.GetAllWhere[*MatchEditor](ctx, db, func(_ context.Context, e *MatchEditor) bool {
+		return e.MatchId == s.ID
+	})
+	if err != nil {
+		return err
+	}
+	for _, e := range editors {
+		if _, _, err := database.DeleteOneById(ctx, db, e, e.ID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (s *IndividualMatch) NewRecord() database.CrudRecord {
 	return new(IndividualMatch)
 }

--- a/model/individual_match_test.go
+++ b/model/individual_match_test.go
@@ -150,3 +150,30 @@ func TestIndividualPointTotals(t *testing.T) {
 		t.Fatal("expected secondary point to be 13")
 	}
 }
+
+func TestIndividualMatchPostDeleteCascadesEditors(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	scoring := newDefaultStoredScoringStructure(t, db)
+	match1, _ := newStoredMatchPair(t, db, scoring)
+
+	count := func() int {
+		rows, err := database.GetAllWhere[*MatchEditor](context.Background(), db, func(_ context.Context, e *MatchEditor) bool {
+			return e.MatchId == match1.ID
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return len(rows)
+	}
+	if count() == 0 {
+		t.Fatal("expected match to have editors")
+	}
+
+	_, _, err := database.DeleteOneById(context.Background(), db, &IndividualMatch{}, match1.ID.RecordId())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count() != 0 {
+		t.Fatal("expected 0 editors after delete")
+	}
+}

--- a/model/lineup.go
+++ b/model/lineup.go
@@ -87,6 +87,23 @@ func (l *Lineup) GetFormat(ctx context.Context, db database.Provider) (*Format, 
 	return database.GetExistingRecordById(ctx, db, &Format{}, draft.Format.RecordId())
 }
 
+// PostDelete cascades deletion to this lineup's lineup_pairing child rows.
+// Without this, deleting a lineup would orphan those rows (see #97).
+func (l *Lineup) PostDelete(ctx context.Context, db database.Provider) error {
+	pairings, err := database.GetAllWhere[*LineupPairing](ctx, db, func(_ context.Context, p *LineupPairing) bool {
+		return p.LineupId == l.ID
+	})
+	if err != nil {
+		return err
+	}
+	for _, p := range pairings {
+		if _, _, err := database.DeleteOneById(ctx, db, p, p.ID.RecordId()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (l *Lineup) NewRecord() database.CrudRecord {
 	return new(Lineup)
 }

--- a/model/ruleset.go
+++ b/model/ruleset.go
@@ -249,6 +249,37 @@ func (r *Ruleset) RemoveSection(ctx context.Context, db database.Provider, secti
 // Fork creates a new Ruleset that is a copy of this one, with a new owner.
 // The new ruleset gets an incremented revision number and copies all sections
 // from the original ruleset. Returns an error if the ruleset has no sections.
+// PostDelete cascades deletion to this ruleset's rule_section and
+// ruleset_section rows. Without this, deleting a ruleset would orphan those
+// rows (see #97).
+func (r *Ruleset) PostDelete(ctx context.Context, db database.Provider) error {
+	sections, err := database.GetAllWhere[*RuleSection](ctx, db, func(_ context.Context, s *RuleSection) bool {
+		return s.Parent == r.ID
+	})
+	if err != nil {
+		return err
+	}
+	for _, s := range sections {
+		if _, _, err := database.DeleteOneById(ctx, db, s, s.ID.RecordId()); err != nil {
+			return err
+		}
+	}
+
+	relations, err := database.GetAllWhere[*RulesetSection](ctx, db, func(_ context.Context, s *RulesetSection) bool {
+		return s.RulesetId == r.ID
+	})
+	if err != nil {
+		return err
+	}
+	for _, s := range relations {
+		if _, _, err := database.DeleteOneById(ctx, db, s, s.ID); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (r *Ruleset) NewRecord() database.CrudRecord {
 	return new(Ruleset)
 }

--- a/model/ruleset_test.go
+++ b/model/ruleset_test.go
@@ -225,3 +225,49 @@ func TestSupersededByOwnerMustBeIdentical(t *testing.T) {
 	assertRulesetIsDynamicallyInvalid(t, db, r, "does not match this ruleset's owner")
 
 }
+
+func TestRulesetPostDeleteCascadesChildren(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	ruleset := newValidStoredRuleset(t, db)
+
+	section := &RuleSection{Parent: ruleset.ID, Title: "title", Markdown: "contents", Owner: ruleset.Owner}
+	created, err := database.CreateOne(context.Background(), db, section)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = ruleset.AddSection(context.Background(), db, created.ID, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	counts := func() (int, int) {
+		sections, err := database.GetAllWhere[*RuleSection](context.Background(), db, func(_ context.Context, s *RuleSection) bool {
+			return s.Parent == ruleset.ID
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		relations, err := database.GetAllWhere[*RulesetSection](context.Background(), db, func(_ context.Context, s *RulesetSection) bool {
+			return s.RulesetId == ruleset.ID
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return len(sections), len(relations)
+	}
+
+	sections, relations := counts()
+	if sections != 1 || relations != 1 {
+		t.Fatalf("expected 1 section and 1 relation, got sections=%d relations=%d", sections, relations)
+	}
+
+	_, _, err = database.DeleteOneById(context.Background(), db, &Ruleset{}, ruleset.ID.RecordId())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sections, relations = counts()
+	if sections != 0 || relations != 0 {
+		t.Fatalf("expected 0 after delete, got sections=%d relations=%d", sections, relations)
+	}
+}

--- a/model/scoring_structure.go
+++ b/model/scoring_structure.go
@@ -395,6 +395,24 @@ func (c *ScoringStructure) WinningScore(myScore, yourScore int) bool {
 	return false
 }
 
+// PostDelete cascades deletion to this scoring structure's
+// scoring_structure_secondary join rows. Without this, deleting a scoring
+// structure would orphan those rows (see #97).
+func (c *ScoringStructure) PostDelete(ctx context.Context, db database.Provider) error {
+	secondaries, err := database.GetAllWhere[*ScoringStructureSecondary](ctx, db, func(_ context.Context, s *ScoringStructureSecondary) bool {
+		return s.ScoringStructureId == c.ID
+	})
+	if err != nil {
+		return err
+	}
+	for _, s := range secondaries {
+		if _, _, err := database.DeleteOneById(ctx, db, s, s.ID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (c *ScoringStructure) NewRecord() database.CrudRecord {
 	return new(ScoringStructure)
 }

--- a/model/scoring_structure_test.go
+++ b/model/scoring_structure_test.go
@@ -264,3 +264,29 @@ func TestInvalidOwnerId(t *testing.T) {
 	}
 	fmt.Println(err)
 }
+
+func TestScoringStructurePostDeleteCascadesSecondaries(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	sc := newDefaultStoredScoringStructure(t, db)
+
+	count := func() int {
+		rows, err := database.GetAllWhere[*ScoringStructureSecondary](context.Background(), db, func(_ context.Context, s *ScoringStructureSecondary) bool {
+			return s.ScoringStructureId == sc.ID
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return len(rows)
+	}
+	if count() == 0 {
+		t.Fatal("expected scoring structure to have secondaries")
+	}
+
+	_, _, err := database.DeleteOneById(context.Background(), db, &ScoringStructure{}, sc.ID.RecordId())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count() != 0 {
+		t.Fatal("expected 0 secondaries after delete")
+	}
+}

--- a/model/season.go
+++ b/model/season.go
@@ -434,6 +434,49 @@ func (s *Season) IsTeamAssignedToSeason(ctx context.Context, db database.Provide
 	return false
 }
 
+// PostDelete cascades deletion to this season's season_commissioner,
+// season_late_addition, and season_team join rows. Without this, deleting a
+// season would orphan those rows (see #97).
+func (s *Season) PostDelete(ctx context.Context, db database.Provider) error {
+	commissioners, err := database.GetAllWhere[*SeasonCommissioner](ctx, db, func(_ context.Context, c *SeasonCommissioner) bool {
+		return c.SeasonId == s.ID
+	})
+	if err != nil {
+		return err
+	}
+	for _, c := range commissioners {
+		if _, _, err := database.DeleteOneById(ctx, db, c, c.ID); err != nil {
+			return err
+		}
+	}
+
+	lateAdditions, err := database.GetAllWhere[*SeasonLateAddition](ctx, db, func(_ context.Context, c *SeasonLateAddition) bool {
+		return c.SeasonId == s.ID
+	})
+	if err != nil {
+		return err
+	}
+	for _, c := range lateAdditions {
+		if _, _, err := database.DeleteOneById(ctx, db, c, c.ID); err != nil {
+			return err
+		}
+	}
+
+	teams, err := database.GetAllWhere[*SeasonTeam](ctx, db, func(_ context.Context, c *SeasonTeam) bool {
+		return c.SeasonId == s.ID
+	})
+	if err != nil {
+		return err
+	}
+	for _, c := range teams {
+		if _, _, err := database.DeleteOneById(ctx, db, c, c.ID); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (s *Season) NewRecord() database.CrudRecord {
 	return new(Season)
 }

--- a/model/season_test.go
+++ b/model/season_test.go
@@ -66,3 +66,54 @@ func TestCreateSeasonAfterDraft(t *testing.T) {
 	}
 	fmt.Printf("%+v\n", season)
 }
+
+func TestSeasonPostDeleteCascadesChildren(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	season, _ := newDefaultSeasonWithTeams(t, db, 4)
+
+	lateUser := newStoredUser(t, db)
+	_, err := database.CreateOne(context.Background(), db, &SeasonLateAddition{SeasonId: season.ID, UserId: lateUser.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	counts := func() (int, int, int) {
+		commissioners, err := database.GetAllWhere[*SeasonCommissioner](context.Background(), db, func(_ context.Context, r *SeasonCommissioner) bool {
+			return r.SeasonId == season.ID
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		late, err := database.GetAllWhere[*SeasonLateAddition](context.Background(), db, func(_ context.Context, r *SeasonLateAddition) bool {
+			return r.SeasonId == season.ID
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		teams, err := database.GetAllWhere[*SeasonTeam](context.Background(), db, func(_ context.Context, r *SeasonTeam) bool {
+			return r.SeasonId == season.ID
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return len(commissioners), len(late), len(teams)
+	}
+
+	commCount, lateCount, teamCount := counts()
+	if commCount == 0 || teamCount == 0 {
+		t.Fatalf("expected season to have commissioners and teams, got commissioners=%d teams=%d", commCount, teamCount)
+	}
+	if lateCount != 1 {
+		t.Fatalf("expected 1 late addition, got %d", lateCount)
+	}
+
+	_, _, err = database.DeleteOneById(context.Background(), db, &Season{}, season.ID.RecordId())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	commCount, lateCount, teamCount = counts()
+	if commCount != 0 || lateCount != 0 || teamCount != 0 {
+		t.Fatalf("expected 0 after delete, got commissioners=%d late=%d teams=%d", commCount, lateCount, teamCount)
+	}
+}

--- a/model/team.go
+++ b/model/team.go
@@ -478,7 +478,32 @@ func (t *Team) PreDelete(ctx context.Context, db database.Provider) error {
 	return nil
 }
 
-func (t *Team) PostDelete() error {
+// PostDelete cascades deletion to this team's team_rating and team_assignment
+// join rows. Without this, deleting a team would orphan those rows (see #97).
+func (t *Team) PostDelete(ctx context.Context, db database.Provider) error {
+	ratings, err := database.GetAllWhere[*TeamRating](ctx, db, func(_ context.Context, r *TeamRating) bool {
+		return r.TeamId == t.ID
+	})
+	if err != nil {
+		return err
+	}
+	for _, r := range ratings {
+		if _, _, err := database.DeleteOneById(ctx, db, r, r.ID); err != nil {
+			return err
+		}
+	}
+
+	assignments, err := database.GetAllWhere[*TeamAssignment](ctx, db, func(_ context.Context, a *TeamAssignment) bool {
+		return a.TeamId == t.ID
+	})
+	if err != nil {
+		return err
+	}
+	for _, a := range assignments {
+		if _, _, err := database.DeleteOneById(ctx, db, a, a.ID); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/model/team_match.go
+++ b/model/team_match.go
@@ -80,6 +80,23 @@ func (t *TeamMatch) EditableBy(ctx context.Context, db database.Provider) []data
 	return []database.UserId{database.SysAdminUserId}
 }
 
+// PostDelete cascades deletion to this team match's team_match_individual_match
+// join rows. Without this, deleting a team match would orphan those rows (see #97).
+func (t *TeamMatch) PostDelete(ctx context.Context, db database.Provider) error {
+	rows, err := database.GetAllWhere[*TeamMatchIndividualMatch](ctx, db, func(_ context.Context, m *TeamMatchIndividualMatch) bool {
+		return m.TeamMatchId == t.ID
+	})
+	if err != nil {
+		return err
+	}
+	for _, m := range rows {
+		if _, _, err := database.DeleteOneById(ctx, db, m, m.ID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (t *TeamMatch) NewRecord() database.CrudRecord {
 	return new(TeamMatch)
 }

--- a/model/team_match_test.go
+++ b/model/team_match_test.go
@@ -229,3 +229,55 @@ func TestTeamMatchValidateMatchesVsLineup(t *testing.T) {
 	require.NoError(t, err)
 	assert.Error(t, teamMatch.ValidateMatchesVsLineup(context.Background(), db))
 }
+
+func TestTeamMatchPostDeleteCascadesIndividualMatches(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	teamMatch := newStoredTeamMatch(t, db)
+	lineup, err := database.GetExistingRecordById(context.Background(), db, &Lineup{}, teamMatch.Lineup.RecordId())
+	require.NoError(t, err)
+	homeTeam, err := database.GetExistingRecordById(context.Background(), db, &Team{}, teamMatch.HomeTeam.RecordId())
+	require.NoError(t, err)
+	pairing := newStoredLineupPairing(t, db, lineup, homeTeam)
+	match := newStoredIndividualMatch(t, db)
+
+	_, err = teamMatch.AssignIndividualMatch(context.Background(), db, pairing.ID, match.ID)
+	require.NoError(t, err)
+
+	count := func() int {
+		rows, err := database.GetAllWhere[*TeamMatchIndividualMatch](context.Background(), db, func(_ context.Context, r *TeamMatchIndividualMatch) bool {
+			return r.TeamMatchId == teamMatch.ID
+		})
+		require.NoError(t, err)
+		return len(rows)
+	}
+	require.Equal(t, 1, count())
+
+	_, _, err = database.DeleteOneById(context.Background(), db, &TeamMatch{}, teamMatch.ID.RecordId())
+	require.NoError(t, err)
+
+	require.Equal(t, 0, count())
+}
+
+func TestLineupPostDeleteCascadesPairings(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	teamMatch := newStoredTeamMatch(t, db)
+	lineup, err := database.GetExistingRecordById(context.Background(), db, &Lineup{}, teamMatch.Lineup.RecordId())
+	require.NoError(t, err)
+	homeTeam, err := database.GetExistingRecordById(context.Background(), db, &Team{}, teamMatch.HomeTeam.RecordId())
+	require.NoError(t, err)
+	newStoredLineupPairing(t, db, lineup, homeTeam)
+
+	count := func() int {
+		rows, err := database.GetAllWhere[*LineupPairing](context.Background(), db, func(_ context.Context, p *LineupPairing) bool {
+			return p.LineupId == lineup.ID
+		})
+		require.NoError(t, err)
+		return len(rows)
+	}
+	require.Equal(t, 1, count())
+
+	_, _, err = database.DeleteOneById(context.Background(), db, &Lineup{}, lineup.ID.RecordId())
+	require.NoError(t, err)
+
+	require.Equal(t, 0, count())
+}

--- a/model/team_test.go
+++ b/model/team_test.go
@@ -293,3 +293,38 @@ func TestTeamRatingCrudRecordInterface(t *testing.T) {
 	assert.Equal(t, database.UserId(0), blankTr.UserId)
 	assert.Equal(t, RatingId(0), blankTr.RatingId)
 }
+
+func TestTeamPostDeleteCascadesChildren(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	captain := newStoredUser(t, db)
+	team := newStoredTeam(t, db, captain.ID) // creates a TeamAssignment
+
+	member := newStoredUser(t, db)
+	rating := newStoredRating(t, db)
+	tr := &TeamRating{TeamId: team.ID, UserId: member.ID, RatingId: rating.ID}
+	_, err := database.CreateOne(context.Background(), db, tr)
+	require.NoError(t, err)
+
+	counts := func() (int, int) {
+		assignments, err := database.GetAllWhere[*TeamAssignment](context.Background(), db, func(_ context.Context, a *TeamAssignment) bool {
+			return a.TeamId == team.ID
+		})
+		require.NoError(t, err)
+		ratings, err := database.GetAllWhere[*TeamRating](context.Background(), db, func(_ context.Context, r *TeamRating) bool {
+			return r.TeamId == team.ID
+		})
+		require.NoError(t, err)
+		return len(assignments), len(ratings)
+	}
+
+	assignments, ratings := counts()
+	require.Greater(t, assignments, 0)
+	require.Greater(t, ratings, 0)
+
+	_, _, err = database.DeleteOneById(context.Background(), db, &Team{}, team.ID.RecordId())
+	require.NoError(t, err)
+
+	assignments, ratings = counts()
+	assert.Equal(t, 0, assignments)
+	assert.Equal(t, 0, ratings)
+}

--- a/model/user.go
+++ b/model/user.go
@@ -100,6 +100,23 @@ func (u *User) DynamicallyValid(ctx context.Context, db database.Provider) error
 	return nil
 }
 
+// PostDelete cascades deletion to this user's user_role_assignment rows.
+// Without this, deleting a user would orphan those rows (see #97).
+func (u *User) PostDelete(ctx context.Context, db database.Provider) error {
+	assignments, err := database.GetAllWhere[*UserRoleAssignment](ctx, db, func(_ context.Context, a *UserRoleAssignment) bool {
+		return a.UserId == u.ID
+	})
+	if err != nil {
+		return err
+	}
+	for _, a := range assignments {
+		if _, _, err := database.DeleteOneById(ctx, db, a, a.ID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (u *User) NewRecord() database.CrudRecord {
 	return new(User)
 }

--- a/model/user_test.go
+++ b/model/user_test.go
@@ -323,3 +323,28 @@ func TestUserDynamicallyValid(t *testing.T) {
 	err := user.DynamicallyValid(ctx, db)
 	assert.NoError(t, err)
 }
+
+func TestUserPostDeleteCascadesRoleAssignments(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	user := newStoredUser(t, db)
+
+	_, err := database.CreateOne(context.Background(), db, &UserRoleAssignment{
+		UserId: user.ID,
+		Role:   SystemAdministrator,
+	})
+	require.NoError(t, err)
+
+	count := func() int {
+		rows, err := database.GetAllWhere[*UserRoleAssignment](context.Background(), db, func(_ context.Context, r *UserRoleAssignment) bool {
+			return r.UserId == user.ID
+		})
+		require.NoError(t, err)
+		return len(rows)
+	}
+	require.Equal(t, 1, count())
+
+	_, _, err = database.DeleteOneById(context.Background(), db, &User{}, user.ID.RecordId())
+	require.NoError(t, err)
+
+	require.Equal(t, 0, count())
+}


### PR DESCRIPTION
Closes #97

Mirrors the #94 delete-cascade fix: adds a `PostDelete` hook to every affected parent so deleting a parent cleans up its child/join rows instead of orphaning them.

## Cascade hooks added
- `Team` -> `team_ratings`, `team_assignments` (replaces the previous dead no-arg `PostDelete`)
- `Draft` -> `draft_available_players`, `draft_captains`, `draft_formats`, `draft_picks`, `draft_rating_cutoffs`, `pre_draft_grades`
- `Season` -> `season_commissioners`, `season_late_additions`, `season_teams`
- `User` -> `user_role_assignments`
- `Ruleset` -> `rule_sections`, `ruleset_sections`
- `ScoringStructure` -> `scoring_structure_secondaries`
- `IndividualMatch` -> `match_editors`
- `TeamMatch` -> `team_match_individual_matches`
- `Lineup` -> `lineup_pairings`
- `Blurb` -> `blurb_photos`, `blurb_reactions`
- `Comment` -> `comment_reactions`
- `CommissionerProposal` -> `commissioner_proposal_votes`

## Tests
Adds a cascade test per parent that creates child rows, deletes the parent, and asserts the child rows are gone. `go build ./...`, `go test ./...`, and `go vet ./...` all pass.

Note: the ticket lists `TeamMatch -> team_matches` as a child, but the only table that references `team_match` is `team_match_individual_match` (`team_matches` is the parent table's own plural). The cascade covers the actual FK child.