### PR TITLE
Fix flaky parallel e2e: wait for hydration before clicking Create

### DIFF
--- a/ui/e2e/facility.spec.ts
+++ b/ui/e2e/facility.spec.ts
@@ -2,6 +2,7 @@ import { expect, test, type Page } from '@playwright/test';
 import { DatabaseSync } from 'node:sqlite';
 import crypto from 'node:crypto';
 import { fileURLToPath } from 'node:url';
+import { waitForHydration } from './helpers';
 
 // The Go backend runs with --dev-token from the repo root (see
 // playwright.config.ts), so POST /api/one_time_password returns the magic-link
@@ -30,6 +31,7 @@ test('facility CRUD: create, view, update, delete', async ({ page }) => {
 	await page.goto('/facilities');
 	await page.getByRole('link', { name: 'New facility' }).click();
 	await expect(page).toHaveURL(/\/facilities\/new$/);
+	await waitForHydration(page);
 	await page.getByLabel('Name').fill(`Test Facility ${unique}`);
 	await page.getByLabel('Address').fill(`${unique} Main St`);
 	await page.getByLabel('Number of courts').fill('4');
@@ -67,6 +69,7 @@ test('facility delete is blocked when the facility is assigned to a season', asy
 	// Create a facility to attempt deletion of.
 	const unique = Date.now();
 	await page.goto('/facilities/new');
+	await waitForHydration(page);
 	await page.getByLabel('Name').fill(`In Use Facility ${unique}`);
 	await page.getByLabel('Address').fill(`${unique} St`);
 	await page.getByLabel('Number of courts').fill('2');

--- a/ui/e2e/format-ratings.spec.ts
+++ b/ui/e2e/format-ratings.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test, type Page } from '@playwright/test';
+import { waitForHydration } from './helpers';
 
 // The Go backend runs with --dev-token from the repo root (see
 // playwright.config.ts), so POST /api/one_time_password returns the magic-link
@@ -25,6 +26,7 @@ test('assign ratings to a format: add, list, remove', async ({ page }) => {
 	// Create two ratings to assign.
 	for (const ratingName of [ratingName1, ratingName2]) {
 		await page.goto('/ratings/new');
+		await waitForHydration(page);
 		await page.getByLabel('Name').fill(ratingName);
 		await page.getByLabel('Description').fill(`Description ${unique}`);
 		await page.getByRole('button', { name: 'Create rating' }).click();
@@ -33,6 +35,7 @@ test('assign ratings to a format: add, list, remove', async ({ page }) => {
 
 	// Create a fresh format with no ratings yet.
 	await page.goto('/formats/new');
+	await waitForHydration(page);
 	await page.getByLabel('Name').fill(formatName);
 	await page.getByRole('button', { name: 'Create format' }).click();
 	await expect(page).toHaveURL(/\/formats\/[0-9a-f]+$/);

--- a/ui/e2e/format.spec.ts
+++ b/ui/e2e/format.spec.ts
@@ -2,6 +2,7 @@ import { expect, test, type Page } from '@playwright/test';
 import { DatabaseSync } from 'node:sqlite';
 import crypto from 'node:crypto';
 import { fileURLToPath } from 'node:url';
+import { waitForHydration } from './helpers';
 
 // The Go backend runs with --dev-token from the repo root (see
 // playwright.config.ts), so POST /api/one_time_password returns the magic-link
@@ -30,6 +31,7 @@ test('format CRUD: create, view, update, delete', async ({ page }) => {
 	await page.goto('/formats');
 	await page.getByRole('link', { name: 'New format' }).click();
 	await expect(page).toHaveURL(/\/formats\/new$/);
+	await waitForHydration(page);
 	await page.getByLabel('Name').fill(`Test Format ${unique}`);
 	await page.getByRole('button', { name: 'Create format' }).click();
 
@@ -65,6 +67,7 @@ test('format delete is blocked when the format is assigned to a draft', async ({
 	// Create a format to attempt deletion of.
 	const unique = Date.now();
 	await page.goto('/formats/new');
+	await waitForHydration(page);
 	await page.getByLabel('Name').fill(`In Use Format ${unique}`);
 	await page.getByRole('button', { name: 'Create format' }).click();
 	await expect(page).toHaveURL(/\/formats\/([0-9a-f]+)$/);

--- a/ui/e2e/helpers.ts
+++ b/ui/e2e/helpers.ts
@@ -1,0 +1,20 @@
+import type { Page } from '@playwright/test';
+
+/**
+ * Wait for SvelteKit hydration to finish after navigating to a page.
+ *
+ * Svelte 5 attaches a form's `onsubmit` handler through event delegation only
+ * during hydration. If a test fills and clicks "Create" before hydration is
+ * live, the `<form>` submits natively as a GET (`/new?`) instead of running the
+ * enhanced submit handler's `goto(...)`, so the detail page never loads; a
+ * `bind:value` input filled pre-hydration can also be reset. Under
+ * `fullyParallel` the race is much more likely because Vite compiles route
+ * chunks on demand, so each worker can reach the `/new` page before its JS is
+ * ready — the flake tracked in issue #103.
+ *
+ * `networkidle` settles once the route's JS chunks have been fetched and the
+ * app has hydrated — the same barrier the login flow already relies on.
+ */
+export async function waitForHydration(page: Page): Promise<void> {
+	await page.waitForLoadState('networkidle');
+}

--- a/ui/e2e/playoff-structure.spec.ts
+++ b/ui/e2e/playoff-structure.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test, type Page } from '@playwright/test';
+import { waitForHydration } from './helpers';
 
 // The Go backend runs with --dev-token from the repo root (see
 // playwright.config.ts), so POST /api/one_time_password returns the magic-link
@@ -21,6 +22,7 @@ test('playoff structure CRUD: create, view, update, delete', async ({ page }) =>
 	await page.goto('/playoff-structures');
 	await page.getByRole('link', { name: 'New playoff structure' }).click();
 	await expect(page).toHaveURL(/\/playoff-structures\/new$/);
+	await waitForHydration(page);
 	await page.getByLabel('Byes').fill('0');
 	await page.getByLabel('Number of teams').fill('8');
 	await page.getByRole('button', { name: 'Create playoff structure' }).click();

--- a/ui/e2e/rating.spec.ts
+++ b/ui/e2e/rating.spec.ts
@@ -2,6 +2,7 @@ import { expect, test, type Page } from '@playwright/test';
 import { DatabaseSync } from 'node:sqlite';
 import crypto from 'node:crypto';
 import { fileURLToPath } from 'node:url';
+import { waitForHydration } from './helpers';
 
 // The Go backend runs with --dev-token from the repo root (see
 // playwright.config.ts), so POST /api/one_time_password returns the magic-link
@@ -30,6 +31,7 @@ test('rating CRUD: create, view, update, delete', async ({ page }) => {
 	await page.goto('/ratings');
 	await page.getByRole('link', { name: 'New rating' }).click();
 	await expect(page).toHaveURL(/\/ratings\/new$/);
+	await waitForHydration(page);
 	await page.getByLabel('Name').fill(`Test Rating ${unique}`);
 	await page.getByLabel('Description').fill(`Description ${unique}`);
 	await page.getByRole('button', { name: 'Create rating' }).click();
@@ -68,6 +70,7 @@ test('rating delete is blocked when the rating is assigned to a format', async (
 	// Create a rating to attempt deletion of.
 	const unique = Date.now();
 	await page.goto('/ratings/new');
+	await waitForHydration(page);
 	await page.getByLabel('Name').fill(`In Use Rating ${unique}`);
 	await page.getByLabel('Description').fill(`Description ${unique}`);
 	await page.getByRole('button', { name: 'Create rating' }).click();

--- a/ui/e2e/ruleset.spec.ts
+++ b/ui/e2e/ruleset.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test, type Page } from '@playwright/test';
+import { waitForHydration } from './helpers';
 
 // The Go backend runs with --dev-token from the repo root (see
 // playwright.config.ts), so POST /api/one_time_password returns the magic-link
@@ -23,6 +24,7 @@ test('ruleset CRUD: create, view, amend (update), delete', async ({ page }) => {
 	await page.goto('/rulesets');
 	await page.getByRole('link', { name: 'New ruleset' }).click();
 	await expect(page).toHaveURL(/\/rulesets\/new$/);
+	await waitForHydration(page);
 	await page.getByLabel('Name').fill(`Test Ruleset ${unique}`);
 	await page.getByRole('button', { name: 'Create ruleset' }).click();
 

--- a/ui/e2e/scoring-structure.spec.ts
+++ b/ui/e2e/scoring-structure.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test, type Page } from '@playwright/test';
+import { waitForHydration } from './helpers';
 
 // The Go backend runs with --dev-token from the repo root (see
 // playwright.config.ts), so POST /api/one_time_password returns the magic-link
@@ -23,6 +24,7 @@ test('scoring structure CRUD: create, view, update, delete', async ({ page }) =>
 	await page.goto('/scoring-structures');
 	await page.getByRole('link', { name: 'New scoring structure' }).click();
 	await expect(page).toHaveURL(/\/scoring-structures\/new$/);
+	await waitForHydration(page);
 	await page.getByLabel('Name').fill(`Test Scoring Structure ${unique}`);
 	await page.getByLabel('Score counting type').selectOption({ label: 'Game' });
 	await page.getByLabel('Win threshold', { exact: true }).fill('5');


### PR DESCRIPTION
## Summary
Fixes #103 — the intermittent failures in the `make e2e` suite (facility / format / format-ratings CRUD) under `fullyParallel`.

## Root cause
The failing symptom was a native GET form submit (`/formats/new?`) after clicking **Create**, meaning the SvelteKit `onsubmit` handler wasn't attached yet — the test clicked Create before hydration completed. Under parallel load, Vite compiles route chunks on demand, so a worker can reach a `/new` page before its JS has hydrated. This is the "client hydration not ready" cause the ticket hypothesized; the trailing `?` proves it's not a SQLite write-contention issue (a failed create POST would leave `/new` with no query string).

## Fix
Added `waitForHydration(page)` (`ui/e2e/helpers.ts`), which waits for `networkidle` — the same hydration barrier the login flow already relies on (`e2e/login.spec.ts`). Called it right after navigating to each `/new` page, before filling/clicking **Create**, across all 7 CRUD specs (facility, format, format-ratings, rating, ruleset, playoff-structure, scoring-structure).

## Verification
- 10 consecutive full `make e2e` runs all pass (**12/12**). Previously the suite failed 4–5 tests per run.
- The flake reproduced reliably before the fix (`/formats/new?` native GET); after the fix it does not.

## Out of scope
No change to worker/DB config — the shared dev DB and `reuseExistingServer` were not the cause.