### PR TITLE
UI: migrate Ratings pages to shadcn-svelte

### DIFF
--- a/ui/e2e/format-ratings.spec.ts
+++ b/ui/e2e/format-ratings.spec.ts
@@ -71,10 +71,8 @@ test('assign ratings to a format: add, list, remove', async ({ page }) => {
 
 	// Clean up. Deleting a format now cascades to its format_rating / format_line
 	// join rows, so the ratings are no longer "in-use" and can be deleted to
-	// keep the shared dev db clean.
-	// The format delete confirms via an in-app popover (no window.confirm); the
-	// dialog handler below is still needed for the ratings deletes further down.
-	page.on('dialog', (d) => d.accept());
+	// keep the shared dev db clean. Both deletes below confirm via an in-app
+	// popover (no window.confirm).
 	await page.getByRole('button', { name: 'Delete format' }).click();
 	await page.getByRole('button', { name: 'Delete', exact: true }).click();
 	await expect(page).toHaveURL('/formats');
@@ -85,6 +83,7 @@ test('assign ratings to a format: add, list, remove', async ({ page }) => {
 		await page.getByRole('link', { name: ratingName }).click();
 		await expect(page).toHaveURL(/\/ratings\/[0-9a-f]+$/);
 		await page.getByRole('button', { name: 'Delete rating' }).click();
+		await page.getByRole('button', { name: 'Delete', exact: true }).click();
 		await expect(page).toHaveURL('/ratings');
 		await expect(page.getByRole('link', { name: ratingName })).toHaveCount(0);
 	}

--- a/ui/e2e/format-ratings.spec.ts
+++ b/ui/e2e/format-ratings.spec.ts
@@ -72,8 +72,11 @@ test('assign ratings to a format: add, list, remove', async ({ page }) => {
 	// Clean up. Deleting a format now cascades to its format_rating / format_line
 	// join rows, so the ratings are no longer "in-use" and can be deleted to
 	// keep the shared dev db clean.
+	// The format delete confirms via an in-app popover (no window.confirm); the
+	// dialog handler below is still needed for the ratings deletes further down.
 	page.on('dialog', (d) => d.accept());
 	await page.getByRole('button', { name: 'Delete format' }).click();
+	await page.getByRole('button', { name: 'Delete', exact: true }).click();
 	await expect(page).toHaveURL('/formats');
 	await expect(page.getByRole('link', { name: formatName })).toHaveCount(0);
 

--- a/ui/e2e/format.spec.ts
+++ b/ui/e2e/format.spec.ts
@@ -22,6 +22,13 @@ async function login(page: Page) {
 // (spawned from the repo root) keeps its SQLite db at <repo>/intraclub.db.
 const dbPath = fileURLToPath(new URL('../../intraclub.db', import.meta.url));
 
+// Delete now confirms through an in-app shadcn Popover (no native window.confirm):
+// click the trigger, then the "Delete" button inside the popover.
+async function confirmDelete(page: Page) {
+	await page.getByRole('button', { name: 'Delete format' }).click();
+	await page.getByRole('button', { name: 'Delete', exact: true }).click();
+}
+
 test('format CRUD: create, view, update, delete', async ({ page }) => {
 	await login(page);
 
@@ -49,20 +56,16 @@ test('format CRUD: create, view, update, delete', async ({ page }) => {
 	const row = page.getByRole('link', { name: `Test Format ${unique} Updated` });
 	await expect(row).toBeVisible();
 
-	// Delete (accept the confirm dialog)
+	// Delete (confirm via the popover)
 	await row.click();
 	await expect(page.getByRole('heading', { name: `Test Format ${unique} Updated` })).toBeVisible();
-	page.on('dialog', (d) => d.accept());
-	await page.getByRole('button', { name: 'Delete format' }).click();
+	await confirmDelete(page);
 	await expect(page).toHaveURL('/formats');
 	await expect(page.getByRole('link', { name: `Test Format ${unique} Updated` })).toHaveCount(0);
 });
 
 test('format delete is blocked when the format is assigned to a draft', async ({ page }) => {
 	await login(page);
-
-	// Both delete attempts below use window.confirm; accept every dialog.
-	page.on('dialog', (d) => d.accept());
 
 	// Create a format to attempt deletion of.
 	const unique = Date.now();
@@ -93,7 +96,7 @@ test('format delete is blocked when the format is assigned to a draft', async ({
 		);
 
 		// Attempt to delete -> PreDelete blocks it and the page surfaces the error.
-		await page.getByRole('button', { name: 'Delete format' }).click();
+		await confirmDelete(page);
 		await expect(page.getByText(/assigned drafts/)).toBeVisible();
 	} finally {
 		// Clean up the draft_format row so it can't affect other tests.
@@ -102,7 +105,7 @@ test('format delete is blocked when the format is assigned to a draft', async ({
 	}
 
 	// With the draft gone, the format can now be deleted.
-	await page.getByRole('button', { name: 'Delete format' }).click();
+	await confirmDelete(page);
 	await expect(page).toHaveURL('/formats');
 	await expect(page.getByRole('link', { name: `In Use Format ${unique}` })).toHaveCount(0);
 });

--- a/ui/e2e/rating.spec.ts
+++ b/ui/e2e/rating.spec.ts
@@ -22,6 +22,13 @@ async function login(page: Page) {
 // (spawned from the repo root) keeps its SQLite db at <repo>/intraclub.db.
 const dbPath = fileURLToPath(new URL('../../intraclub.db', import.meta.url));
 
+// Delete now confirms through an in-app shadcn Popover (no native window.confirm):
+// click the trigger, then the "Delete" button inside the popover.
+async function confirmDelete(page: Page) {
+	await page.getByRole('button', { name: 'Delete rating' }).click();
+	await page.getByRole('button', { name: 'Delete', exact: true }).click();
+}
+
 test('rating CRUD: create, view, update, delete', async ({ page }) => {
 	await login(page);
 
@@ -52,20 +59,16 @@ test('rating CRUD: create, view, update, delete', async ({ page }) => {
 	const row = page.getByRole('link', { name: `Test Rating ${unique} Updated` });
 	await expect(row).toBeVisible();
 
-	// Delete (accept the confirm dialog)
+	// Delete (confirm via the popover)
 	await row.click();
 	await expect(page.getByRole('heading', { name: `Test Rating ${unique} Updated` })).toBeVisible();
-	page.on('dialog', (d) => d.accept());
-	await page.getByRole('button', { name: 'Delete rating' }).click();
+	await confirmDelete(page);
 	await expect(page).toHaveURL('/ratings');
 	await expect(page.getByRole('link', { name: `Test Rating ${unique} Updated` })).toHaveCount(0);
 });
 
 test('rating delete is blocked when the rating is assigned to a format', async ({ page }) => {
 	await login(page);
-
-	// Both delete attempts below use window.confirm; accept every dialog.
-	page.on('dialog', (d) => d.accept());
 
 	// Create a rating to attempt deletion of.
 	const unique = Date.now();
@@ -94,7 +97,7 @@ test('rating delete is blocked when the rating is assigned to a format', async (
 		).run(formatRatingId, formatId, ratingId, 0);
 
 		// Attempt to delete -> PreDelete blocks it and the page surfaces the error.
-		await page.getByRole('button', { name: 'Delete rating' }).click();
+		await confirmDelete(page);
 		await expect(page.getByText(/in-use by/)).toBeVisible();
 	} finally {
 		// Clean up the format_rating row so it can't affect other tests.
@@ -103,7 +106,7 @@ test('rating delete is blocked when the rating is assigned to a format', async (
 	}
 
 	// With the format_rating gone, the rating can now be deleted.
-	await page.getByRole('button', { name: 'Delete rating' }).click();
+	await confirmDelete(page);
 	await expect(page).toHaveURL('/ratings');
 	await expect(page.getByRole('link', { name: `In Use Rating ${unique}` })).toHaveCount(0);
 });

--- a/ui/src/lib/components/ui/native-select/index.ts
+++ b/ui/src/lib/components/ui/native-select/index.ts
@@ -1,0 +1,12 @@
+import OptGroup from "./native-select-opt-group.svelte";
+import Option from "./native-select-option.svelte";
+import Root from "./native-select.svelte";
+
+export {
+	Root,
+	Option,
+	OptGroup,
+	Root as NativeSelect,
+	Option as NativeSelectOption,
+	OptGroup as NativeSelectOptGroup,
+};

--- a/ui/src/lib/components/ui/native-select/native-select-opt-group.svelte
+++ b/ui/src/lib/components/ui/native-select/native-select-opt-group.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	import type { WithElementRef } from "$lib/utils.js";
+	import type { HTMLOptgroupAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		children,
+		...restProps
+	}: WithElementRef<HTMLOptgroupAttributes> = $props();
+</script>
+
+<optgroup bind:this={ref} data-slot="native-select-opt-group" {...restProps}>
+	{@render children?.()}
+</optgroup>

--- a/ui/src/lib/components/ui/native-select/native-select-option.svelte
+++ b/ui/src/lib/components/ui/native-select/native-select-option.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLOptionAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLOptionAttributes> = $props();
+</script>
+
+<option
+	bind:this={ref}
+	data-slot="native-select-option"
+	class={cn("bg-[Canvas] text-[CanvasText]", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</option>

--- a/ui/src/lib/components/ui/native-select/native-select.svelte
+++ b/ui/src/lib/components/ui/native-select/native-select.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+	import ChevronDownIcon from '@lucide/svelte/icons/chevron-down';
+	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLSelectAttributes } from "svelte/elements";
+
+	type NativeSelectProps = Omit<WithElementRef<HTMLSelectAttributes>, "size"> & {
+		size?: "sm" | "default";
+	};
+
+	let {
+		ref = $bindable(null),
+		value = $bindable(),
+		class: className,
+		size = "default",
+		children,
+		...restProps
+	}: NativeSelectProps = $props();
+</script>
+
+<div
+	class={cn(
+		"cn-native-select-wrapper group/native-select relative w-fit has-[select:disabled]:opacity-50",
+		className
+	)}
+	data-slot="native-select-wrapper"
+	data-size={size}
+>
+	<select
+		bind:value
+		bind:this={ref}
+		data-slot="native-select"
+		data-size={size}
+		class="h-8 w-full min-w-0 appearance-none rounded-lg border border-input bg-transparent py-1 pr-8 pl-2.5 text-sm transition-colors select-none selection:bg-primary selection:text-primary-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] data-[size=sm]:py-0.5 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 outline-none disabled:pointer-events-none disabled:cursor-not-allowed"
+		{...restProps}
+	>
+		{@render children?.()}
+	</select>
+	<ChevronDownIcon class="top-1/2 right-2.5 size-4 -translate-y-1/2 text-muted-foreground pointer-events-none absolute select-none" aria-hidden data-slot="native-select-icon" />
+</div>

--- a/ui/src/lib/components/ui/textarea/index.ts
+++ b/ui/src/lib/components/ui/textarea/index.ts
@@ -1,0 +1,7 @@
+import Root from "./textarea.svelte";
+
+export {
+	Root,
+	//
+	Root as Textarea,
+};

--- a/ui/src/lib/components/ui/textarea/textarea.svelte
+++ b/ui/src/lib/components/ui/textarea/textarea.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLTextareaAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		value = $bindable(),
+		class: className,
+		"data-slot": dataSlot = "textarea",
+		...restProps
+	}: WithElementRef<HTMLTextareaAttributes> = $props();
+</script>
+
+<textarea
+	bind:this={ref}
+	data-slot={dataSlot}
+	class={cn(
+		"rounded-lg border border-input bg-transparent px-2.5 py-2 text-base transition-colors focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:bg-input/50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 flex field-sizing-content min-h-16 w-full outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+		className
+	)}
+	bind:value
+	{...restProps}></textarea>

--- a/ui/src/routes/formats/+page.svelte
+++ b/ui/src/routes/formats/+page.svelte
@@ -2,6 +2,15 @@
 	import { onMount } from 'svelte';
 	import { listFormats } from '$lib/format';
 	import type { Format } from '$lib/format';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import {
+		Table,
+		TableBody,
+		TableCell,
+		TableHead,
+		TableHeader,
+		TableRow
+	} from '$lib/components/ui/table/index.js';
 
 	let formats = $state<Format[]>([]);
 	let loading = $state(true);
@@ -22,44 +31,36 @@
 	<title>Formats</title>
 </svelte:head>
 
-<h1>Formats</h1>
-<a href="/formats/new">New format</a>
+<div class="flex items-center justify-between gap-4">
+	<h1 class="text-2xl font-semibold tracking-tight">Formats</h1>
+	<Button href="/formats/new">New format</Button>
+</div>
 
 {#if loading}
-	<p>Loading...</p>
+	<p class="text-muted-foreground">Loading...</p>
 {:else if error}
-	<p class="error">{error}</p>
+	<p class="text-sm font-medium text-destructive">{error}</p>
 {:else if formats.length === 0}
-	<p>No formats yet.</p>
+	<p class="text-muted-foreground">No formats yet.</p>
 {:else}
-	<table>
-		<thead>
-			<tr>
-				<th>Name</th>
-			</tr>
-		</thead>
-		<tbody>
-			{#each formats as format}
-				<tr>
-					<td><a href={`/formats/${format.id}`}>{format.name}</a></td>
-				</tr>
-			{/each}
-		</tbody>
-	</table>
+	<div class="mt-4 overflow-hidden rounded-lg border">
+		<Table>
+			<TableHeader>
+				<TableRow>
+					<TableHead>Name</TableHead>
+				</TableRow>
+			</TableHeader>
+			<TableBody>
+				{#each formats as format}
+					<TableRow>
+						<TableCell>
+							<a href={`/formats/${format.id}`} class="font-medium text-primary underline-offset-4 hover:underline">
+								{format.name}
+							</a>
+						</TableCell>
+					</TableRow>
+				{/each}
+			</TableBody>
+		</Table>
+	</div>
 {/if}
-
-<style>
-	.error {
-		color: #c00;
-	}
-	table {
-		border-collapse: collapse;
-		margin-top: 1rem;
-	}
-	th,
-	td {
-		border: 1px solid #ccc;
-		padding: 0.4rem 0.8rem;
-		text-align: left;
-	}
-</style>

--- a/ui/src/routes/formats/[id]/+page.svelte
+++ b/ui/src/routes/formats/[id]/+page.svelte
@@ -12,6 +12,23 @@
 	import type { Format } from '$lib/format';
 	import { listRatings } from '$lib/rating';
 	import type { Rating } from '$lib/rating';
+	import { Badge } from '$lib/components/ui/badge/index.js';
+	import { Button, buttonVariants } from '$lib/components/ui/button/index.js';
+	import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
+	import {
+		NativeSelect,
+		NativeSelectOption
+	} from '$lib/components/ui/native-select/index.js';
+	import {
+		Popover,
+		PopoverClose,
+		PopoverContent,
+		PopoverHeader,
+		PopoverTitle,
+		PopoverTrigger
+	} from '$lib/components/ui/popover/index.js';
 
 	const id = () => page.params.id as string;
 
@@ -21,6 +38,7 @@
 	let error = $state('');
 	let saving = $state(false);
 	let deleting = $state(false);
+	let deleteOpen = $state(false);
 
 	// Possible ratings assigned to this format.
 	let possibleRatings = $state<Rating[]>([]);
@@ -77,7 +95,7 @@
 	}
 
 	async function handleDelete() {
-		if (!confirm('Delete this format?')) return;
+		deleteOpen = false;
 		error = '';
 		deleting = true;
 		try {
@@ -121,41 +139,53 @@
 </svelte:head>
 
 {#if loadError}
-	<h1>Format</h1>
-	<p class="error">{loadError}</p>
-	<a href="/formats">&larr; Back to formats</a>
+	<h1 class="text-2xl font-semibold tracking-tight">Format</h1>
+	<p class="text-sm font-medium text-destructive">{loadError}</p>
+	<a href="/formats" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to formats</a>
 {:else if !format}
-	<h1>Format</h1>
-	<p>Loading...</p>
+	<h1 class="text-2xl font-semibold tracking-tight">Format</h1>
+	<p class="text-muted-foreground">Loading...</p>
 {:else}
-	<h1>{format.name}</h1>
-	<a href="/formats">&larr; Back to formats</a>
+	<div class="flex items-center gap-4">
+		<h1 class="text-2xl font-semibold tracking-tight">{format.name}</h1>
+		<a href="/formats" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to formats</a>
+	</div>
 
-	<form onsubmit={handleSave}>
-		<label>
-			Name
-			<input type="text" bind:value={name} required />
-		</label>
-		<button type="submit" disabled={saving}>{saving ? 'Saving...' : 'Save changes'}</button>
-	</form>
+	<Card class="mt-6 max-w-md">
+		<CardHeader>
+			<CardTitle class="text-base">Format details</CardTitle>
+		</CardHeader>
+		<CardContent>
+			<form onsubmit={handleSave} class="flex flex-col gap-4">
+				<div class="flex flex-col gap-2">
+					<Label for="name">Name</Label>
+					<Input id="name" type="text" bind:value={name} required />
+				</div>
+				<Button type="submit" disabled={saving} class="w-fit">
+					{saving ? 'Saving...' : 'Save changes'}
+				</Button>
+			</form>
+		</CardContent>
+	</Card>
 
-	<section class="ratings">
-		<h2>Possible ratings</h2>
-		<p class="hint">
+	<section class="mt-8 max-w-md">
+		<h2 class="text-xl font-semibold tracking-tight">Possible ratings</h2>
+		<p class="mt-1 text-sm text-muted-foreground">
 			The skill ratings that players can be assigned to in this format, ordered
 			highest-skill to lowest-skill.
 		</p>
 
 		{#if possibleRatings.length === 0}
-			<p>No ratings assigned yet.</p>
+			<p class="mt-4 text-muted-foreground">No ratings assigned yet.</p>
 		{:else}
-			<ul class="rating-list">
+			<ul class="mt-4 flex flex-col gap-2">
 				{#each possibleRatings as rating}
-					<li>
-						<span class="rating-name">{rating.name}</span>
-						<button
+					<li class="flex items-center justify-between gap-2 rounded-lg border p-2 pl-3">
+						<Badge variant="secondary" class="rating-name">{rating.name}</Badge>
+						<Button
 							type="button"
-							class="remove"
+							variant="outline"
+							size="sm"
 							onclick={() => handleRemoveRating(rating.id)}
 							disabled={ratingsSaving || possibleRatings.length === 1}
 							title={possibleRatings.length === 1
@@ -163,103 +193,61 @@
 								: undefined}
 						>
 							Remove
-						</button>
+						</Button>
 					</li>
 				{/each}
 			</ul>
 			{#if possibleRatings.length === 1}
-				<p class="hint">A format must keep at least one rating.</p>
+				<p class="mt-2 text-sm text-muted-foreground">A format must keep at least one rating.</p>
 			{/if}
 		{/if}
 
 		{#if unassignedRatings.length > 0}
-			<form class="add" onsubmit={handleAddRating}>
-				<select bind:value={selectedRatingId} aria-label="Rating to assign">
-					<option value="" disabled>Select a rating…</option>
+			<form onsubmit={handleAddRating} class="mt-4 flex items-center gap-2">
+				<NativeSelect
+					bind:value={selectedRatingId}
+					aria-label="Rating to assign"
+					class="flex-1"
+				>
+					<NativeSelectOption value="" disabled>Select a rating…</NativeSelectOption>
 					{#each unassignedRatings as rating}
-						<option value={rating.id}>{rating.name}</option>
+						<NativeSelectOption value={rating.id}>{rating.name}</NativeSelectOption>
 					{/each}
-				</select>
-				<button type="submit" disabled={ratingsSaving || !selectedRatingId}>
+				</NativeSelect>
+				<Button type="submit" disabled={ratingsSaving || !selectedRatingId}>
 					Add rating
-				</button>
+				</Button>
 			</form>
 		{:else if allRatings.length > 0}
-			<p class="hint">All ratings are already assigned.</p>
+			<p class="mt-4 text-sm text-muted-foreground">All ratings are already assigned.</p>
 		{/if}
 
 		{#if ratingsError}
-			<p class="error">{ratingsError}</p>
+			<p class="mt-3 text-sm font-medium text-destructive">{ratingsError}</p>
 		{/if}
 	</section>
 
-	<button type="button" onclick={handleDelete} disabled={deleting} class="danger">
-		{deleting ? 'Deleting...' : 'Delete format'}
-	</button>
+	<div class="mt-8">
+		<Popover bind:open={deleteOpen}>
+			<PopoverTrigger disabled={deleting} class={buttonVariants({ variant: 'destructive' })}>
+				{deleting ? 'Deleting...' : 'Delete format'}
+			</PopoverTrigger>
+			<PopoverContent class="w-80">
+				<PopoverHeader>
+					<PopoverTitle>Delete format?</PopoverTitle>
+					<p class="text-sm text-muted-foreground">
+						This permanently removes this format and cannot be undone.
+					</p>
+				</PopoverHeader>
+				<div class="flex justify-end gap-2">
+					<PopoverClose class={buttonVariants({ variant: 'outline', size: 'sm' })}>Cancel</PopoverClose>
+					<Button variant="destructive" size="sm" onclick={handleDelete}>Delete</Button>
+				</div>
+			</PopoverContent>
+		</Popover>
+	</div>
 
 	{#if error}
-		<p class="error">{error}</p>
+		<p class="mt-4 text-sm font-medium text-destructive">{error}</p>
 	{/if}
 {/if}
-
-<style>
-	.error {
-		color: #c00;
-	}
-	.hint {
-		color: #666;
-		font-size: 0.9rem;
-	}
-	form {
-		display: flex;
-		flex-direction: column;
-		gap: 0.75rem;
-		max-width: 24rem;
-		margin-top: 1rem;
-	}
-	label {
-		display: flex;
-		flex-direction: column;
-		gap: 0.25rem;
-	}
-	input {
-		padding: 0.35rem;
-	}
-	.ratings {
-		margin-top: 1.5rem;
-		max-width: 24rem;
-	}
-	.rating-list {
-		list-style: none;
-		padding: 0;
-		margin: 0.5rem 0;
-		display: flex;
-		flex-direction: column;
-		gap: 0.4rem;
-	}
-	.rating-list li {
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		border: 1px solid #ccc;
-		padding: 0.4rem 0.6rem;
-	}
-	.rating-name {
-		font-weight: 600;
-	}
-	.remove {
-		color: #c00;
-	}
-	.add {
-		flex-direction: row;
-		align-items: center;
-	}
-	select {
-		padding: 0.35rem;
-		flex: 1;
-	}
-	.danger {
-		margin-top: 1.5rem;
-		color: #c00;
-	}
-</style>

--- a/ui/src/routes/formats/new/+page.svelte
+++ b/ui/src/routes/formats/new/+page.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
 	import { createFormat } from '$lib/format';
 	import { goto } from '$app/navigation';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
 
 	let name = $state('');
 	let error = $state('');
@@ -25,38 +29,28 @@
 	<title>New format</title>
 </svelte:head>
 
-<h1>New format</h1>
-<a href="/formats">&larr; Back to formats</a>
+<div class="flex items-center gap-4">
+	<h1 class="text-2xl font-semibold tracking-tight">New format</h1>
+	<a href="/formats" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to formats</a>
+</div>
 
-<form onsubmit={handleSubmit}>
-	<label>
-		Name
-		<input type="text" bind:value={name} required />
-	</label>
-	<button type="submit" disabled={submitting}>{submitting ? 'Creating...' : 'Create format'}</button>
-</form>
+<Card class="mt-6 max-w-md">
+	<CardHeader>
+		<CardTitle class="text-base">Format details</CardTitle>
+	</CardHeader>
+	<CardContent>
+		<form onsubmit={handleSubmit} class="flex flex-col gap-4">
+			<div class="flex flex-col gap-2">
+				<Label for="name">Name</Label>
+				<Input id="name" type="text" bind:value={name} required />
+			</div>
+			<Button type="submit" disabled={submitting} class="w-fit">
+				{submitting ? 'Creating...' : 'Create format'}
+			</Button>
+		</form>
+	</CardContent>
+</Card>
 
 {#if error}
-	<p class="error">{error}</p>
+	<p class="mt-4 text-sm font-medium text-destructive">{error}</p>
 {/if}
-
-<style>
-	.error {
-		color: #c00;
-	}
-	form {
-		display: flex;
-		flex-direction: column;
-		gap: 0.75rem;
-		max-width: 24rem;
-		margin-top: 1rem;
-	}
-	label {
-		display: flex;
-		flex-direction: column;
-		gap: 0.25rem;
-	}
-	input {
-		padding: 0.35rem;
-	}
-</style>

--- a/ui/src/routes/ratings/+page.svelte
+++ b/ui/src/routes/ratings/+page.svelte
@@ -2,6 +2,15 @@
 	import { onMount } from 'svelte';
 	import { listRatings } from '$lib/rating';
 	import type { Rating } from '$lib/rating';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import {
+		Table,
+		TableBody,
+		TableCell,
+		TableHead,
+		TableHeader,
+		TableRow
+	} from '$lib/components/ui/table/index.js';
 
 	let ratings = $state<Rating[]>([]);
 	let loading = $state(true);
@@ -22,46 +31,38 @@
 	<title>Ratings</title>
 </svelte:head>
 
-<h1>Ratings</h1>
-<a href="/ratings/new">New rating</a>
+<div class="flex items-center justify-between gap-4">
+	<h1 class="text-2xl font-semibold tracking-tight">Ratings</h1>
+	<Button href="/ratings/new">New rating</Button>
+</div>
 
 {#if loading}
-	<p>Loading...</p>
+	<p class="text-muted-foreground">Loading...</p>
 {:else if error}
-	<p class="error">{error}</p>
+	<p class="text-sm font-medium text-destructive">{error}</p>
 {:else if ratings.length === 0}
-	<p>No ratings yet.</p>
+	<p class="text-muted-foreground">No ratings yet.</p>
 {:else}
-	<table>
-		<thead>
-			<tr>
-				<th>Name</th>
-				<th>Description</th>
-			</tr>
-		</thead>
-		<tbody>
-			{#each ratings as rating}
-				<tr>
-					<td><a href={`/ratings/${rating.id}`}>{rating.name}</a></td>
-					<td>{rating.description}</td>
-				</tr>
-			{/each}
-		</tbody>
-	</table>
+	<div class="mt-4 overflow-hidden rounded-lg border">
+		<Table>
+			<TableHeader>
+				<TableRow>
+					<TableHead>Name</TableHead>
+					<TableHead>Description</TableHead>
+				</TableRow>
+			</TableHeader>
+			<TableBody>
+				{#each ratings as rating}
+					<TableRow>
+						<TableCell>
+							<a href={`/ratings/${rating.id}`} class="font-medium text-primary underline-offset-4 hover:underline">
+								{rating.name}
+							</a>
+						</TableCell>
+						<TableCell>{rating.description}</TableCell>
+					</TableRow>
+				{/each}
+			</TableBody>
+		</Table>
+	</div>
 {/if}
-
-<style>
-	.error {
-		color: #c00;
-	}
-	table {
-		border-collapse: collapse;
-		margin-top: 1rem;
-	}
-	th,
-	td {
-		border: 1px solid #ccc;
-		padding: 0.4rem 0.8rem;
-		text-align: left;
-	}
-</style>

--- a/ui/src/routes/ratings/[id]/+page.svelte
+++ b/ui/src/routes/ratings/[id]/+page.svelte
@@ -4,6 +4,19 @@
 	import { goto } from '$app/navigation';
 	import { getRating, updateRating, deleteRating } from '$lib/rating';
 	import type { Rating } from '$lib/rating';
+	import { Button, buttonVariants } from '$lib/components/ui/button/index.js';
+	import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
+	import { Textarea } from '$lib/components/ui/textarea/index.js';
+	import {
+		Popover,
+		PopoverClose,
+		PopoverContent,
+		PopoverHeader,
+		PopoverTitle,
+		PopoverTrigger
+	} from '$lib/components/ui/popover/index.js';
 
 	const id = () => page.params.id as string;
 
@@ -14,6 +27,7 @@
 	let error = $state('');
 	let saving = $state(false);
 	let deleting = $state(false);
+	let deleteOpen = $state(false);
 
 	onMount(load);
 
@@ -44,7 +58,7 @@
 	}
 
 	async function handleDelete() {
-		if (!confirm('Delete this rating?')) return;
+		deleteOpen = false;
 		error = '';
 		deleting = true;
 		try {
@@ -63,63 +77,60 @@
 </svelte:head>
 
 {#if loadError}
-	<h1>Rating</h1>
-	<p class="error">{loadError}</p>
-	<a href="/ratings">&larr; Back to ratings</a>
+	<h1 class="text-2xl font-semibold tracking-tight">Rating</h1>
+	<p class="text-sm font-medium text-destructive">{loadError}</p>
+	<a href="/ratings" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to ratings</a>
 {:else if !rating}
-	<h1>Rating</h1>
-	<p>Loading...</p>
+	<h1 class="text-2xl font-semibold tracking-tight">Rating</h1>
+	<p class="text-muted-foreground">Loading...</p>
 {:else}
-	<h1>{rating.name}</h1>
-	<a href="/ratings">&larr; Back to ratings</a>
+	<div class="flex items-center gap-4">
+		<h1 class="text-2xl font-semibold tracking-tight">{rating.name}</h1>
+		<a href="/ratings" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to ratings</a>
+	</div>
 
-	<form onsubmit={handleSave}>
-		<label>
-			Name
-			<input type="text" bind:value={name} required />
-		</label>
-		<label>
-			Description
-			<textarea bind:value={description} required></textarea>
-		</label>
-		<button type="submit" disabled={saving}>{saving ? 'Saving...' : 'Save changes'}</button>
-	</form>
+	<Card class="mt-6 max-w-md">
+		<CardHeader>
+			<CardTitle class="text-base">Rating details</CardTitle>
+		</CardHeader>
+		<CardContent>
+			<form onsubmit={handleSave} class="flex flex-col gap-4">
+				<div class="flex flex-col gap-2">
+					<Label for="name">Name</Label>
+					<Input id="name" type="text" bind:value={name} required />
+				</div>
+				<div class="flex flex-col gap-2">
+					<Label for="description">Description</Label>
+					<Textarea id="description" bind:value={description} required />
+				</div>
+				<Button type="submit" disabled={saving} class="w-fit">
+					{saving ? 'Saving...' : 'Save changes'}
+				</Button>
+			</form>
+		</CardContent>
+	</Card>
 
-	<button type="button" onclick={handleDelete} disabled={deleting} class="danger">
-		{deleting ? 'Deleting...' : 'Delete rating'}
-	</button>
+	<div class="mt-8">
+		<Popover bind:open={deleteOpen}>
+			<PopoverTrigger disabled={deleting} class={buttonVariants({ variant: 'destructive' })}>
+				{deleting ? 'Deleting...' : 'Delete rating'}
+			</PopoverTrigger>
+			<PopoverContent class="w-80">
+				<PopoverHeader>
+					<PopoverTitle>Delete rating?</PopoverTitle>
+					<p class="text-sm text-muted-foreground">
+						This permanently removes this rating and cannot be undone.
+					</p>
+				</PopoverHeader>
+				<div class="flex justify-end gap-2">
+					<PopoverClose class={buttonVariants({ variant: 'outline', size: 'sm' })}>Cancel</PopoverClose>
+					<Button variant="destructive" size="sm" onclick={handleDelete}>Delete</Button>
+				</div>
+			</PopoverContent>
+		</Popover>
+	</div>
 
 	{#if error}
-		<p class="error">{error}</p>
+		<p class="mt-4 text-sm font-medium text-destructive">{error}</p>
 	{/if}
 {/if}
-
-<style>
-	.error {
-		color: #c00;
-	}
-	form {
-		display: flex;
-		flex-direction: column;
-		gap: 0.75rem;
-		max-width: 24rem;
-		margin-top: 1rem;
-	}
-	label {
-		display: flex;
-		flex-direction: column;
-		gap: 0.25rem;
-	}
-	input,
-	textarea {
-		padding: 0.35rem;
-	}
-	textarea {
-		min-height: 5rem;
-		resize: vertical;
-	}
-	.danger {
-		margin-top: 1rem;
-		color: #c00;
-	}
-</style>

--- a/ui/src/routes/ratings/new/+page.svelte
+++ b/ui/src/routes/ratings/new/+page.svelte
@@ -1,6 +1,11 @@
 <script lang="ts">
 	import { createRating } from '$lib/rating';
 	import { goto } from '$app/navigation';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
+	import { Textarea } from '$lib/components/ui/textarea/index.js';
 
 	let name = $state('');
 	let description = $state('');
@@ -26,47 +31,32 @@
 	<title>New rating</title>
 </svelte:head>
 
-<h1>New rating</h1>
-<a href="/ratings">&larr; Back to ratings</a>
+<div class="flex items-center gap-4">
+	<h1 class="text-2xl font-semibold tracking-tight">New rating</h1>
+	<a href="/ratings" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to ratings</a>
+</div>
 
-<form onsubmit={handleSubmit}>
-	<label>
-		Name
-		<input type="text" bind:value={name} required />
-	</label>
-	<label>
-		Description
-		<textarea bind:value={description} required></textarea>
-	</label>
-	<button type="submit" disabled={submitting}>{submitting ? 'Creating...' : 'Create rating'}</button>
-</form>
+<Card class="mt-6 max-w-md">
+	<CardHeader>
+		<CardTitle class="text-base">Rating details</CardTitle>
+	</CardHeader>
+	<CardContent>
+		<form onsubmit={handleSubmit} class="flex flex-col gap-4">
+			<div class="flex flex-col gap-2">
+				<Label for="name">Name</Label>
+				<Input id="name" type="text" bind:value={name} required />
+			</div>
+			<div class="flex flex-col gap-2">
+				<Label for="description">Description</Label>
+				<Textarea id="description" bind:value={description} required />
+			</div>
+			<Button type="submit" disabled={submitting} class="w-fit">
+				{submitting ? 'Creating...' : 'Create rating'}
+			</Button>
+		</form>
+	</CardContent>
+</Card>
 
 {#if error}
-	<p class="error">{error}</p>
+	<p class="mt-4 text-sm font-medium text-destructive">{error}</p>
 {/if}
-
-<style>
-	.error {
-		color: #c00;
-	}
-	form {
-		display: flex;
-		flex-direction: column;
-		gap: 0.75rem;
-		max-width: 24rem;
-		margin-top: 1rem;
-	}
-	label {
-		display: flex;
-		flex-direction: column;
-		gap: 0.25rem;
-	}
-	input,
-	textarea {
-		padding: 0.35rem;
-	}
-	textarea {
-		min-height: 5rem;
-		resize: vertical;
-	}
-</style>


### PR DESCRIPTION
Closes #111

Ports the ratings domain to the shadcn-svelte + Tailwind v4 design system piloted on facilities (#109).

## Changes
- **List page** (`ratings/+page.svelte`): raw `<table>` -> `Table` components; "New rating" link -> `Button`.
- **New page** (`ratings/new/+page.svelte`): raw `<label><input>`/`<textarea>` -> `Card` + `Input`/`Label`/`Textarea`/`Button`.
- **Detail page** (`ratings/[id]/+page.svelte`): `Card` form with `Input`/`Label`/`Textarea`/`Button`.
- **Delete confirm**: native `window.confirm` replaced with an in-app `Popover` (Cancel / Delete), mirroring the facilities detail page.

## New primitive
- **Textarea** installed via shadcn-svelte. The generated component referenced a `WithoutChildren` type not present in this project's `src/lib/utils.ts`, so it was aligned to the existing `WithElementRef` pattern used by the installed `Input` component.

## e2e
- `rating.spec.ts`: new `confirmDelete` helper clicks the trigger then `{ name: 'Delete', exact: true }`; removed the `page.on('dialog')` handlers.
- `format-ratings.spec.ts`: the ratings-cleanup loop at the end now drives the popover delete too, and the now-unneeded `dialog` handler was removed.
- e2e-visible text, labels, and roles are unchanged.

## Verification
- `npm run check`: 0 errors / 0 warnings
- `npm run build`: succeeds
- `make e2e`: full Playwright suite green (3 consecutive full runs)