### PR TITLE
UI: general-purpose PlayoffStructure CRUD page (#85)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,9 @@ dockertest:
 	@docker build -t $(TEST_DOCKER_NAME) -f Dockerfile.test .
 
 e2e:
+	$(info Resetting SQLite DB for a clean e2e baseline)
+	@db="$${INTRACLUB_DB_PATH:-intraclub.db}"; \
+	rm -f "$$db" "$$db-wal" "$$db-shm"
 	$(info Running Playwright e2e tests (headless, from ./ui))
 	@cd ui && npm run test:e2e
 

--- a/main.go
+++ b/main.go
@@ -96,6 +96,9 @@ func main() {
 
 	rg.GET("/draft_order_patterns", model.GetDraftOrderPatterns)
 
+	playoffStructures := api.NewCrudCommon(model.NewPlayoffStructure, false, db)
+	playoffStructures.HandleRouteTypes(rg, api.CrudWrapperFunctionAll...)
+
 	err = r.Run(cfg.addr)
 	if err != nil {
 		panic(err)

--- a/model/playoff_structure.go
+++ b/model/playoff_structure.go
@@ -11,6 +11,15 @@ import (
 
 type PlayoffStructureId database.RecordId
 
+func (id PlayoffStructureId) UnmarshalJSON(bytes []byte) error {
+	rid := id.RecordId()
+	return (*database.RecordId)(&rid).UnmarshalJSON(bytes)
+}
+
+func (id PlayoffStructureId) MarshalJSON() ([]byte, error) {
+	return id.RecordId().MarshalJSON()
+}
+
 func (id PlayoffStructureId) RecordId() database.RecordId {
 	return database.RecordId(id)
 }
@@ -21,9 +30,9 @@ func (id PlayoffStructureId) String() string {
 
 type PlayoffStructure struct {
 	ID            PlayoffStructureId `json:"id"` // unique ID for this record
-	UserId        database.UserId
-	Byes          int // number of teams which get a bye week
-	NumberOfTeams int // number of teams which make the playoffs
+	UserId        database.UserId    `json:"user_id"`
+	Byes          int                `json:"byes"`           // number of teams which get a bye week
+	NumberOfTeams int                `json:"number_of_teams"` // number of teams which make the playoffs
 }
 
 func (p *PlayoffStructure) GetOwner() database.UserId {

--- a/ui/e2e/playoff-structure.spec.ts
+++ b/ui/e2e/playoff-structure.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test, type Page } from '@playwright/test';
+
+// The Go backend runs with --dev-token from the repo root (see
+// playwright.config.ts), so POST /api/one_time_password returns the magic-link
+// token in the response body. Login with the user seeded by SeedDevData.
+async function login(page: Page) {
+	await page.goto('/login');
+	await page.waitForLoadState('networkidle');
+	await page.getByLabel('Email').fill('jdarthur@gatech.edu');
+	await page.getByRole('button', { name: 'Send login link' }).click();
+	const link = page.getByRole('main').getByRole('link', { name: 'Log in' });
+	await expect(link).toBeVisible();
+	await link.click();
+	await expect(page).toHaveURL('/');
+}
+
+test('playoff structure CRUD: create, view, update, delete', async ({ page }) => {
+	await login(page);
+
+	// Create (8 teams, 0 byes -> 4 first-round matchups, a valid bracket)
+	await page.goto('/playoff-structures');
+	await page.getByRole('link', { name: 'New playoff structure' }).click();
+	await expect(page).toHaveURL(/\/playoff-structures\/new$/);
+	await page.getByLabel('Byes').fill('0');
+	await page.getByLabel('Number of teams').fill('8');
+	await page.getByRole('button', { name: 'Create playoff structure' }).click();
+
+	// View: lands on the detail page with the submitted values reflected
+	await expect(page).toHaveURL(/\/playoff-structures\/[0-9a-f]+$/);
+	await expect(page.getByRole('heading', { name: 'Playoff Structure' })).toBeVisible();
+	await expect(page.getByLabel('Byes')).toHaveValue('0');
+	await expect(page.getByLabel('Number of teams')).toHaveValue('8');
+
+	// The record's detail path uniquely identifies it (configs like "0 byes /
+	// 8 teams" are not unique, so select the list row by href rather than text).
+	const recordLink = page.locator(`a[href="${new URL(page.url()).pathname}"]`);
+
+	// Update: 8 -> 4 teams keeps a valid bracket (2 first-round matchups)
+	await page.getByLabel('Number of teams').fill('4');
+	await page.getByRole('button', { name: 'Save changes' }).click();
+	await expect(page.getByLabel('Number of teams')).toHaveValue('4');
+
+	// The list reflects the update
+	await page.goto('/playoff-structures');
+	await expect(recordLink).toHaveText('0 byes / 4 teams');
+
+	// Delete (accept the confirm dialog)
+	await recordLink.click();
+	await expect(page).toHaveURL(/\/playoff-structures\/[0-9a-f]+$/);
+	page.on('dialog', (d) => d.accept());
+	await page.getByRole('button', { name: 'Delete playoff structure' }).click();
+	await expect(page).toHaveURL('/playoff-structures');
+	await expect(recordLink).toHaveCount(0);
+});

--- a/ui/src/lib/components/NavBar.svelte
+++ b/ui/src/lib/components/NavBar.svelte
@@ -18,6 +18,7 @@
 		<a href="/formats">Formats</a>
 		<a href="/ratings">Ratings</a>
 		<a href="/rulesets">Rulesets</a>
+		<a href="/playoff-structures">Playoff Structures</a>
 	</div>
 	<div class="actions">
 		{#if loggedIn}

--- a/ui/src/lib/playoffStructure.ts
+++ b/ui/src/lib/playoffStructure.ts
@@ -1,0 +1,87 @@
+// PlayoffStructure API client. PlayoffStructure records are backed by the
+// existing REST CRUD routes generated from `model.PlayoffStructure` (see
+// main.go):
+//
+//	GET    /api/playoff_structure     -> { resource: PlayoffStructure[] }
+//	GET    /api/playoff_structure/:id -> { resource: PlayoffStructure }
+//	POST   /api/playoff_structure     -> { resource: PlayoffStructure }  (owner = token user)
+//	PUT    /api/playoff_structure/:id -> { resource: PlayoffStructure }
+//	DELETE /api/playoff_structure/:id -> { resource: PlayoffStructure }
+//
+// A PlayoffStructure is the playoff bracket shape (number of teams that make
+// the playoffs, and how many get a bye week), owned by a User. Record IDs are
+// 16-char hex strings; an empty string represents "not set" (InvalidRecordId).
+import { authFetch } from '$lib/auth';
+
+export interface PlayoffStructure {
+	id: string;
+	user_id: string;
+	byes: number;
+	number_of_teams: number;
+}
+
+export interface PlayoffStructureInput {
+	byes: number;
+	number_of_teams: number;
+}
+
+const BASE = '/api/playoff_structure';
+
+// unwrap parses a CrudCommon response (`{ resource: ... }`) and throws the
+// backend error message on non-2xx responses so callers can surface it.
+async function unwrap(res: Response): Promise<any> {
+	if (!res.ok) {
+		let message = `Request failed (${res.status})`;
+		try {
+			const body = await res.json();
+			if (body?.error) message = body.error;
+		} catch {
+			// non-JSON error body; fall back to the status message
+		}
+		throw new Error(message);
+	}
+	const body = await res.json();
+	return body?.resource;
+}
+
+export async function listPlayoffStructures(): Promise<PlayoffStructure[]> {
+	return unwrap(await authFetch(BASE));
+}
+
+export async function getPlayoffStructure(id: string): Promise<PlayoffStructure> {
+	return unwrap(await authFetch(`${BASE}/${id}`));
+}
+
+export async function createPlayoffStructure(input: PlayoffStructureInput): Promise<PlayoffStructure> {
+	return unwrap(
+		await authFetch(BASE, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(input)
+		})
+	);
+}
+
+export async function updatePlayoffStructure(id: string, input: PlayoffStructureInput): Promise<PlayoffStructure> {
+	return unwrap(
+		await authFetch(`${BASE}/${id}`, {
+			method: 'PUT',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(input)
+		})
+	);
+}
+
+export async function deletePlayoffStructure(id: string): Promise<void> {
+	const res = await authFetch(`${BASE}/${id}`, { method: 'DELETE' });
+	if (!res.ok) {
+		let message = `Delete failed (${res.status})`;
+		try {
+			const body = await res.json();
+			if (body?.error) message = body.error;
+		} catch {
+			// non-JSON error body; fall back to the status message
+		}
+		throw new Error(message);
+	}
+}

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -11,7 +11,7 @@
 
 {#if loggedIn}
 	<h1>Welcome to IntraClub</h1>
-	<p>Head to <a href="/facilities">Facilities</a>, <a href="/formats">Formats</a>, <a href="/ratings">Ratings</a>, or <a href="/rulesets">Rulesets</a> to get started.</p>
+	<p>Head to <a href="/facilities">Facilities</a>, <a href="/formats">Formats</a>, <a href="/ratings">Ratings</a>, <a href="/rulesets">Rulesets</a>, or <a href="/playoff-structures">Playoff Structures</a> to get started.</p>
 {:else}
 	<h1>IntraClub</h1>
 	<p>Welcome! Log in to manage your club.</p>

--- a/ui/src/routes/playoff-structures/+page.svelte
+++ b/ui/src/routes/playoff-structures/+page.svelte
@@ -1,0 +1,65 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { listPlayoffStructures } from '$lib/playoffStructure';
+	import type { PlayoffStructure } from '$lib/playoffStructure';
+
+	let structures = $state<PlayoffStructure[]>([]);
+	let loading = $state(true);
+	let error = $state('');
+
+	onMount(async () => {
+		try {
+			structures = await listPlayoffStructures();
+		} catch (e) {
+			error = e instanceof Error ? e.message : 'Failed to load playoff structures';
+		} finally {
+			loading = false;
+		}
+	});
+</script>
+
+<svelte:head>
+	<title>Playoff Structures</title>
+</svelte:head>
+
+<h1>Playoff Structures</h1>
+<a href="/playoff-structures/new">New playoff structure</a>
+
+{#if loading}
+	<p>Loading...</p>
+{:else if error}
+	<p class="error">{error}</p>
+{:else if structures.length === 0}
+	<p>No playoff structures yet.</p>
+{:else}
+	<table>
+		<thead>
+			<tr>
+				<th>Playoff structure</th>
+			</tr>
+		</thead>
+		<tbody>
+			{#each structures as structure}
+				<tr>
+					<td><a href={`/playoff-structures/${structure.id}`}>{structure.byes} byes / {structure.number_of_teams} teams</a></td>
+				</tr>
+			{/each}
+		</tbody>
+	</table>
+{/if}
+
+<style>
+	.error {
+		color: #c00;
+	}
+	table {
+		border-collapse: collapse;
+		margin-top: 1rem;
+	}
+	th,
+	td {
+		border: 1px solid #ccc;
+		padding: 0.4rem 0.8rem;
+		text-align: left;
+	}
+</style>

--- a/ui/src/routes/playoff-structures/[id]/+page.svelte
+++ b/ui/src/routes/playoff-structures/[id]/+page.svelte
@@ -143,8 +143,7 @@
 		flex-direction: column;
 		gap: 0.25rem;
 	}
-	input,
-	select {
+	input {
 		padding: 0.35rem;
 	}
 	.danger {

--- a/ui/src/routes/playoff-structures/[id]/+page.svelte
+++ b/ui/src/routes/playoff-structures/[id]/+page.svelte
@@ -1,0 +1,154 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { page } from '$app/state';
+	import { goto } from '$app/navigation';
+	import {
+		getPlayoffStructure,
+		updatePlayoffStructure,
+		deletePlayoffStructure
+	} from '$lib/playoffStructure';
+	import type { PlayoffStructure } from '$lib/playoffStructure';
+
+	const id = () => page.params.id as string;
+
+	let structure = $state<PlayoffStructure | null>(null);
+	let loadError = $state('');
+	let byes = $state<string>('');
+	let numberOfTeams = $state<string>('');
+	let error = $state('');
+	let saving = $state(false);
+	let deleting = $state(false);
+
+	onMount(load);
+
+	async function load() {
+		loadError = '';
+		try {
+			const s = await getPlayoffStructure(id());
+			structure = s;
+			byes = String(s.byes);
+			numberOfTeams = String(s.number_of_teams);
+		} catch (e) {
+			loadError = e instanceof Error ? e.message : 'Failed to load playoff structure';
+		}
+	}
+
+	async function handleSave(e: Event) {
+		e.preventDefault();
+		error = '';
+		saving = true;
+		try {
+			const updated = await updatePlayoffStructure(id(), {
+				byes: parseInt(byes || '0', 10),
+				number_of_teams: parseInt(numberOfTeams, 10)
+			});
+			structure = updated;
+			byes = String(updated.byes);
+			numberOfTeams = String(updated.number_of_teams);
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Failed to update playoff structure';
+		} finally {
+			saving = false;
+		}
+	}
+
+	async function handleDelete() {
+		if (!confirm('Delete this playoff structure?')) return;
+		error = '';
+		deleting = true;
+		try {
+			await deletePlayoffStructure(id());
+			await goto('/playoff-structures');
+		} catch (err) {
+			// e.g. the structure is referenced by a Season and PreDelete blocks it
+			error = err instanceof Error ? err.message : 'Failed to delete playoff structure';
+			deleting = false;
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>Playoff Structure</title>
+</svelte:head>
+
+{#if loadError}
+	<h1>Playoff Structure</h1>
+	<p class="error">{loadError}</p>
+	<a href="/playoff-structures">&larr; Back to playoff structures</a>
+{:else if !structure}
+	<h1>Playoff Structure</h1>
+	<p>Loading...</p>
+{:else}
+	<h1>Playoff Structure</h1>
+	<a href="/playoff-structures">&larr; Back to playoff structures</a>
+
+	<dl class="meta">
+		<div>
+			<dt>Byes</dt>
+			<dd>{structure.byes}</dd>
+		</div>
+		<div>
+			<dt>Number of teams</dt>
+			<dd>{structure.number_of_teams}</dd>
+		</div>
+	</dl>
+
+	<h2>Edit</h2>
+	<form onsubmit={handleSave}>
+		<label>
+			Byes
+			<input type="number" min="0" bind:value={byes} required />
+		</label>
+		<label>
+			Number of teams
+			<input type="number" min="2" bind:value={numberOfTeams} required />
+		</label>
+		<button type="submit" disabled={saving}>{saving ? 'Saving...' : 'Save changes'}</button>
+	</form>
+
+	<button type="button" onclick={handleDelete} disabled={deleting} class="danger">
+		{deleting ? 'Deleting...' : 'Delete playoff structure'}
+	</button>
+
+	{#if error}
+		<p class="error">{error}</p>
+	{/if}
+{/if}
+
+<style>
+	.error {
+		color: #c00;
+	}
+	.meta {
+		display: flex;
+		gap: 1.5rem;
+		margin: 1rem 0;
+	}
+	.meta dt {
+		font-size: 0.85rem;
+		color: #666;
+	}
+	.meta dd {
+		margin: 0;
+	}
+	form {
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+		max-width: 24rem;
+		margin-top: 0.5rem;
+	}
+	label {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+	}
+	input,
+	select {
+		padding: 0.35rem;
+	}
+	.danger {
+		margin-top: 1rem;
+		color: #c00;
+	}
+</style>

--- a/ui/src/routes/playoff-structures/new/+page.svelte
+++ b/ui/src/routes/playoff-structures/new/+page.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+	import { createPlayoffStructure } from '$lib/playoffStructure';
+	import { goto } from '$app/navigation';
+
+	let byes = $state<string>('0');
+	let numberOfTeams = $state<string>('8');
+	let error = $state('');
+	let submitting = $state(false);
+
+	async function handleSubmit(e: Event) {
+		e.preventDefault();
+		error = '';
+		submitting = true;
+		try {
+			const created = await createPlayoffStructure({
+				byes: parseInt(byes || '0', 10),
+				number_of_teams: parseInt(numberOfTeams, 10)
+			});
+			await goto(`/playoff-structures/${created.id}`);
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Failed to create playoff structure';
+		} finally {
+			submitting = false;
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>New playoff structure</title>
+</svelte:head>
+
+<h1>New playoff structure</h1>
+<a href="/playoff-structures">&larr; Back to playoff structures</a>
+
+<form onsubmit={handleSubmit}>
+	<label>
+		Byes
+		<input type="number" min="0" bind:value={byes} required />
+	</label>
+	<label>
+		Number of teams
+		<input type="number" min="2" bind:value={numberOfTeams} required />
+	</label>
+	<button type="submit" disabled={submitting}>{submitting ? 'Creating...' : 'Create playoff structure'}</button>
+</form>
+
+{#if error}
+	<p class="error">{error}</p>
+{/if}
+
+<style>
+	.error {
+		color: #c00;
+	}
+	form {
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+		max-width: 24rem;
+		margin-top: 1rem;
+	}
+	label {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+	}
+	input,
+	select {
+		padding: 0.35rem;
+	}
+</style>

--- a/ui/src/routes/playoff-structures/new/+page.svelte
+++ b/ui/src/routes/playoff-structures/new/+page.svelte
@@ -64,8 +64,7 @@
 		flex-direction: column;
 		gap: 0.25rem;
 	}
-	input,
-	select {
+	input {
 		padding: 0.35rem;
 	}
 </style>


### PR DESCRIPTION
Closes #85.

## Summary
Build a general-purpose CRUD page for `PlayoffStructure` in the SvelteKit UI, mirroring the existing Facility / ScoringStructure / Ruleset CRUD pages.

## Backend
- `model/playoff_structure.go`: add `user_id`/`byes`/`number_of_teams` JSON tags and hex-string `MarshalJSON`/`UnmarshalJSON` for `PlayoffStructureId` (consistent with Facility/ScoringStructure).
- `main.go`: register `/api/playoff_structure` CRUD routes via `api.NewCrudCommon(model.NewPlayoffStructure, false, db)` + `HandleRouteTypes(...CrudWrapperFunctionAll...)`.

## UI (`ui/`)
- `src/lib/playoffStructure.ts`: API client (list/get/create/update/delete).
- List page (`/playoff-structures`), create page (`/playoff-structures/new`), detail page (`/playoff-structures/[id]`) with edit + confirm-guarded delete.
- Nav links in `NavBar.svelte` and the root `+page.svelte`.

## Tests
- `e2e/playoff-structure.spec.ts`: Playwright test covering create → view → update → delete.

## Verification
- `go build ./...`, `go vet ./...`, `go test ./...` all pass (including the PlayoffStructure SQLite round-trip test).