### PR TITLE
UI: general-purpose CRUD page for Photo (#87)

### DIFF
--- a/main.go
+++ b/main.go
@@ -99,6 +99,9 @@ func main() {
 	playoffStructures := api.NewCrudCommon(model.NewPlayoffStructure, false, db)
 	playoffStructures.HandleRouteTypes(rg, api.CrudWrapperFunctionAll...)
 
+	photos := api.NewCrudCommon(model.NewPhoto, false, db)
+	photos.HandleRouteTypes(rg, api.CrudWrapperFunctionAll...)
+
 	err = r.Run(cfg.addr)
 	if err != nil {
 		panic(err)

--- a/model/photo.go
+++ b/model/photo.go
@@ -60,11 +60,11 @@ func (id PhotoId) UnmarshalJSON(data []byte) error {
 }
 
 type Photo struct {
-	ID       PhotoId `json:"id"`
-	Owner    database.UserId
-	AltText  string
-	Contents []byte
-	FileType PhotoType
+	ID       PhotoId         `json:"id"`
+	Owner    database.UserId `json:"owner"`
+	AltText  string          `json:"alt_text"`
+	Contents []byte          `json:"contents"`
+	FileType PhotoType       `json:"file_type"`
 }
 
 func (p *Photo) GetOwner() database.UserId {

--- a/ui/e2e/photo.spec.ts
+++ b/ui/e2e/photo.spec.ts
@@ -1,0 +1,76 @@
+import { expect, test, type Page } from '@playwright/test';
+import { waitForHydration } from './helpers';
+
+// The Go backend runs with --dev-token from the repo root (see
+// playwright.config.ts), so POST /api/one_time_password returns the magic-link
+// token in the response body. Login with the user seeded by SeedDevData.
+async function login(page: Page) {
+	await page.goto('/login');
+	await page.waitForLoadState('networkidle');
+	await page.getByLabel('Email').fill('jdarthur@gatech.edu');
+	await page.getByRole('button', { name: 'Send login link' }).click();
+	const link = page.getByRole('main').getByRole('link', { name: 'Log in' });
+	await expect(link).toBeVisible();
+	await link.click();
+	await expect(page).toHaveURL('/');
+}
+
+// A 1x1 transparent PNG. The backend stores raw bytes and doesn't decode the
+// image, so this is enough to exercise the upload path end to end.
+const PNG_1PX =
+	'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
+
+test('photo CRUD: upload, view, update, delete', async ({ page }) => {
+	await login(page);
+
+	const unique = Date.now();
+	const altText = `Test Photo ${unique}`;
+
+	// Create (upload)
+	await page.goto('/photos');
+	await page.getByRole('link', { name: 'New photo' }).click();
+	await expect(page).toHaveURL(/\/photos\/new$/);
+	await waitForHydration(page);
+	await page.getByLabel('Alt text').fill(altText);
+	await page.setInputFiles('input[type=file]', {
+		name: 'photo.png',
+		mimeType: 'image/png',
+		buffer: Buffer.from(PNG_1PX, 'base64')
+	});
+	// File type is auto-derived from the extension.
+	await expect(page.getByLabel('File type')).toHaveValue('0'); // png
+	await page.getByRole('button', { name: 'Create photo' }).click();
+
+	// View: lands on the detail page with the image and alt text reflected
+	await expect(page).toHaveURL(/\/photos\/[0-9a-f]+$/);
+	await expect(page.getByRole('heading', { name: 'Photo' })).toBeVisible();
+	await expect(page.locator('img.detail')).toHaveAttribute('src', /^data:image\/png;base64,/);
+	await expect(page.getByText(altText)).toBeVisible();
+
+	// Update: change alt text and swap the image
+	await page.getByLabel('Alt text').fill(`${altText} Updated`);
+	await page.setInputFiles('input[type=file]', {
+		name: 'photo.jpg',
+		mimeType: 'image/jpeg',
+		buffer: Buffer.from(PNG_1PX, 'base64')
+	});
+	await expect(page.getByLabel('File type')).toHaveValue('1'); // jpg
+	await page.getByRole('button', { name: 'Save changes' }).click();
+	await expect(page.getByText(`${altText} Updated`)).toBeVisible();
+	await expect(page.locator('img.detail')).toHaveAttribute('src', /^data:image\/jpg;base64,/);
+
+	// The list reflects the update (thumbnail + alt text)
+	await page.goto('/photos');
+	const row = page
+		.getByRole('link', { name: `${altText} Updated` })
+		.filter({ hasText: `${altText} Updated` });
+	await expect(row).toBeVisible();
+
+	// Delete (accept the confirm dialog)
+	await row.click();
+	await expect(page.getByRole('heading', { name: 'Photo' })).toBeVisible();
+	page.on('dialog', (d) => d.accept());
+	await page.getByRole('button', { name: 'Delete photo' }).click();
+	await expect(page).toHaveURL('/photos');
+	await expect(page.getByRole('link', { name: `${altText} Updated` })).toHaveCount(0);
+});

--- a/ui/src/lib/components/NavBar.svelte
+++ b/ui/src/lib/components/NavBar.svelte
@@ -20,6 +20,7 @@
 		<a href="/rulesets">Rulesets</a>
 		<a href="/scoring-structures">Scoring Structures</a>
 		<a href="/playoff-structures">Playoff Structures</a>
+		<a href="/photos">Photos</a>
 	</div>
 	<div class="actions">
 		{#if loggedIn}

--- a/ui/src/lib/photo.ts
+++ b/ui/src/lib/photo.ts
@@ -1,0 +1,133 @@
+// Photo API client. Photo records are backed by the existing REST CRUD routes
+// generated from `model.Photo` (see main.go):
+//
+//	GET    /api/photo     -> { resource: Photo[] }
+//	GET    /api/photo/:id -> { resource: Photo }
+//	POST   /api/photo     -> { resource: Photo }  (owner = token user)
+//	PUT    /api/photo/:id -> { resource: Photo }
+//	DELETE /api/photo/:id -> { resource: Photo }
+//
+// A Photo is a binary image asset (e.g. a Facility layout photo) owned by a
+// User. `contents` is base64-encoded image bytes (Go's `[]byte` marshals to
+// base64 over JSON); `file_type` is the PhotoType enum value. Record IDs are
+// 16-char hex strings; an empty string represents "not set" (InvalidRecordId).
+import { authFetch } from '$lib/auth';
+
+// PhotoType enum values mirror model.PhotoType (model/photo.go).
+export const PHOTO_TYPE_PNG = 0;
+export const PHOTO_TYPE_JPG = 1;
+export const PHOTO_TYPE_JPEG = 2;
+export const PHOTO_TYPE_GIF = 3;
+export const PHOTO_TYPE_WEBP = 4;
+
+export const photoTypeLabels: Record<number, string> = {
+	[PHOTO_TYPE_PNG]: 'png',
+	[PHOTO_TYPE_JPG]: 'jpg',
+	[PHOTO_TYPE_JPEG]: 'jpeg',
+	[PHOTO_TYPE_GIF]: 'gif',
+	[PHOTO_TYPE_WEBP]: 'webp'
+};
+
+export type PhotoType = number;
+
+export interface Photo {
+	id: string;
+	owner: string;
+	alt_text: string;
+	contents: string; // base64-encoded image bytes
+	file_type: PhotoType;
+}
+
+export interface PhotoInput {
+	alt_text: string;
+	contents: string; // base64-encoded image bytes
+	file_type: PhotoType;
+}
+
+const BASE = '/api/photo';
+
+// dataUrlFor returns a `data:` URL that can be passed straight to an <img src>,
+// decoding the base64 contents back into a renderable image.
+export function dataUrlFor(photo: Photo): string {
+	const mime = photoTypeLabels[photo.file_type] ?? 'png';
+	return `data:image/${mime};base64,${photo.contents}`;
+}
+
+// photoTypeFromExtension maps a file extension to its PhotoType value, or
+// returns null when the extension isn't a supported image type.
+export function photoTypeFromExtension(filename: string): PhotoType | null {
+	const ext = filename.split('.').pop()?.toLowerCase() ?? '';
+	switch (ext) {
+		case 'png':
+			return PHOTO_TYPE_PNG;
+		case 'jpg':
+			return PHOTO_TYPE_JPG;
+		case 'jpeg':
+			return PHOTO_TYPE_JPEG;
+		case 'gif':
+			return PHOTO_TYPE_GIF;
+		case 'webp':
+			return PHOTO_TYPE_WEBP;
+		default:
+			return null;
+	}
+}
+
+// unwrap parses a CrudCommon response (`{ resource: ... }`) and throws the
+// backend error message on non-2xx responses so callers can surface it.
+async function unwrap(res: Response): Promise<any> {
+	if (!res.ok) {
+		let message = `Request failed (${res.status})`;
+		try {
+			const body = await res.json();
+			if (body?.error) message = body.error;
+		} catch {
+			// non-JSON error body; fall back to the status message
+		}
+		throw new Error(message);
+	}
+	const body = await res.json();
+	return body?.resource;
+}
+
+export async function listPhotos(): Promise<Photo[]> {
+	return unwrap(await authFetch(BASE));
+}
+
+export async function getPhoto(id: string): Promise<Photo> {
+	return unwrap(await authFetch(`${BASE}/${id}`));
+}
+
+export async function createPhoto(input: PhotoInput): Promise<Photo> {
+	return unwrap(
+		await authFetch(BASE, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(input)
+		})
+	);
+}
+
+export async function updatePhoto(id: string, input: PhotoInput): Promise<Photo> {
+	return unwrap(
+		await authFetch(`${BASE}/${id}`, {
+			method: 'PUT',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(input)
+		})
+	);
+}
+
+export async function deletePhoto(id: string): Promise<void> {
+	const res = await authFetch(`${BASE}/${id}`, { method: 'DELETE' });
+	if (!res.ok) {
+		let message = `Delete failed (${res.status})`;
+		try {
+			const body = await res.json();
+			if (body?.error) message = body.error;
+		} catch {
+			// non-JSON error body; fall back to the status message
+		}
+		throw new Error(message);
+	}
+}

--- a/ui/src/routes/photos/+page.svelte
+++ b/ui/src/routes/photos/+page.svelte
@@ -1,0 +1,84 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { listPhotos, dataUrlFor, photoTypeLabels } from '$lib/photo';
+	import type { Photo } from '$lib/photo';
+
+	let photos = $state<Photo[]>([]);
+	let loading = $state(true);
+	let error = $state('');
+
+	function photoTypeLabel(type: number): string {
+		return photoTypeLabels[type] ?? 'unknown';
+	}
+
+	onMount(async () => {
+		try {
+			photos = await listPhotos();
+		} catch (e) {
+			error = e instanceof Error ? e.message : 'Failed to load photos';
+		} finally {
+			loading = false;
+		}
+	});
+</script>
+
+<svelte:head>
+	<title>Photos</title>
+</svelte:head>
+
+<h1>Photos</h1>
+<a href="/photos/new">New photo</a>
+
+{#if loading}
+	<p>Loading...</p>
+{:else if error}
+	<p class="error">{error}</p>
+{:else if photos.length === 0}
+	<p>No photos yet.</p>
+{:else}
+	<table>
+		<thead>
+			<tr>
+				<th>Thumbnail</th>
+				<th>Alt text</th>
+				<th>Type</th>
+			</tr>
+		</thead>
+		<tbody>
+			{#each photos as photo}
+				<tr>
+					<td class="thumb">
+						<a href={`/photos/${photo.id}`}>
+							<img src={dataUrlFor(photo)} alt={photo.alt_text || 'Photo thumbnail'} />
+						</a>
+					</td>
+					<td><a href={`/photos/${photo.id}`}>{photo.alt_text || '(no alt text)'}</a></td>
+					<td>{photoTypeLabel(photo.file_type)}</td>
+				</tr>
+			{/each}
+		</tbody>
+	</table>
+{/if}
+
+<style>
+	.error {
+		color: #c00;
+	}
+	table {
+		border-collapse: collapse;
+		margin-top: 1rem;
+	}
+	th,
+	td {
+		border: 1px solid #ccc;
+		padding: 0.4rem 0.8rem;
+		text-align: left;
+	}
+	.thumb img {
+		display: block;
+		width: 48px;
+		height: 48px;
+		object-fit: cover;
+		border-radius: 4px;
+	}
+</style>

--- a/ui/src/routes/photos/[id]/+page.svelte
+++ b/ui/src/routes/photos/[id]/+page.svelte
@@ -1,0 +1,203 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { page } from '$app/state';
+	import { goto } from '$app/navigation';
+	import {
+		getPhoto,
+		updatePhoto,
+		deletePhoto,
+		dataUrlFor,
+		photoTypeFromExtension,
+		photoTypeLabels,
+		type Photo,
+		type PhotoType
+	} from '$lib/photo';
+
+	const id = () => page.params.id as string;
+
+	let photo = $state<Photo | null>(null);
+	let loadError = $state('');
+	let altText = $state('');
+	let fileType = $state<PhotoType>(0);
+	let contents = $state('');
+	let error = $state('');
+	let saving = $state(false);
+	let deleting = $state(false);
+
+	onMount(load);
+
+	async function load() {
+		loadError = '';
+		try {
+			const p = await getPhoto(id());
+			photo = p;
+			altText = p.alt_text;
+			fileType = p.file_type;
+			contents = p.contents;
+		} catch (e) {
+			loadError = e instanceof Error ? e.message : 'Failed to load photo';
+		}
+	}
+
+	function onFileChange(e: Event) {
+		const input = e.target as HTMLInputElement;
+		const file = input.files?.[0];
+		if (!file) return;
+		const type = photoTypeFromExtension(file.name);
+		if (type === null) {
+			error = `Unsupported file type. Use one of: ${Object.values(photoTypeLabels).join(', ')}.`;
+			return;
+		}
+		fileType = type;
+		error = '';
+		const reader = new FileReader();
+		reader.onload = () => {
+			const result = reader.result as string;
+			contents = result.split(',')[1] ?? '';
+		};
+		reader.readAsDataURL(file);
+	}
+
+	async function handleSave(e: Event) {
+		e.preventDefault();
+		error = '';
+		saving = true;
+		try {
+			const updated = await updatePhoto(id(), {
+				alt_text: altText,
+				contents,
+				file_type: fileType
+			});
+			photo = updated;
+			altText = updated.alt_text;
+			fileType = updated.file_type;
+			contents = updated.contents;
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Failed to update photo';
+		} finally {
+			saving = false;
+		}
+	}
+
+	async function handleDelete() {
+		if (!confirm('Delete this photo?')) return;
+		error = '';
+		deleting = true;
+		try {
+			await deletePhoto(id());
+			await goto('/photos');
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Failed to delete photo';
+			deleting = false;
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>Photo</title>
+</svelte:head>
+
+{#if loadError}
+	<h1>Photo</h1>
+	<p class="error">{loadError}</p>
+	<a href="/photos">&larr; Back to photos</a>
+{:else if !photo}
+	<h1>Photo</h1>
+	<p>Loading...</p>
+{:else}
+	<h1>Photo</h1>
+	<a href="/photos">&larr; Back to photos</a>
+
+	<img class="detail" src={dataUrlFor(photo)} alt={photo.alt_text || 'Photo'} />
+
+	<dl class="meta">
+		<div>
+			<dt>Alt text</dt>
+			<dd>{photo.alt_text || '(none)'}</dd>
+		</div>
+		<div>
+			<dt>File type</dt>
+			<dd>{photoTypeLabels[photo.file_type] ?? 'unknown'}</dd>
+		</div>
+		<div>
+			<dt>Owner</dt>
+			<dd>{photo.owner}</dd>
+		</div>
+	</dl>
+
+	<h2>Edit</h2>
+	<form onsubmit={handleSave}>
+		<label>
+			Alt text
+			<input type="text" bind:value={altText} />
+		</label>
+		<label>
+			File
+			<input type="file" accept="image/*" onchange={onFileChange} />
+		</label>
+		<label>
+			File type
+			<select bind:value={fileType}>
+				<option value={0}>png</option>
+				<option value={1}>jpg</option>
+				<option value={2}>jpeg</option>
+				<option value={3}>gif</option>
+				<option value={4}>webp</option>
+			</select>
+		</label>
+		<button type="submit" disabled={saving}>{saving ? 'Saving...' : 'Save changes'}</button>
+	</form>
+
+	<button type="button" onclick={handleDelete} disabled={deleting} class="danger">
+		{deleting ? 'Deleting...' : 'Delete photo'}
+	</button>
+
+	{#if error}
+		<p class="error">{error}</p>
+	{/if}
+{/if}
+
+<style>
+	.error {
+		color: #c00;
+	}
+	.detail {
+		max-width: 360px;
+		max-height: 240px;
+		border: 1px solid #ccc;
+		border-radius: 6px;
+		margin-top: 0.5rem;
+	}
+	.meta {
+		display: flex;
+		gap: 1.5rem;
+		margin: 1rem 0;
+	}
+	.meta dt {
+		font-size: 0.85rem;
+		color: #666;
+	}
+	.meta dd {
+		margin: 0;
+	}
+	form {
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+		max-width: 24rem;
+		margin-top: 0.5rem;
+	}
+	label {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+	}
+	input,
+	select {
+		padding: 0.35rem;
+	}
+	.danger {
+		margin-top: 1rem;
+		color: #c00;
+	}
+</style>

--- a/ui/src/routes/photos/new/+page.svelte
+++ b/ui/src/routes/photos/new/+page.svelte
@@ -1,0 +1,103 @@
+<script lang="ts">
+	import { createPhoto, photoTypeFromExtension, photoTypeLabels } from '$lib/photo';
+	import { goto } from '$app/navigation';
+	import type { PhotoType } from '$lib/photo';
+
+	let altText = $state('');
+	let contents = $state('');
+	let fileType = $state<PhotoType>(0);
+	let error = $state('');
+	let submitting = $state(false);
+
+	function onFileChange(e: Event) {
+		const input = e.target as HTMLInputElement;
+		const file = input.files?.[0];
+		if (!file) return;
+		const type = photoTypeFromExtension(file.name);
+		if (type === null) {
+			error = `Unsupported file type. Use one of: ${Object.values(photoTypeLabels).join(', ')}.`;
+			return;
+		}
+		fileType = type;
+		error = '';
+		const reader = new FileReader();
+		reader.onload = () => {
+			const result = reader.result as string;
+			contents = result.split(',')[1] ?? '';
+		};
+		reader.readAsDataURL(file);
+	}
+
+	async function handleSubmit(e: Event) {
+		e.preventDefault();
+		error = '';
+		if (!contents) {
+			error = 'Please choose an image file to upload.';
+			return;
+		}
+		submitting = true;
+		try {
+			const created = await createPhoto({ alt_text: altText, contents, file_type: fileType });
+			await goto(`/photos/${created.id}`);
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Failed to create photo';
+		} finally {
+			submitting = false;
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>New photo</title>
+</svelte:head>
+
+<h1>New photo</h1>
+<a href="/photos">&larr; Back to photos</a>
+
+<form onsubmit={handleSubmit}>
+	<label>
+		File
+		<input type="file" accept="image/*" onchange={onFileChange} required />
+	</label>
+	<label>
+		Alt text
+		<input type="text" bind:value={altText} />
+	</label>
+	<label>
+		File type
+		<select bind:value={fileType}>
+			<option value={0}>png</option>
+			<option value={1}>jpg</option>
+			<option value={2}>jpeg</option>
+			<option value={3}>gif</option>
+			<option value={4}>webp</option>
+		</select>
+	</label>
+	<button type="submit" disabled={submitting}>{submitting ? 'Creating...' : 'Create photo'}</button>
+</form>
+
+{#if error}
+	<p class="error">{error}</p>
+{/if}
+
+<style>
+	.error {
+		color: #c00;
+	}
+	form {
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+		max-width: 24rem;
+		margin-top: 1rem;
+	}
+	label {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+	}
+	input,
+	select {
+		padding: 0.35rem;
+	}
+</style>


### PR DESCRIPTION
Implements #87.

## Backend
- Register `/api/photo` CRUD routes via `api.NewCrudCommon(model.NewPhoto, ...)` in `main.go` (get one / get all / create / update / delete).
- Add snake_case JSON tags to the `Photo` model. `Contents` stays `[]byte`, which Go's `encoding/json` base64-encodes/decodes — so the general-purpose JSON CRUD flow handles the binary payload without a dedicated upload endpoint.

## UI
- `ui/src/lib/photo.ts`: API client with base64 contents, a `dataUrlFor` helper to render images, and an extension→`PhotoType` mapper.
- `/photos` list page with thumbnails.
- `/photos/[id]` detail page: view image, edit (alt text + re-upload), delete.
- `/photos/new` create page with file upload; file type auto-derived from the extension.
- Added a **Photos** link to the navbar.

## Tests
- `ui/e2e/photo.spec.ts`: upload → view → update (alt text + image swap) → delete, plus list reflection.
- `go test ./...`, `npm run check`, and `make e2e` (13/13) all green across two runs.