### PR TITLE
UI: general-purpose ScoringStructure CRUD page (#84)

### DIFF
--- a/ui/e2e/scoring-structure.spec.ts
+++ b/ui/e2e/scoring-structure.spec.ts
@@ -1,0 +1,69 @@
+import { expect, test, type Page } from '@playwright/test';
+
+// The Go backend runs with --dev-token from the repo root (see
+// playwright.config.ts), so POST /api/one_time_password returns the magic-link
+// token in the response body. Login with the user seeded by SeedDevData.
+async function login(page: Page) {
+	await page.goto('/login');
+	await page.waitForLoadState('networkidle');
+	await page.getByLabel('Email').fill('jdarthur@gatech.edu');
+	await page.getByRole('button', { name: 'Send login link' }).click();
+	const link = page.getByRole('main').getByRole('link', { name: 'Log in' });
+	await expect(link).toBeVisible();
+	await link.click();
+	await expect(page).toHaveURL('/');
+}
+
+test('scoring structure CRUD: create, view, update, delete', async ({ page }) => {
+	await login(page);
+
+	const unique = Date.now();
+
+	// Create
+	await page.goto('/scoring-structures');
+	await page.getByRole('link', { name: 'New scoring structure' }).click();
+	await expect(page).toHaveURL(/\/scoring-structures\/new$/);
+	await page.getByLabel('Name').fill(`Test Scoring Structure ${unique}`);
+	await page.getByLabel('Score counting type').selectOption({ label: 'Game' });
+	await page.getByLabel('Win threshold', { exact: true }).fill('5');
+	await page.getByLabel('Must win by', { exact: true }).fill('2');
+	await page.getByLabel('Instant win threshold', { exact: true }).fill('0');
+	await page.getByRole('button', { name: 'Create scoring structure' }).click();
+
+	// View: lands on the detail page with the submitted values reflected
+	await expect(page).toHaveURL(/\/scoring-structures\/[0-9a-f]+$/);
+	await expect(
+		page.getByRole('heading', { name: `Test Scoring Structure ${unique}` })
+	).toBeVisible();
+	await expect(page.getByLabel('Score counting type')).toHaveValue('1'); // Game
+	await expect(page.getByLabel('Win threshold', { exact: true })).toHaveValue('5');
+	await expect(page.getByLabel('Must win by', { exact: true })).toHaveValue('2');
+
+	// Update
+	await page.getByLabel('Name').fill(`Test Scoring Structure ${unique} Updated`);
+	await page.getByLabel('Score counting type').selectOption({ label: 'Set' });
+	await page.getByLabel('Win threshold', { exact: true }).fill('3');
+	await page.getByRole('button', { name: 'Save changes' }).click();
+	await expect(
+		page.getByRole('heading', { name: `Test Scoring Structure ${unique} Updated` })
+	).toBeVisible();
+	await expect(page.getByLabel('Score counting type')).toHaveValue('2'); // Set
+	await expect(page.getByLabel('Win threshold', { exact: true })).toHaveValue('3');
+
+	// The list reflects the update
+	await page.goto('/scoring-structures');
+	const row = page.getByRole('link', { name: `Test Scoring Structure ${unique} Updated` });
+	await expect(row).toBeVisible();
+
+	// Delete (accept the confirm dialog)
+	await row.click();
+	await expect(
+		page.getByRole('heading', { name: `Test Scoring Structure ${unique} Updated` })
+	).toBeVisible();
+	page.on('dialog', (d) => d.accept());
+	await page.getByRole('button', { name: 'Delete scoring structure' }).click();
+	await expect(page).toHaveURL('/scoring-structures');
+	await expect(
+		page.getByRole('link', { name: `Test Scoring Structure ${unique} Updated` })
+	).toHaveCount(0);
+});

--- a/ui/src/lib/components/NavBar.svelte
+++ b/ui/src/lib/components/NavBar.svelte
@@ -18,6 +18,7 @@
 		<a href="/formats">Formats</a>
 		<a href="/ratings">Ratings</a>
 		<a href="/rulesets">Rulesets</a>
+		<a href="/scoring-structures">Scoring Structures</a>
 	</div>
 	<div class="actions">
 		{#if loggedIn}

--- a/ui/src/lib/scoringStructure.ts
+++ b/ui/src/lib/scoringStructure.ts
@@ -1,0 +1,106 @@
+// ScoringStructure API client. ScoringStructure records are backed by the
+// existing REST CRUD routes generated from `model.ScoringStructure` (see
+// main.go) plus the score-counting-type enumeration endpoint:
+//
+//	GET    /api/scoring_structure        -> { resource: ScoringStructure[] }
+//	GET    /api/scoring_structure/:id    -> { resource: ScoringStructure }
+//	POST   /api/scoring_structure        -> { resource: ScoringStructure }  (owner = token user)
+//	PUT    /api/scoring_structure/:id    -> { resource: ScoringStructure }
+//	DELETE /api/scoring_structure/:id    -> { resource: ScoringStructure }
+//	GET    /api/score_counting_types     -> { resource: ScoreCountingType[] }
+//
+// A ScoringStructure is how a match is scored (win condition + counting
+// type), owned by a User. Record IDs are 16-char hex strings; an empty string
+// represents "not set" (InvalidRecordId).
+import { authFetch } from '$lib/auth';
+
+export interface WinCondition {
+	win_threshold: number;
+	must_win_by: number;
+	instant_win_threshold: number;
+}
+
+export interface ScoringStructure {
+	id: string;
+	owner: string;
+	name: string;
+	win_condition_counting_type: number;
+	win_condition: WinCondition;
+}
+
+export interface ScoreCountingType {
+	type: number;
+	name: string;
+}
+
+export interface ScoringStructureInput {
+	name: string;
+	win_condition_counting_type: number;
+	win_condition: WinCondition;
+}
+
+const BASE = '/api/scoring_structure';
+const COUNTING_TYPES_BASE = '/api/score_counting_types';
+
+// unwrap parses a CrudCommon response (`{ resource: ... }`) and throws the
+// backend error message on non-2xx responses so callers can surface it.
+async function unwrap(res: Response): Promise<any> {
+	if (!res.ok) {
+		let message = `Request failed (${res.status})`;
+		try {
+			const body = await res.json();
+			if (body?.error) message = body.error;
+		} catch {
+			// non-JSON error body; fall back to the status message
+		}
+		throw new Error(message);
+	}
+	const body = await res.json();
+	return body?.resource;
+}
+
+export async function listScoringStructures(): Promise<ScoringStructure[]> {
+	return unwrap(await authFetch(BASE));
+}
+
+export async function getScoringStructure(id: string): Promise<ScoringStructure> {
+	return unwrap(await authFetch(`${BASE}/${id}`));
+}
+
+export async function getScoreCountingTypes(): Promise<ScoreCountingType[]> {
+	return unwrap(await authFetch(COUNTING_TYPES_BASE));
+}
+
+export async function createScoringStructure(input: ScoringStructureInput): Promise<ScoringStructure> {
+	return unwrap(
+		await authFetch(BASE, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(input)
+		})
+	);
+}
+
+export async function updateScoringStructure(id: string, input: ScoringStructureInput): Promise<ScoringStructure> {
+	return unwrap(
+		await authFetch(`${BASE}/${id}`, {
+			method: 'PUT',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(input)
+		})
+	);
+}
+
+export async function deleteScoringStructure(id: string): Promise<void> {
+	const res = await authFetch(`${BASE}/${id}`, { method: 'DELETE' });
+	if (!res.ok) {
+		let message = `Delete failed (${res.status})`;
+		try {
+			const body = await res.json();
+			if (body?.error) message = body.error;
+		} catch {
+			// non-JSON error body; fall back to the status message
+		}
+		throw new Error(message);
+	}
+}

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -11,7 +11,7 @@
 
 {#if loggedIn}
 	<h1>Welcome to IntraClub</h1>
-	<p>Head to <a href="/facilities">Facilities</a>, <a href="/formats">Formats</a>, <a href="/ratings">Ratings</a>, or <a href="/rulesets">Rulesets</a> to get started.</p>
+	<p>Head to <a href="/facilities">Facilities</a>, <a href="/formats">Formats</a>, <a href="/ratings">Ratings</a>, <a href="/rulesets">Rulesets</a>, or <a href="/scoring-structures">Scoring Structures</a> to get started.</p>
 {:else}
 	<h1>IntraClub</h1>
 	<p>Welcome! Log in to manage your club.</p>

--- a/ui/src/routes/scoring-structures/+page.svelte
+++ b/ui/src/routes/scoring-structures/+page.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { listScoringStructures, getScoreCountingTypes } from '$lib/scoringStructure';
+	import type { ScoringStructure, ScoreCountingType } from '$lib/scoringStructure';
+
+	let structures = $state<ScoringStructure[]>([]);
+	let countingTypes = $state<ScoreCountingType[]>([]);
+	let loading = $state(true);
+	let error = $state('');
+
+	function countingTypeName(type: number): string {
+		return countingTypes.find((t) => t.type === type)?.name ?? String(type);
+	}
+
+	onMount(async () => {
+		try {
+			[structures, countingTypes] = await Promise.all([
+				listScoringStructures(),
+				getScoreCountingTypes()
+			]);
+		} catch (e) {
+			error = e instanceof Error ? e.message : 'Failed to load scoring structures';
+		} finally {
+			loading = false;
+		}
+	});
+</script>
+
+<svelte:head>
+	<title>Scoring Structures</title>
+</svelte:head>
+
+<h1>Scoring Structures</h1>
+<a href="/scoring-structures/new">New scoring structure</a>
+
+{#if loading}
+	<p>Loading...</p>
+{:else if error}
+	<p class="error">{error}</p>
+{:else if structures.length === 0}
+	<p>No scoring structures yet.</p>
+{:else}
+	<table>
+		<thead>
+			<tr>
+				<th>Name</th>
+				<th>Counting type</th>
+				<th>Win threshold</th>
+			</tr>
+		</thead>
+		<tbody>
+			{#each structures as structure}
+				<tr>
+					<td><a href={`/scoring-structures/${structure.id}`}>{structure.name}</a></td>
+					<td>{countingTypeName(structure.win_condition_counting_type)}</td>
+					<td>{structure.win_condition.win_threshold}</td>
+				</tr>
+			{/each}
+		</tbody>
+	</table>
+{/if}
+
+<style>
+	.error {
+		color: #c00;
+	}
+	table {
+		border-collapse: collapse;
+		margin-top: 1rem;
+	}
+	th,
+	td {
+		border: 1px solid #ccc;
+		padding: 0.4rem 0.8rem;
+		text-align: left;
+	}
+</style>

--- a/ui/src/routes/scoring-structures/[id]/+page.svelte
+++ b/ui/src/routes/scoring-structures/[id]/+page.svelte
@@ -1,0 +1,201 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { page } from '$app/state';
+	import { goto } from '$app/navigation';
+	import {
+		getScoringStructure,
+		getScoreCountingTypes,
+		updateScoringStructure,
+		deleteScoringStructure
+	} from '$lib/scoringStructure';
+	import type { ScoringStructure, ScoreCountingType } from '$lib/scoringStructure';
+
+	const id = () => page.params.id as string;
+
+	let structure = $state<ScoringStructure | null>(null);
+	let countingTypes = $state<ScoreCountingType[]>([]);
+	let loadError = $state('');
+	let name = $state('');
+	let countingType = $state<number>(0);
+	let winThreshold = $state<string>('');
+	let mustWinBy = $state<string>('');
+	let instantWinThreshold = $state<string>('');
+	let error = $state('');
+	let saving = $state(false);
+	let deleting = $state(false);
+
+	function countingTypeName(type: number): string {
+		return countingTypes.find((t) => t.type === type)?.name ?? String(type);
+	}
+
+	onMount(async () => {
+		try {
+			countingTypes = await getScoreCountingTypes();
+		} catch (e) {
+			loadError = e instanceof Error ? e.message : 'Failed to load score counting types';
+			return;
+		}
+		load();
+	});
+
+	async function load() {
+		loadError = '';
+		try {
+			const s = await getScoringStructure(id());
+			structure = s;
+			name = s.name;
+			countingType = s.win_condition_counting_type;
+			winThreshold = String(s.win_condition.win_threshold);
+			mustWinBy = String(s.win_condition.must_win_by);
+			instantWinThreshold = String(s.win_condition.instant_win_threshold);
+		} catch (e) {
+			loadError = e instanceof Error ? e.message : 'Failed to load scoring structure';
+		}
+	}
+
+	async function handleSave(e: Event) {
+		e.preventDefault();
+		error = '';
+		saving = true;
+		try {
+			const updated = await updateScoringStructure(id(), {
+				name: name.trim(),
+				win_condition_counting_type: countingType,
+				win_condition: {
+					win_threshold: parseInt(winThreshold, 10),
+					must_win_by: parseInt(mustWinBy, 10),
+					instant_win_threshold: parseInt(instantWinThreshold || '0', 10)
+				}
+			});
+			structure = updated;
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Failed to update scoring structure';
+		} finally {
+			saving = false;
+		}
+	}
+
+	async function handleDelete() {
+		if (!confirm('Delete this scoring structure?')) return;
+		error = '';
+		deleting = true;
+		try {
+			await deleteScoringStructure(id());
+			await goto('/scoring-structures');
+		} catch (err) {
+			// e.g. the structure is referenced by a Schedule/PlayoffStructure and PreDelete blocks it
+			error = err instanceof Error ? err.message : 'Failed to delete scoring structure';
+			deleting = false;
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>{structure ? structure.name : 'Scoring Structure'}</title>
+</svelte:head>
+
+{#if loadError}
+	<h1>Scoring Structure</h1>
+	<p class="error">{loadError}</p>
+	<a href="/scoring-structures">&larr; Back to scoring structures</a>
+{:else if !structure}
+	<h1>Scoring Structure</h1>
+	<p>Loading...</p>
+{:else}
+	<h1>{structure.name}</h1>
+	<a href="/scoring-structures">&larr; Back to scoring structures</a>
+
+	<dl class="meta">
+		<div>
+			<dt>Counting type</dt>
+			<dd>{countingTypeName(structure.win_condition_counting_type)}</dd>
+		</div>
+		<div>
+			<dt>Win threshold</dt>
+			<dd>{structure.win_condition.win_threshold}</dd>
+		</div>
+		<div>
+			<dt>Must win by</dt>
+			<dd>{structure.win_condition.must_win_by}</dd>
+		</div>
+		<div>
+			<dt>Instant win threshold</dt>
+			<dd>{structure.win_condition.instant_win_threshold}</dd>
+		</div>
+	</dl>
+
+	<h2>Edit</h2>
+	<form onsubmit={handleSave}>
+		<label>
+			Name
+			<input type="text" bind:value={name} required />
+		</label>
+		<label>
+			Score counting type
+			<select bind:value={countingType}>
+				{#each countingTypes as ct}
+					<option value={ct.type}>{ct.name}</option>
+				{/each}
+			</select>
+		</label>
+		<label>
+			Win threshold
+			<input type="number" min="1" bind:value={winThreshold} required />
+		</label>
+		<label>
+			Must win by
+			<input type="number" min="1" bind:value={mustWinBy} required />
+		</label>
+		<label>
+			Instant win threshold
+			<input type="number" min="0" bind:value={instantWinThreshold} placeholder="0 (disabled)" />
+		</label>
+		<button type="submit" disabled={saving}>{saving ? 'Saving...' : 'Save changes'}</button>
+	</form>
+
+	<button type="button" onclick={handleDelete} disabled={deleting} class="danger">
+		{deleting ? 'Deleting...' : 'Delete scoring structure'}
+	</button>
+
+	{#if error}
+		<p class="error">{error}</p>
+	{/if}
+{/if}
+
+<style>
+	.error {
+		color: #c00;
+	}
+	.meta {
+		display: flex;
+		gap: 1.5rem;
+		margin: 1rem 0;
+	}
+	.meta dt {
+		font-size: 0.85rem;
+		color: #666;
+	}
+	.meta dd {
+		margin: 0;
+	}
+	form {
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+		max-width: 24rem;
+		margin-top: 0.5rem;
+	}
+	label {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+	}
+	input,
+	select {
+		padding: 0.35rem;
+	}
+	.danger {
+		margin-top: 1rem;
+		color: #c00;
+	}
+</style>

--- a/ui/src/routes/scoring-structures/new/+page.svelte
+++ b/ui/src/routes/scoring-structures/new/+page.svelte
@@ -1,0 +1,107 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { createScoringStructure, getScoreCountingTypes } from '$lib/scoringStructure';
+	import type { ScoreCountingType } from '$lib/scoringStructure';
+	import { goto } from '$app/navigation';
+
+	let countingTypes = $state<ScoreCountingType[]>([]);
+	let name = $state('');
+	let countingType = $state<number>(0);
+	let winThreshold = $state<string>('1');
+	let mustWinBy = $state<string>('1');
+	let instantWinThreshold = $state<string>('0');
+	let error = $state('');
+	let submitting = $state(false);
+
+	onMount(async () => {
+		try {
+			countingTypes = await getScoreCountingTypes();
+			if (countingTypes.length > 0) countingType = countingTypes[0].type;
+		} catch (e) {
+			error = e instanceof Error ? e.message : 'Failed to load score counting types';
+		}
+	});
+
+	async function handleSubmit(e: Event) {
+		e.preventDefault();
+		error = '';
+		submitting = true;
+		try {
+			const created = await createScoringStructure({
+				name: name.trim(),
+				win_condition_counting_type: countingType,
+				win_condition: {
+					win_threshold: parseInt(winThreshold, 10),
+					must_win_by: parseInt(mustWinBy, 10),
+					instant_win_threshold: parseInt(instantWinThreshold || '0', 10)
+				}
+			});
+			await goto(`/scoring-structures/${created.id}`);
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Failed to create scoring structure';
+		} finally {
+			submitting = false;
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>New scoring structure</title>
+</svelte:head>
+
+<h1>New scoring structure</h1>
+<a href="/scoring-structures">&larr; Back to scoring structures</a>
+
+<form onsubmit={handleSubmit}>
+	<label>
+		Name
+		<input type="text" bind:value={name} required />
+	</label>
+	<label>
+		Score counting type
+		<select bind:value={countingType}>
+			{#each countingTypes as ct}
+				<option value={ct.type}>{ct.name}</option>
+			{/each}
+		</select>
+	</label>
+	<label>
+		Win threshold
+		<input type="number" min="1" bind:value={winThreshold} required />
+	</label>
+	<label>
+		Must win by
+		<input type="number" min="1" bind:value={mustWinBy} required />
+	</label>
+	<label>
+		Instant win threshold
+		<input type="number" min="0" bind:value={instantWinThreshold} placeholder="0 (disabled)" />
+	</label>
+	<button type="submit" disabled={submitting}>{submitting ? 'Creating...' : 'Create scoring structure'}</button>
+</form>
+
+{#if error}
+	<p class="error">{error}</p>
+{/if}
+
+<style>
+	.error {
+		color: #c00;
+	}
+	form {
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+		max-width: 24rem;
+		margin-top: 1rem;
+	}
+	label {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+	}
+	input,
+	select {
+		padding: 0.35rem;
+	}
+</style>


### PR DESCRIPTION
Implements #84 — a general-purpose CRUD page for `ScoringStructure`, backed by the existing REST CRUD routes (`/api/scoring_structure`) and the `/api/score_counting_types` enumeration endpoint.

## What's included
- `ui/src/lib/scoringStructure.ts` — API client (list/get/create/update/delete + score counting types)
- `ui/src/routes/scoring-structures/+page.svelte` — list page
- `ui/src/routes/scoring-structures/[id]/+page.svelte` — detail view + edit form + delete
- `ui/src/routes/scoring-structures/new/+page.svelte` — create form (name, counting type select from `/score_counting_types`, win condition fields)
- Nav links in `NavBar.svelte` and the landing page
- `ui/e2e/scoring-structure.spec.ts` — Playwright e2e covering create → view → update → delete

## Verification
- `npm run check` (svelte-kit sync + svelte-check): 0 errors, 0 warnings
- `npx playwright test e2e/scoring-structure.spec.ts`: passed