### PR TITLE
Automated handling of magic-link / JWT token expiry (re-login UX)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ make clean           # remove build artifacts
 
 ./main --dev-token   # run backend, dev mode (loopback-only, seeds sample data) on :8080
 cd ui && npm install && npm run dev   # frontend dev server (port 5173)
+cd ui && npm run test                # frontend unit tests (vitest)
 cd ui && npm run check                # svelte-check + typecheck
 ```
 Verify: `go build ./...` succeeds; Go toolchain is go1.26.

--- a/api/api_auth.go
+++ b/api/api_auth.go
@@ -27,8 +27,11 @@ const JwtCertFile = "token.crt"
 // JwtKeyFile is the filename for the persisted JWT private key.
 const JwtKeyFile = "token.key"
 
-// JwtLifetime is the duration for which issued tokens remain valid.
-const JwtLifetime = time.Hour * 2
+// JwtLifetime is the duration for which issued tokens remain valid. It is a
+// package variable (not a const) so it can be configured at startup via the
+// --jwt-lifetime flag or the INTRACLUB_JWT_LIFETIME env var (see main.go).
+// Tests can shorten it to exercise expiry without waiting for the real window.
+var JwtLifetime = time.Hour * 2
 
 // JwtPublicKey holds the loaded ECDSA public key used to verify JWT signatures.
 var JwtPublicKey *ecdsa.PublicKey

--- a/api/api_auth_test.go
+++ b/api/api_auth_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"intraclub/database"
 )
@@ -129,5 +130,33 @@ func TestGenerateTokenDifferentUsers(t *testing.T) {
 	}
 	if token1 == token2 {
 		t.Fatal("tokens for different users should not be equal")
+	}
+}
+
+// TestGenerateTokenExpired validates that a token minted with an already-elapsed
+// JwtLifetime is rejected. It also proves JwtLifetime is configurable (not a
+// hard-coded const), which the --jwt-lifetime flag / INTRACLUB_JWT_LIFETIME env
+// var rely on and which lets tests exercise the expiry path without waiting 2h.
+func TestGenerateTokenExpired(t *testing.T) {
+	deleteKeyPair(t)
+	err := GenerateJwtKeyPairIfNotExists()
+	if err != nil {
+		t.Fatalf("GenerateJwtKeyPairIfNotExists failed: %v", err)
+	}
+
+	userId := database.NewRecordId()
+
+	// A negative lifetime mints an already-expired token (ExpiresAt in the past).
+	orig := JwtLifetime
+	JwtLifetime = -time.Minute
+	token, err := GenerateToken(userId)
+	JwtLifetime = orig
+	if err != nil {
+		t.Fatalf("GenerateToken failed: %v", err)
+	}
+
+	_, err = ValidateToken(token)
+	if err == nil {
+		t.Fatal("expected an error for an expired token")
 	}
 }

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net"
 	"os"
+	"time"
 
 	"intraclub/api"
 	"intraclub/database"
@@ -125,6 +126,7 @@ func (c serverConfig) providerConfig() database.ProviderConfig {
 func parseFlags() serverConfig {
 	useDevTokenMode := flag.Bool("dev-token", false, "Use development token mode")
 	addr := flag.String("addr", "127.0.0.1:8080", "Address to listen on, e.g. 127.0.0.1:8080")
+	jwtLifetimeFlag := flag.String("jwt-lifetime", "", "JWT token lifetime (e.g. 2h, 90m, 5s); falls back to INTRACLUB_JWT_LIFETIME env, then 2h")
 
 	// defaultDBKind is the provider used at startup. SQLite is the default
 	// (file-backed, single-file .db); pass --db memory for an ephemeral run.
@@ -132,6 +134,12 @@ func parseFlags() serverConfig {
 	dbKind := flag.String("db", string(defaultDBKind), "Database provider (memory | sqlite)")
 	dbPath := flag.String("db-path", "", "Path to the SQLite database file; falls back to INTRACLUB_DB_PATH env")
 	flag.Parse()
+
+	jwtLifetime, err := resolveJwtLifetime(*jwtLifetimeFlag)
+	if err != nil {
+		log.Fatalf("invalid JWT lifetime: %v", err)
+	}
+	api.JwtLifetime = jwtLifetime
 
 	if useDevTokenMode != nil && *useDevTokenMode == true {
 		model.UseDevTokenMode = true
@@ -157,6 +165,27 @@ func resolveDBPath(flagPath string) string {
 		return flagPath
 	}
 	return os.Getenv("INTRACLUB_DB_PATH")
+}
+
+// resolveJwtLifetime returns the JWT token lifetime, preferring the explicit
+// --jwt-lifetime flag and falling back to the INTRACLUB_JWT_LIFETIME env var,
+// then to the package default of api.JwtLifetime.
+func resolveJwtLifetime(flagVal string) (time.Duration, error) {
+	raw := flagVal
+	if raw == "" {
+		raw = os.Getenv("INTRACLUB_JWT_LIFETIME")
+	}
+	if raw == "" {
+		return api.JwtLifetime, nil
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return 0, fmt.Errorf("invalid JWT lifetime %q: %w", raw, err)
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("JWT lifetime must be positive, got %q", raw)
+	}
+	return d, nil
 }
 
 // isLoopbackAddress reports whether addr's host is a loopback interface

--- a/main.go
+++ b/main.go
@@ -99,6 +99,9 @@ func main() {
 	playoffStructures := api.NewCrudCommon(model.NewPlayoffStructure, false, db)
 	playoffStructures.HandleRouteTypes(rg, api.CrudWrapperFunctionAll...)
 
+	photos := api.NewCrudCommon(model.NewPhoto, false, db)
+	photos.HandleRouteTypes(rg, api.CrudWrapperFunctionAll...)
+
 	err = r.Run(cfg.addr)
 	if err != nil {
 		panic(err)

--- a/main_test.go
+++ b/main_test.go
@@ -3,6 +3,9 @@ package main
 import (
 	"os"
 	"testing"
+	"time"
+
+	"intraclub/api"
 )
 
 func TestResolveDBPath(t *testing.T) {
@@ -58,6 +61,64 @@ func TestIsLoopbackAddress(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := isLoopbackAddress(tt.addr); got != tt.want {
 				t.Errorf("isLoopbackAddress(%q) = %v, want %v", tt.addr, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveJwtLifetimeDefaultsToPackageDefault(t *testing.T) {
+	// No flag, no env var -> package default (2h).
+	api.JwtLifetime = time.Hour * 2
+	t.Setenv("INTRACLUB_JWT_LIFETIME", "")
+
+	d, err := resolveJwtLifetime("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if d != time.Hour*2 {
+		t.Fatalf("expected default 2h, got %v", d)
+	}
+}
+
+func TestResolveJwtLifetimeEnvVar(t *testing.T) {
+	t.Setenv("INTRACLUB_JWT_LIFETIME", "90m")
+
+	d, err := resolveJwtLifetime("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if d != 90*time.Minute {
+		t.Fatalf("expected 90m, got %v", d)
+	}
+}
+
+func TestResolveJwtLifetimeFlagWins(t *testing.T) {
+	t.Setenv("INTRACLUB_JWT_LIFETIME", "90m")
+
+	d, err := resolveJwtLifetime("5s")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if d != 5*time.Second {
+		t.Fatalf("expected 5s, got %v", d)
+	}
+}
+
+func TestResolveJwtLifetimeInvalid(t *testing.T) {
+	t.Setenv("INTRACLUB_JWT_LIFETIME", "not-a-duration")
+
+	_, err := resolveJwtLifetime("")
+	if err == nil {
+		t.Fatal("expected an error for an invalid lifetime")
+	}
+}
+
+func TestResolveJwtLifetimeRejectsNonPositive(t *testing.T) {
+	for _, raw := range []string{"0s", "-5s", "-1h"} {
+		t.Run(raw, func(t *testing.T) {
+			t.Setenv("INTRACLUB_JWT_LIFETIME", raw)
+			if _, err := resolveJwtLifetime(""); err == nil {
+				t.Fatalf("expected an error for lifetime %q", raw)
 			}
 		})
 	}

--- a/model/photo.go
+++ b/model/photo.go
@@ -60,11 +60,11 @@ func (id PhotoId) UnmarshalJSON(data []byte) error {
 }
 
 type Photo struct {
-	ID       PhotoId `json:"id"`
-	Owner    database.UserId
-	AltText  string
-	Contents []byte
-	FileType PhotoType
+	ID       PhotoId         `json:"id"`
+	Owner    database.UserId `json:"owner"`
+	AltText  string          `json:"alt_text"`
+	Contents []byte          `json:"contents"`
+	FileType PhotoType       `json:"file_type"`
 }
 
 func (p *Photo) GetOwner() database.UserId {

--- a/ui/e2e/photo.spec.ts
+++ b/ui/e2e/photo.spec.ts
@@ -1,0 +1,76 @@
+import { expect, test, type Page } from '@playwright/test';
+import { waitForHydration } from './helpers';
+
+// The Go backend runs with --dev-token from the repo root (see
+// playwright.config.ts), so POST /api/one_time_password returns the magic-link
+// token in the response body. Login with the user seeded by SeedDevData.
+async function login(page: Page) {
+	await page.goto('/login');
+	await page.waitForLoadState('networkidle');
+	await page.getByLabel('Email').fill('jdarthur@gatech.edu');
+	await page.getByRole('button', { name: 'Send login link' }).click();
+	const link = page.getByRole('main').getByRole('link', { name: 'Log in' });
+	await expect(link).toBeVisible();
+	await link.click();
+	await expect(page).toHaveURL('/');
+}
+
+// A 1x1 transparent PNG. The backend stores raw bytes and doesn't decode the
+// image, so this is enough to exercise the upload path end to end.
+const PNG_1PX =
+	'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
+
+test('photo CRUD: upload, view, update, delete', async ({ page }) => {
+	await login(page);
+
+	const unique = Date.now();
+	const altText = `Test Photo ${unique}`;
+
+	// Create (upload)
+	await page.goto('/photos');
+	await page.getByRole('link', { name: 'New photo' }).click();
+	await expect(page).toHaveURL(/\/photos\/new$/);
+	await waitForHydration(page);
+	await page.getByLabel('Alt text').fill(altText);
+	await page.setInputFiles('input[type=file]', {
+		name: 'photo.png',
+		mimeType: 'image/png',
+		buffer: Buffer.from(PNG_1PX, 'base64')
+	});
+	// File type is auto-derived from the extension.
+	await expect(page.getByLabel('File type')).toHaveValue('0'); // png
+	await page.getByRole('button', { name: 'Create photo' }).click();
+
+	// View: lands on the detail page with the image and alt text reflected
+	await expect(page).toHaveURL(/\/photos\/[0-9a-f]+$/);
+	await expect(page.getByRole('heading', { name: 'Photo' })).toBeVisible();
+	await expect(page.locator('img.detail')).toHaveAttribute('src', /^data:image\/png;base64,/);
+	await expect(page.getByText(altText)).toBeVisible();
+
+	// Update: change alt text and swap the image
+	await page.getByLabel('Alt text').fill(`${altText} Updated`);
+	await page.setInputFiles('input[type=file]', {
+		name: 'photo.jpg',
+		mimeType: 'image/jpeg',
+		buffer: Buffer.from(PNG_1PX, 'base64')
+	});
+	await expect(page.getByLabel('File type')).toHaveValue('1'); // jpg
+	await page.getByRole('button', { name: 'Save changes' }).click();
+	await expect(page.getByText(`${altText} Updated`)).toBeVisible();
+	await expect(page.locator('img.detail')).toHaveAttribute('src', /^data:image\/jpg;base64,/);
+
+	// The list reflects the update (thumbnail + alt text)
+	await page.goto('/photos');
+	const row = page
+		.getByRole('link', { name: `${altText} Updated` })
+		.filter({ hasText: `${altText} Updated` });
+	await expect(row).toBeVisible();
+
+	// Delete (accept the confirm dialog)
+	await row.click();
+	await expect(page.getByRole('heading', { name: 'Photo' })).toBeVisible();
+	page.on('dialog', (d) => d.accept());
+	await page.getByRole('button', { name: 'Delete photo' }).click();
+	await expect(page).toHaveURL('/photos');
+	await expect(page.getByRole('link', { name: `${altText} Updated` })).toHaveCount(0);
+});

--- a/ui/e2e/session-expiry.spec.ts
+++ b/ui/e2e/session-expiry.spec.ts
@@ -1,0 +1,51 @@
+import { expect, test } from '@playwright/test';
+
+// The client only decodes the JWT's `exp` claim to drive the countdown, so
+// these tests can drive the expiry UX with self-minted tokens whose header and
+// signature are placeholders — no need to wait for a real 2h expiry window.
+function makeToken(expEpochSec: number): string {
+	const payload = Buffer.from(JSON.stringify({ exp: expEpochSec })).toString('base64url');
+	return `header.${payload}.signature`;
+}
+
+test('expired JWT proactively redirects to login with a re-login message', async ({ page }) => {
+	// Token expiring ~7s from now so the background countdown has time to fire.
+	const exp = Math.floor(Date.now() / 1000) + 7;
+
+	await page.goto('/');
+	await page.evaluate((t) => localStorage.setItem('intraclub_jwt', t), makeToken(exp));
+	await page.reload();
+
+	// The token is present, so the landing page treats the user as logged in.
+	await expect(page.getByRole('heading', { name: 'Welcome to IntraClub' })).toBeVisible();
+
+	// Once `exp` elapses the countdown clears the session and shows the message.
+	await expect(page.getByText('Your session expired. Please log in again.')).toBeVisible({
+		timeout: 20_000
+	});
+	await expect(page).toHaveURL('/');
+
+	// The stored token is cleared on expiry.
+	const token = await page.evaluate(() => localStorage.getItem('intraclub_jwt'));
+	expect(token).toBeNull();
+});
+
+test('a 401 response reactively expires the session and redirects to login', async ({ page }) => {
+	// Far-future `exp` so the countdown does NOT fire — this isolates the
+	// reactive 401 path. The bogus signature makes the backend reject the token.
+	const exp = Math.floor(Date.now() / 1000) + 3600;
+
+	await page.goto('/');
+	await page.evaluate((t) => localStorage.setItem('intraclub_jwt', t), makeToken(exp));
+
+	// /facilities calls listFacilities -> authFetch on mount, which 401s and
+	// should trigger the same redirect + message.
+	await page.goto('/facilities');
+	await expect(page.getByText('Your session expired. Please log in again.')).toBeVisible({
+		timeout: 15_000
+	});
+	await expect(page).toHaveURL('/');
+
+	const token = await page.evaluate(() => localStorage.getItem('intraclub_jwt'));
+	expect(token).toBeNull();
+});

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -16,7 +16,8 @@
 				"svelte": "^5.55.2",
 				"svelte-check": "^4.4.6",
 				"typescript": "^6.0.2",
-				"vite": "^8.0.7"
+				"vite": "^8.0.7",
+				"vitest": "^4.1.10"
 			}
 		},
 		"node_modules/@emnapi/core": {
@@ -519,10 +520,28 @@
 				"tslib": "^2.4.0"
 			}
 		},
+		"node_modules/@types/chai": {
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+			"integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/deep-eql": "*",
+				"assertion-error": "^2.0.1"
+			}
+		},
 		"node_modules/@types/cookie": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
 			"integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/deep-eql": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+			"integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -550,6 +569,119 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@vitest/expect": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+			"integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@standard-schema/spec": "^1.1.0",
+				"@types/chai": "^5.2.2",
+				"@vitest/spy": "4.1.10",
+				"@vitest/utils": "4.1.10",
+				"chai": "^6.2.2",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/mocker": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+			"integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/spy": "4.1.10",
+				"estree-walker": "^3.0.3",
+				"magic-string": "^0.30.21"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"msw": "^2.4.9",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"msw": {
+					"optional": true
+				},
+				"vite": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@vitest/pretty-format": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+			"integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/runner": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+			"integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/utils": "4.1.10",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/snapshot": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+			"integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.10",
+				"@vitest/utils": "4.1.10",
+				"magic-string": "^0.30.21",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/spy": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+			"integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/utils": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+			"integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.10",
+				"convert-source-map": "^2.0.0",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
 		"node_modules/acorn": {
 			"version": "8.16.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -573,6 +705,16 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/assertion-error": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+			"integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/axobject-query": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -581,6 +723,16 @@
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/chai": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+			"integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/chokidar": {
@@ -608,6 +760,13 @@
 			"engines": {
 				"node": ">=6"
 			}
+		},
+		"node_modules/convert-source-map": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/cookie": {
 			"version": "0.6.0",
@@ -646,6 +805,13 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/es-module-lexer": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+			"integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/esm-env": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
@@ -669,6 +835,26 @@
 				"@typescript-eslint/types": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/estree-walker": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0"
+			}
+		},
+		"node_modules/expect-type": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+			"integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=12.0.0"
 			}
 		},
 		"node_modules/fdir": {
@@ -1052,6 +1238,13 @@
 			],
 			"license": "MIT"
 		},
+		"node_modules/pathe": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/picocolors": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -1216,6 +1409,13 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/siginfo": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+			"integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+			"dev": true,
+			"license": "ISC"
+		},
 		"node_modules/sirv": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
@@ -1240,6 +1440,20 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/stackback": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+			"integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/std-env": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+			"integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/svelte": {
 			"version": "5.55.9",
@@ -1293,6 +1507,23 @@
 				"typescript": ">=5.0.0"
 			}
 		},
+		"node_modules/tinybench": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+			"integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tinyexec": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+			"integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/tinyglobby": {
 			"version": "0.2.16",
 			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -1308,6 +1539,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/SuperchupuDev"
+			}
+		},
+		"node_modules/tinyrainbow": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+			"integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/totalist": {
@@ -1445,6 +1686,113 @@
 				"vite": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/vitest": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+			"integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/expect": "4.1.10",
+				"@vitest/mocker": "4.1.10",
+				"@vitest/pretty-format": "4.1.10",
+				"@vitest/runner": "4.1.10",
+				"@vitest/snapshot": "4.1.10",
+				"@vitest/spy": "4.1.10",
+				"@vitest/utils": "4.1.10",
+				"es-module-lexer": "^2.0.0",
+				"expect-type": "^1.3.0",
+				"magic-string": "^0.30.21",
+				"obug": "^2.1.1",
+				"pathe": "^2.0.3",
+				"picomatch": "^4.0.3",
+				"std-env": "^4.0.0-rc.1",
+				"tinybench": "^2.9.0",
+				"tinyexec": "^1.0.2",
+				"tinyglobby": "^0.2.15",
+				"tinyrainbow": "^3.1.0",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+				"why-is-node-running": "^2.3.0"
+			},
+			"bin": {
+				"vitest": "vitest.mjs"
+			},
+			"engines": {
+				"node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"@edge-runtime/vm": "*",
+				"@opentelemetry/api": "^1.9.0",
+				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+				"@vitest/browser-playwright": "4.1.10",
+				"@vitest/browser-preview": "4.1.10",
+				"@vitest/browser-webdriverio": "4.1.10",
+				"@vitest/coverage-istanbul": "4.1.10",
+				"@vitest/coverage-v8": "4.1.10",
+				"@vitest/ui": "4.1.10",
+				"happy-dom": "*",
+				"jsdom": "*",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@edge-runtime/vm": {
+					"optional": true
+				},
+				"@opentelemetry/api": {
+					"optional": true
+				},
+				"@types/node": {
+					"optional": true
+				},
+				"@vitest/browser-playwright": {
+					"optional": true
+				},
+				"@vitest/browser-preview": {
+					"optional": true
+				},
+				"@vitest/browser-webdriverio": {
+					"optional": true
+				},
+				"@vitest/coverage-istanbul": {
+					"optional": true
+				},
+				"@vitest/coverage-v8": {
+					"optional": true
+				},
+				"@vitest/ui": {
+					"optional": true
+				},
+				"happy-dom": {
+					"optional": true
+				},
+				"jsdom": {
+					"optional": true
+				},
+				"vite": {
+					"optional": false
+				}
+			}
+		},
+		"node_modules/why-is-node-running": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+			"integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"siginfo": "^2.0.0",
+				"stackback": "0.0.2"
+			},
+			"bin": {
+				"why-is-node-running": "cli.js"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/zimmerframe": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -10,6 +10,7 @@
 		"prepare": "svelte-kit sync || echo ''",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
+		"test": "vitest run",
 		"test:e2e": "playwright test",
 		"test:e2e:ui": "playwright test --ui"
 	},
@@ -22,6 +23,7 @@
 		"svelte": "^5.55.2",
 		"svelte-check": "^4.4.6",
 		"typescript": "^6.0.2",
-		"vite": "^8.0.7"
+		"vite": "^8.0.7",
+		"vitest": "^4.1.10"
 	}
 }

--- a/ui/src/lib/auth.ts
+++ b/ui/src/lib/auth.ts
@@ -1,4 +1,17 @@
+import { goto } from '$app/navigation';
+import { writable } from 'svelte/store';
+import { isSessionExpired } from './session';
+
+export { SESSION_EXPIRED_MESSAGE } from './session';
+
 const TOKEN_KEY = 'intraclub_jwt';
+
+/**
+ * Set to true when a session ends via token expiry. The landing page reads it
+ * to show the "please re-login" message. It is cleared when a new token is set
+ * (i.e. the next successful login).
+ */
+export const sessionExpired = writable(false);
 
 export function getToken(): string | null {
 	if (typeof localStorage === 'undefined') return null;
@@ -7,6 +20,7 @@ export function getToken(): string | null {
 
 export function setToken(token: string): void {
 	localStorage.setItem(TOKEN_KEY, token);
+	sessionExpired.set(false);
 }
 
 export function clearToken(): void {
@@ -17,11 +31,60 @@ export function isLoggedIn(): boolean {
 	return getToken() !== null;
 }
 
+let lastToken: string | null = null;
+let expiredHandled = false;
+
+/**
+ * Tears down the current session: clears the stored token, flags the session as
+ * expired, and navigates to the landing/login page. Idempotent so a burst of
+ * concurrent 401s only redirects once.
+ */
+async function expireSession(): Promise<void> {
+	if (expiredHandled) return;
+	expiredHandled = true;
+	clearToken();
+	sessionExpired.set(true);
+	await goto('/');
+}
+
+/**
+ * A background ticker that watches the stored token's `exp` claim and expires
+ * the session the moment it elapses. Because it re-reads localStorage each tick
+ * it naturally restarts on a fresh token (new login) and self-resets its
+ * idempotency guard when the token changes. Returns a cleanup function.
+ */
+export function startSessionMonitor(intervalMs = 1000): () => void {
+	const id = setInterval(tick, intervalMs);
+	tick();
+	return () => clearInterval(id);
+}
+
+function tick(): void {
+	const token = getToken();
+	if (token !== lastToken) {
+		lastToken = token;
+		expiredHandled = false;
+	}
+	if (!token || expiredHandled) return;
+	if (isSessionExpired(token)) {
+		void expireSession();
+	}
+}
+
+/**
+ * fetch wrapper that attaches the auth token and, belt-and-suspenders for clock
+ * or ticker drift, expires the session if the API rejects it with a 401.
+ */
 export function authFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
 	const token = getToken();
 	const headers = new Headers(init?.headers);
 	if (token) {
 		headers.set('X-INTRACLUB-TOKEN', token);
 	}
-	return fetch(input, { ...init, headers });
+	return fetch(input, { ...init, headers }).then((res) => {
+		if (res.status === 401) {
+			void expireSession();
+		}
+		return res;
+	});
 }

--- a/ui/src/lib/auth.ts
+++ b/ui/src/lib/auth.ts
@@ -44,7 +44,13 @@ async function expireSession(): Promise<void> {
 	expiredHandled = true;
 	clearToken();
 	sessionExpired.set(true);
-	await goto('/');
+	try {
+		await goto('/');
+	} catch {
+		// navigation may be rejected (e.g. mid-route-change); the token is
+		// already cleared and the store updated, so the next page load will
+		// reflect the logged-out state regardless.
+	}
 }
 
 /**
@@ -73,7 +79,10 @@ function tick(): void {
 
 /**
  * fetch wrapper that attaches the auth token and, belt-and-suspenders for clock
- * or ticker drift, expires the session if the API rejects it with a 401.
+ * or ticker drift, expires the session if the API rejects it with a 401. This
+ * relies on the backend contract that a 401 is always an invalid/expired token
+ * (see api/api_route.go auth gate) — login and magic-link endpoints use raw
+ * `fetch` and are unaffected.
  */
 export function authFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
 	const token = getToken();

--- a/ui/src/lib/components/NavBar.svelte
+++ b/ui/src/lib/components/NavBar.svelte
@@ -20,6 +20,7 @@
 		<a href="/rulesets">Rulesets</a>
 		<a href="/scoring-structures">Scoring Structures</a>
 		<a href="/playoff-structures">Playoff Structures</a>
+		<a href="/photos">Photos</a>
 	</div>
 	<div class="actions">
 		{#if loggedIn}

--- a/ui/src/lib/photo.ts
+++ b/ui/src/lib/photo.ts
@@ -1,0 +1,133 @@
+// Photo API client. Photo records are backed by the existing REST CRUD routes
+// generated from `model.Photo` (see main.go):
+//
+//	GET    /api/photo     -> { resource: Photo[] }
+//	GET    /api/photo/:id -> { resource: Photo }
+//	POST   /api/photo     -> { resource: Photo }  (owner = token user)
+//	PUT    /api/photo/:id -> { resource: Photo }
+//	DELETE /api/photo/:id -> { resource: Photo }
+//
+// A Photo is a binary image asset (e.g. a Facility layout photo) owned by a
+// User. `contents` is base64-encoded image bytes (Go's `[]byte` marshals to
+// base64 over JSON); `file_type` is the PhotoType enum value. Record IDs are
+// 16-char hex strings; an empty string represents "not set" (InvalidRecordId).
+import { authFetch } from '$lib/auth';
+
+// PhotoType enum values mirror model.PhotoType (model/photo.go).
+export const PHOTO_TYPE_PNG = 0;
+export const PHOTO_TYPE_JPG = 1;
+export const PHOTO_TYPE_JPEG = 2;
+export const PHOTO_TYPE_GIF = 3;
+export const PHOTO_TYPE_WEBP = 4;
+
+export const photoTypeLabels: Record<number, string> = {
+	[PHOTO_TYPE_PNG]: 'png',
+	[PHOTO_TYPE_JPG]: 'jpg',
+	[PHOTO_TYPE_JPEG]: 'jpeg',
+	[PHOTO_TYPE_GIF]: 'gif',
+	[PHOTO_TYPE_WEBP]: 'webp'
+};
+
+export type PhotoType = number;
+
+export interface Photo {
+	id: string;
+	owner: string;
+	alt_text: string;
+	contents: string; // base64-encoded image bytes
+	file_type: PhotoType;
+}
+
+export interface PhotoInput {
+	alt_text: string;
+	contents: string; // base64-encoded image bytes
+	file_type: PhotoType;
+}
+
+const BASE = '/api/photo';
+
+// dataUrlFor returns a `data:` URL that can be passed straight to an <img src>,
+// decoding the base64 contents back into a renderable image.
+export function dataUrlFor(photo: Photo): string {
+	const mime = photoTypeLabels[photo.file_type] ?? 'png';
+	return `data:image/${mime};base64,${photo.contents}`;
+}
+
+// photoTypeFromExtension maps a file extension to its PhotoType value, or
+// returns null when the extension isn't a supported image type.
+export function photoTypeFromExtension(filename: string): PhotoType | null {
+	const ext = filename.split('.').pop()?.toLowerCase() ?? '';
+	switch (ext) {
+		case 'png':
+			return PHOTO_TYPE_PNG;
+		case 'jpg':
+			return PHOTO_TYPE_JPG;
+		case 'jpeg':
+			return PHOTO_TYPE_JPEG;
+		case 'gif':
+			return PHOTO_TYPE_GIF;
+		case 'webp':
+			return PHOTO_TYPE_WEBP;
+		default:
+			return null;
+	}
+}
+
+// unwrap parses a CrudCommon response (`{ resource: ... }`) and throws the
+// backend error message on non-2xx responses so callers can surface it.
+async function unwrap(res: Response): Promise<any> {
+	if (!res.ok) {
+		let message = `Request failed (${res.status})`;
+		try {
+			const body = await res.json();
+			if (body?.error) message = body.error;
+		} catch {
+			// non-JSON error body; fall back to the status message
+		}
+		throw new Error(message);
+	}
+	const body = await res.json();
+	return body?.resource;
+}
+
+export async function listPhotos(): Promise<Photo[]> {
+	return unwrap(await authFetch(BASE));
+}
+
+export async function getPhoto(id: string): Promise<Photo> {
+	return unwrap(await authFetch(`${BASE}/${id}`));
+}
+
+export async function createPhoto(input: PhotoInput): Promise<Photo> {
+	return unwrap(
+		await authFetch(BASE, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(input)
+		})
+	);
+}
+
+export async function updatePhoto(id: string, input: PhotoInput): Promise<Photo> {
+	return unwrap(
+		await authFetch(`${BASE}/${id}`, {
+			method: 'PUT',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(input)
+		})
+	);
+}
+
+export async function deletePhoto(id: string): Promise<void> {
+	const res = await authFetch(`${BASE}/${id}`, { method: 'DELETE' });
+	if (!res.ok) {
+		let message = `Delete failed (${res.status})`;
+		try {
+			const body = await res.json();
+			if (body?.error) message = body.error;
+		} catch {
+			// non-JSON error body; fall back to the status message
+		}
+		throw new Error(message);
+	}
+}

--- a/ui/src/lib/session.test.ts
+++ b/ui/src/lib/session.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { getTokenExpiry, isSessionExpired } from './session';
+
+// Build a fake JWT with the given `exp` (epoch seconds). The client only reads
+// the payload's exp claim, so the header/signature can be placeholders.
+function tokenWithExp(exp: number): string {
+	const payload = btoa(JSON.stringify({ exp })).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+	return `header.${payload}.sig`;
+}
+
+describe('getTokenExpiry', () => {
+	it('decodes the exp claim as a millisecond timestamp', () => {
+		const exp = 1_700_000_000;
+		expect(getTokenExpiry(tokenWithExp(exp))).toBe(exp * 1000);
+	});
+
+	it('returns null for a malformed token', () => {
+		expect(getTokenExpiry('not-a-jwt')).toBeNull();
+		expect(getTokenExpiry('a.b')).toBeNull();
+		expect(getTokenExpiry('')).toBeNull();
+	});
+
+	it('returns null when the payload has no numeric exp', () => {
+		const payload = btoa(JSON.stringify({ sub: 'x' })).replace(/=+$/, '');
+		expect(getTokenExpiry(`h.${payload}.s`)).toBeNull();
+	});
+
+	it('returns null when the payload is not valid JSON', () => {
+		const payload = btoa('not json').replace(/=+$/, '');
+		expect(getTokenExpiry(`h.${payload}.s`)).toBeNull();
+	});
+});
+
+describe('isSessionExpired', () => {
+	const nowMs = 1_700_000_000 * 1000;
+	const future = nowMs / 1000 + 10;
+
+	it('is false while the token is still valid', () => {
+		expect(isSessionExpired(tokenWithExp(future), nowMs)).toBe(false);
+	});
+
+	it('is true the instant the token expires', () => {
+		expect(isSessionExpired(tokenWithExp(Math.floor(nowMs / 1000)), nowMs)).toBe(true);
+	});
+
+	it('is true once the token is in the past', () => {
+		expect(isSessionExpired(tokenWithExp(Math.floor(nowMs / 1000) - 5), nowMs)).toBe(true);
+	});
+
+	it('is false when the token has no decodable exp (left for the 401 handler)', () => {
+		expect(isSessionExpired('malformed', nowMs)).toBe(false);
+	});
+});

--- a/ui/src/lib/session.ts
+++ b/ui/src/lib/session.ts
@@ -1,0 +1,33 @@
+// Pure JWT-expiry helpers. Kept free of SvelteKit / DOM dependencies so the
+// countdown logic can be unit-tested in isolation (see session.test.ts).
+export const SESSION_EXPIRED_MESSAGE = 'Your session expired. Please log in again.';
+
+/**
+ * Decodes the `exp` claim of a JWT (an epoch-seconds integer) and returns it as
+ * a millisecond timestamp, or null if the token is malformed or has no `exp`.
+ * The signature/header are not verified here — the client only needs the expiry
+ * to drive the countdown; the server is the authority on validity.
+ */
+export function getTokenExpiry(token: string): number | null {
+	try {
+		const part = token.split('.')[1];
+		if (!part) return null;
+		const b64 = part.replace(/-/g, '+').replace(/_/g, '/');
+		const padded = b64.padEnd(Math.ceil(b64.length / 4) * 4, '=');
+		const payload = JSON.parse(atob(padded));
+		if (typeof payload?.exp === 'number') return payload.exp * 1000;
+	} catch {
+		// malformed token — caller decides how to handle it
+	}
+	return null;
+}
+
+/**
+ * Returns true when the token has an `exp` claim at or before `now`. A token
+ * with no decodable `exp` is treated as not-expired (left for the 401 handler).
+ */
+export function isSessionExpired(token: string, now: number = Date.now()): boolean {
+	const exp = getTokenExpiry(token);
+	if (exp === null) return false;
+	return now >= exp;
+}

--- a/ui/src/routes/+layout.svelte
+++ b/ui/src/routes/+layout.svelte
@@ -1,8 +1,17 @@
 <script lang="ts">
 	import favicon from '$lib/assets/favicon.svg';
+	import { startSessionMonitor } from '$lib/auth';
 	import NavBar from '$lib/components/NavBar.svelte';
 
 	let { children } = $props();
+
+	// Start the background JWT-expiry ticker for the whole app. The layout
+	// persists across client-side navigations, so this runs once per page load
+	// and keeps watching until the page is torn down.
+	$effect(() => {
+		const stop = startSessionMonitor();
+		return () => stop();
+	});
 </script>
 
 <svelte:head>

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -1,8 +1,18 @@
 <script lang="ts">
-	import { isLoggedIn } from '$lib/auth';
+	import { isLoggedIn, sessionExpired, SESSION_EXPIRED_MESSAGE } from '$lib/auth';
 	import LoginForm from '$lib/components/LoginForm.svelte';
 
-	let loggedIn = $state(isLoggedIn());
+	let loggedIn = $state(false);
+
+	// Keep the logged-in state in sync with the session: the subscription fires
+	// immediately with the current store value and again when a session expires,
+	// at which point the token has been cleared so isLoggedIn() is false.
+	$effect(() => {
+		const unsub = sessionExpired.subscribe(() => {
+			loggedIn = isLoggedIn();
+		});
+		return unsub;
+	});
 </script>
 
 <svelte:head>
@@ -14,6 +24,16 @@
 	<p>Head to <a href="/facilities">Facilities</a>, <a href="/formats">Formats</a>, <a href="/ratings">Ratings</a>, <a href="/rulesets">Rulesets</a>, <a href="/scoring-structures">Scoring Structures</a>, or <a href="/playoff-structures">Playoff Structures</a> to get started.</p>
 {:else}
 	<h1>IntraClub</h1>
+	{#if $sessionExpired}
+		<p class="session-expired" role="status">{SESSION_EXPIRED_MESSAGE}</p>
+	{/if}
 	<p>Welcome! Log in to manage your club.</p>
 	<LoginForm />
 {/if}
+
+<style>
+	.session-expired {
+		color: #c00;
+		font-weight: 600;
+	}
+</style>

--- a/ui/src/routes/photos/+page.svelte
+++ b/ui/src/routes/photos/+page.svelte
@@ -1,0 +1,84 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { listPhotos, dataUrlFor, photoTypeLabels } from '$lib/photo';
+	import type { Photo } from '$lib/photo';
+
+	let photos = $state<Photo[]>([]);
+	let loading = $state(true);
+	let error = $state('');
+
+	function photoTypeLabel(type: number): string {
+		return photoTypeLabels[type] ?? 'unknown';
+	}
+
+	onMount(async () => {
+		try {
+			photos = await listPhotos();
+		} catch (e) {
+			error = e instanceof Error ? e.message : 'Failed to load photos';
+		} finally {
+			loading = false;
+		}
+	});
+</script>
+
+<svelte:head>
+	<title>Photos</title>
+</svelte:head>
+
+<h1>Photos</h1>
+<a href="/photos/new">New photo</a>
+
+{#if loading}
+	<p>Loading...</p>
+{:else if error}
+	<p class="error">{error}</p>
+{:else if photos.length === 0}
+	<p>No photos yet.</p>
+{:else}
+	<table>
+		<thead>
+			<tr>
+				<th>Thumbnail</th>
+				<th>Alt text</th>
+				<th>Type</th>
+			</tr>
+		</thead>
+		<tbody>
+			{#each photos as photo}
+				<tr>
+					<td class="thumb">
+						<a href={`/photos/${photo.id}`}>
+							<img src={dataUrlFor(photo)} alt={photo.alt_text || 'Photo thumbnail'} />
+						</a>
+					</td>
+					<td><a href={`/photos/${photo.id}`}>{photo.alt_text || '(no alt text)'}</a></td>
+					<td>{photoTypeLabel(photo.file_type)}</td>
+				</tr>
+			{/each}
+		</tbody>
+	</table>
+{/if}
+
+<style>
+	.error {
+		color: #c00;
+	}
+	table {
+		border-collapse: collapse;
+		margin-top: 1rem;
+	}
+	th,
+	td {
+		border: 1px solid #ccc;
+		padding: 0.4rem 0.8rem;
+		text-align: left;
+	}
+	.thumb img {
+		display: block;
+		width: 48px;
+		height: 48px;
+		object-fit: cover;
+		border-radius: 4px;
+	}
+</style>

--- a/ui/src/routes/photos/[id]/+page.svelte
+++ b/ui/src/routes/photos/[id]/+page.svelte
@@ -1,0 +1,203 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { page } from '$app/state';
+	import { goto } from '$app/navigation';
+	import {
+		getPhoto,
+		updatePhoto,
+		deletePhoto,
+		dataUrlFor,
+		photoTypeFromExtension,
+		photoTypeLabels,
+		type Photo,
+		type PhotoType
+	} from '$lib/photo';
+
+	const id = () => page.params.id as string;
+
+	let photo = $state<Photo | null>(null);
+	let loadError = $state('');
+	let altText = $state('');
+	let fileType = $state<PhotoType>(0);
+	let contents = $state('');
+	let error = $state('');
+	let saving = $state(false);
+	let deleting = $state(false);
+
+	onMount(load);
+
+	async function load() {
+		loadError = '';
+		try {
+			const p = await getPhoto(id());
+			photo = p;
+			altText = p.alt_text;
+			fileType = p.file_type;
+			contents = p.contents;
+		} catch (e) {
+			loadError = e instanceof Error ? e.message : 'Failed to load photo';
+		}
+	}
+
+	function onFileChange(e: Event) {
+		const input = e.target as HTMLInputElement;
+		const file = input.files?.[0];
+		if (!file) return;
+		const type = photoTypeFromExtension(file.name);
+		if (type === null) {
+			error = `Unsupported file type. Use one of: ${Object.values(photoTypeLabels).join(', ')}.`;
+			return;
+		}
+		fileType = type;
+		error = '';
+		const reader = new FileReader();
+		reader.onload = () => {
+			const result = reader.result as string;
+			contents = result.split(',')[1] ?? '';
+		};
+		reader.readAsDataURL(file);
+	}
+
+	async function handleSave(e: Event) {
+		e.preventDefault();
+		error = '';
+		saving = true;
+		try {
+			const updated = await updatePhoto(id(), {
+				alt_text: altText,
+				contents,
+				file_type: fileType
+			});
+			photo = updated;
+			altText = updated.alt_text;
+			fileType = updated.file_type;
+			contents = updated.contents;
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Failed to update photo';
+		} finally {
+			saving = false;
+		}
+	}
+
+	async function handleDelete() {
+		if (!confirm('Delete this photo?')) return;
+		error = '';
+		deleting = true;
+		try {
+			await deletePhoto(id());
+			await goto('/photos');
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Failed to delete photo';
+			deleting = false;
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>Photo</title>
+</svelte:head>
+
+{#if loadError}
+	<h1>Photo</h1>
+	<p class="error">{loadError}</p>
+	<a href="/photos">&larr; Back to photos</a>
+{:else if !photo}
+	<h1>Photo</h1>
+	<p>Loading...</p>
+{:else}
+	<h1>Photo</h1>
+	<a href="/photos">&larr; Back to photos</a>
+
+	<img class="detail" src={dataUrlFor(photo)} alt={photo.alt_text || 'Photo'} />
+
+	<dl class="meta">
+		<div>
+			<dt>Alt text</dt>
+			<dd>{photo.alt_text || '(none)'}</dd>
+		</div>
+		<div>
+			<dt>File type</dt>
+			<dd>{photoTypeLabels[photo.file_type] ?? 'unknown'}</dd>
+		</div>
+		<div>
+			<dt>Owner</dt>
+			<dd>{photo.owner}</dd>
+		</div>
+	</dl>
+
+	<h2>Edit</h2>
+	<form onsubmit={handleSave}>
+		<label>
+			Alt text
+			<input type="text" bind:value={altText} />
+		</label>
+		<label>
+			File
+			<input type="file" accept="image/*" onchange={onFileChange} />
+		</label>
+		<label>
+			File type
+			<select bind:value={fileType}>
+				<option value={0}>png</option>
+				<option value={1}>jpg</option>
+				<option value={2}>jpeg</option>
+				<option value={3}>gif</option>
+				<option value={4}>webp</option>
+			</select>
+		</label>
+		<button type="submit" disabled={saving}>{saving ? 'Saving...' : 'Save changes'}</button>
+	</form>
+
+	<button type="button" onclick={handleDelete} disabled={deleting} class="danger">
+		{deleting ? 'Deleting...' : 'Delete photo'}
+	</button>
+
+	{#if error}
+		<p class="error">{error}</p>
+	{/if}
+{/if}
+
+<style>
+	.error {
+		color: #c00;
+	}
+	.detail {
+		max-width: 360px;
+		max-height: 240px;
+		border: 1px solid #ccc;
+		border-radius: 6px;
+		margin-top: 0.5rem;
+	}
+	.meta {
+		display: flex;
+		gap: 1.5rem;
+		margin: 1rem 0;
+	}
+	.meta dt {
+		font-size: 0.85rem;
+		color: #666;
+	}
+	.meta dd {
+		margin: 0;
+	}
+	form {
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+		max-width: 24rem;
+		margin-top: 0.5rem;
+	}
+	label {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+	}
+	input,
+	select {
+		padding: 0.35rem;
+	}
+	.danger {
+		margin-top: 1rem;
+		color: #c00;
+	}
+</style>

--- a/ui/src/routes/photos/new/+page.svelte
+++ b/ui/src/routes/photos/new/+page.svelte
@@ -1,0 +1,103 @@
+<script lang="ts">
+	import { createPhoto, photoTypeFromExtension, photoTypeLabels } from '$lib/photo';
+	import { goto } from '$app/navigation';
+	import type { PhotoType } from '$lib/photo';
+
+	let altText = $state('');
+	let contents = $state('');
+	let fileType = $state<PhotoType>(0);
+	let error = $state('');
+	let submitting = $state(false);
+
+	function onFileChange(e: Event) {
+		const input = e.target as HTMLInputElement;
+		const file = input.files?.[0];
+		if (!file) return;
+		const type = photoTypeFromExtension(file.name);
+		if (type === null) {
+			error = `Unsupported file type. Use one of: ${Object.values(photoTypeLabels).join(', ')}.`;
+			return;
+		}
+		fileType = type;
+		error = '';
+		const reader = new FileReader();
+		reader.onload = () => {
+			const result = reader.result as string;
+			contents = result.split(',')[1] ?? '';
+		};
+		reader.readAsDataURL(file);
+	}
+
+	async function handleSubmit(e: Event) {
+		e.preventDefault();
+		error = '';
+		if (!contents) {
+			error = 'Please choose an image file to upload.';
+			return;
+		}
+		submitting = true;
+		try {
+			const created = await createPhoto({ alt_text: altText, contents, file_type: fileType });
+			await goto(`/photos/${created.id}`);
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Failed to create photo';
+		} finally {
+			submitting = false;
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>New photo</title>
+</svelte:head>
+
+<h1>New photo</h1>
+<a href="/photos">&larr; Back to photos</a>
+
+<form onsubmit={handleSubmit}>
+	<label>
+		File
+		<input type="file" accept="image/*" onchange={onFileChange} required />
+	</label>
+	<label>
+		Alt text
+		<input type="text" bind:value={altText} />
+	</label>
+	<label>
+		File type
+		<select bind:value={fileType}>
+			<option value={0}>png</option>
+			<option value={1}>jpg</option>
+			<option value={2}>jpeg</option>
+			<option value={3}>gif</option>
+			<option value={4}>webp</option>
+		</select>
+	</label>
+	<button type="submit" disabled={submitting}>{submitting ? 'Creating...' : 'Create photo'}</button>
+</form>
+
+{#if error}
+	<p class="error">{error}</p>
+{/if}
+
+<style>
+	.error {
+		color: #c00;
+	}
+	form {
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+		max-width: 24rem;
+		margin-top: 1rem;
+	}
+	label {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+	}
+	input,
+	select {
+		padding: 0.35rem;
+	}
+</style>

--- a/ui/vitest.config.ts
+++ b/ui/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		// Only pick up unit tests under src/ — the Playwright suites live in
+		// e2e/*.spec.ts and run via `npm run test:e2e`.
+		include: ['src/**/*.test.ts'],
+		environment: 'node'
+	}
+});


### PR DESCRIPTION
Closes #92

## Summary
Graceful, automated handling of JWT/magic-link token expiry on the client so users are sent back to the login page with a "please re-login" message instead of opaque API errors.

## Backend
- `api.JwtLifetime` is now a configurable variable (was a hard-coded const) driven by a new `--jwt-lifetime` flag and `INTRACLUB_JWT_LIFETIME` env var (default 2h). Non-positive values are rejected. This lets tests mint short-lived tokens and exercise the expiry path end-to-end instead of waiting 2h.

## Client (`ui/src/lib`)
- `session.ts`: pure helpers `getTokenExpiry` / `isSessionExpired` that decode the stored token's `exp` claim.
- `auth.ts`: background ticker (`startSessionMonitor`) started in the root layout that clears the token and redirects to `/` the moment `exp` elapses; `authFetch` also expires the session reactively on a 401 (belt-and-suspenders for clock/ticker drift). Both paths converge on an idempotent `expireSession()`.
- Landing page (`+page.svelte`) shows "Your session expired. Please log in again." when the session was ended by expiry.

## Tests
- Unit (vitest): countdown helpers — decode, already-expired, malformed tokens.
- e2e (Playwright): proactive countdown redirect + message + token cleared; reactive 401 redirect + message + token cleared.
- Go: configurable-lifetime resolution (flag/env/default, non-positive rejected) and an already-expired-token validation test.