### PR TITLE
Migrate rulesets pages to shadcn-svelte design system

### DIFF
--- a/ui/e2e/ruleset.spec.ts
+++ b/ui/e2e/ruleset.spec.ts
@@ -54,11 +54,11 @@ test('ruleset CRUD: create, view, amend (update), delete', async ({ page }) => {
 	const row = page.getByRole('link', { name: `Test Ruleset ${unique} Amended` });
 	await expect(row).toBeVisible();
 
-	// Delete (accept the confirm dialog)
+	// Delete (confirm via the popover)
 	await row.click();
 	await expect(page.getByRole('heading', { name: `Test Ruleset ${unique} Amended` })).toBeVisible();
-	page.on('dialog', (d) => d.accept());
 	await page.getByRole('button', { name: 'Delete ruleset' }).click();
+	await page.getByRole('button', { name: 'Delete', exact: true }).click();
 	await expect(page).toHaveURL('/rulesets');
 	await expect(page.getByRole('link', { name: `Test Ruleset ${unique} Amended` })).toHaveCount(0);
 });

--- a/ui/src/routes/rulesets/+page.svelte
+++ b/ui/src/routes/rulesets/+page.svelte
@@ -2,6 +2,15 @@
 	import { onMount } from 'svelte';
 	import { listRulesets } from '$lib/ruleset';
 	import type { Ruleset } from '$lib/ruleset';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import {
+		Table,
+		TableBody,
+		TableCell,
+		TableHead,
+		TableHeader,
+		TableRow
+	} from '$lib/components/ui/table/index.js';
 
 	let rulesets = $state<Ruleset[]>([]);
 	let loading = $state(true);
@@ -22,46 +31,38 @@
 	<title>Rulesets</title>
 </svelte:head>
 
-<h1>Rulesets</h1>
-<a href="/rulesets/new">New ruleset</a>
+<div class="flex items-center justify-between gap-4">
+	<h1 class="text-2xl font-semibold tracking-tight">Rulesets</h1>
+	<Button href="/rulesets/new">New ruleset</Button>
+</div>
 
 {#if loading}
-	<p>Loading...</p>
+	<p class="text-muted-foreground">Loading...</p>
 {:else if error}
-	<p class="error">{error}</p>
+	<p class="text-sm font-medium text-destructive">{error}</p>
 {:else if rulesets.length === 0}
-	<p>No rulesets yet.</p>
+	<p class="text-muted-foreground">No rulesets yet.</p>
 {:else}
-	<table>
-		<thead>
-			<tr>
-				<th>Name</th>
-				<th>Revision</th>
-			</tr>
-		</thead>
-		<tbody>
-			{#each rulesets as ruleset}
-				<tr>
-					<td><a href={`/rulesets/${ruleset.id}`}>{ruleset.name}</a></td>
-					<td>{ruleset.revision}</td>
-				</tr>
-			{/each}
-		</tbody>
-	</table>
+	<div class="mt-4 overflow-hidden rounded-lg border">
+		<Table>
+			<TableHeader>
+				<TableRow>
+					<TableHead>Name</TableHead>
+					<TableHead>Revision</TableHead>
+				</TableRow>
+			</TableHeader>
+			<TableBody>
+				{#each rulesets as ruleset}
+					<TableRow>
+						<TableCell>
+							<a href={`/rulesets/${ruleset.id}`} class="font-medium text-primary underline-offset-4 hover:underline">
+								{ruleset.name}
+							</a>
+						</TableCell>
+						<TableCell>{ruleset.revision}</TableCell>
+					</TableRow>
+				{/each}
+			</TableBody>
+		</Table>
+	</div>
 {/if}
-
-<style>
-	.error {
-		color: #c00;
-	}
-	table {
-		border-collapse: collapse;
-		margin-top: 1rem;
-	}
-	th,
-	td {
-		border: 1px solid #ccc;
-		padding: 0.4rem 0.8rem;
-		text-align: left;
-	}
-</style>

--- a/ui/src/routes/rulesets/[id]/+page.svelte
+++ b/ui/src/routes/rulesets/[id]/+page.svelte
@@ -3,6 +3,18 @@
 	import { goto } from '$app/navigation';
 	import { getRuleset, amendRulesetName, deleteRuleset } from '$lib/ruleset';
 	import type { Ruleset } from '$lib/ruleset';
+	import { Button, buttonVariants } from '$lib/components/ui/button/index.js';
+	import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
+	import {
+		Popover,
+		PopoverClose,
+		PopoverContent,
+		PopoverHeader,
+		PopoverTitle,
+		PopoverTrigger
+	} from '$lib/components/ui/popover/index.js';
 
 	// Derived from the route param so the page re-loads when navigating between
 	// ruleset revisions (same [id] route, different id).
@@ -14,6 +26,7 @@
 	let error = $state('');
 	let saving = $state(false);
 	let deleting = $state(false);
+	let deleteOpen = $state(false);
 
 	$effect(() => {
 		load(currentId);
@@ -48,7 +61,7 @@
 	}
 
 	async function handleDelete() {
-		if (!confirm('Delete this ruleset?')) return;
+		deleteOpen = false;
 		error = '';
 		deleting = true;
 		try {
@@ -66,15 +79,17 @@
 </svelte:head>
 
 {#if loadError}
-	<h1>Ruleset</h1>
-	<p class="error">{loadError}</p>
-	<a href="/rulesets">&larr; Back to rulesets</a>
+	<h1 class="text-2xl font-semibold tracking-tight">Ruleset</h1>
+	<p class="text-sm font-medium text-destructive">{loadError}</p>
+	<a href="/rulesets" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to rulesets</a>
 {:else if !ruleset}
-	<h1>Ruleset</h1>
-	<p>Loading...</p>
+	<h1 class="text-2xl font-semibold tracking-tight">Ruleset</h1>
+	<p class="text-muted-foreground">Loading...</p>
 {:else}
-	<h1>{ruleset.name}</h1>
-	<a href="/rulesets">&larr; Back to rulesets</a>
+	<div class="flex items-center gap-4">
+		<h1 class="text-2xl font-semibold tracking-tight">{ruleset.name}</h1>
+		<a href="/rulesets" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to rulesets</a>
+	</div>
 
 	<dl class="meta">
 		<div>
@@ -97,32 +112,52 @@
 		</div>
 	</dl>
 
-	<h2>Edit</h2>
-	<p class="hint">Saving edits amends this ruleset and creates a new revision.</p>
-	<form onsubmit={handleSave}>
-		<label>
-			Name
-			<input type="text" bind:value={name} required />
-		</label>
-		<button type="submit" disabled={saving}>{saving ? 'Saving...' : 'Save changes'}</button>
-	</form>
+	<Card class="mt-6 max-w-md">
+		<CardHeader>
+			<CardTitle class="text-base">Edit</CardTitle>
+		</CardHeader>
+		<CardContent>
+			<p class="hint text-sm text-muted-foreground">
+				Saving edits amends this ruleset and creates a new revision.
+			</p>
+			<form onsubmit={handleSave} class="flex flex-col gap-4">
+				<div class="flex flex-col gap-2">
+					<Label for="name">Name</Label>
+					<Input id="name" type="text" bind:value={name} required />
+				</div>
+				<Button type="submit" disabled={saving} class="w-fit">
+					{saving ? 'Saving...' : 'Save changes'}
+				</Button>
+			</form>
+		</CardContent>
+	</Card>
 
-	<button type="button" onclick={handleDelete} disabled={deleting} class="danger">
-		{deleting ? 'Deleting...' : 'Delete ruleset'}
-	</button>
+	<div class="mt-4">
+		<Popover bind:open={deleteOpen}>
+			<PopoverTrigger disabled={deleting} class={buttonVariants({ variant: 'destructive' })}>
+				{deleting ? 'Deleting...' : 'Delete ruleset'}
+			</PopoverTrigger>
+			<PopoverContent class="w-80">
+				<PopoverHeader>
+					<PopoverTitle>Delete ruleset?</PopoverTitle>
+					<p class="text-sm text-muted-foreground">
+						This permanently removes this ruleset and cannot be undone.
+					</p>
+				</PopoverHeader>
+				<div class="flex justify-end gap-2">
+					<PopoverClose class={buttonVariants({ variant: 'outline', size: 'sm' })}>Cancel</PopoverClose>
+					<Button variant="destructive" size="sm" onclick={handleDelete}>Delete</Button>
+				</div>
+			</PopoverContent>
+		</Popover>
+	</div>
 
 	{#if error}
-		<p class="error">{error}</p>
+		<p class="mt-4 text-sm font-medium text-destructive">{error}</p>
 	{/if}
 {/if}
 
 <style>
-	.error {
-		color: #c00;
-	}
-	.hint {
-		color: #666;
-	}
 	.meta {
 		display: flex;
 		gap: 1.5rem;
@@ -134,24 +169,5 @@
 	}
 	.meta dd {
 		margin: 0;
-	}
-	form {
-		display: flex;
-		flex-direction: column;
-		gap: 0.75rem;
-		max-width: 24rem;
-		margin-top: 0.5rem;
-	}
-	label {
-		display: flex;
-		flex-direction: column;
-		gap: 0.25rem;
-	}
-	input {
-		padding: 0.35rem;
-	}
-	.danger {
-		margin-top: 1rem;
-		color: #c00;
 	}
 </style>

--- a/ui/src/routes/rulesets/new/+page.svelte
+++ b/ui/src/routes/rulesets/new/+page.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
 	import { createRuleset } from '$lib/ruleset';
 	import { goto } from '$app/navigation';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
 
 	let name = $state('');
 	let error = $state('');
@@ -25,38 +29,28 @@
 	<title>New ruleset</title>
 </svelte:head>
 
-<h1>New ruleset</h1>
-<a href="/rulesets">&larr; Back to rulesets</a>
+<div class="flex items-center gap-4">
+	<h1 class="text-2xl font-semibold tracking-tight">New ruleset</h1>
+	<a href="/rulesets" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to rulesets</a>
+</div>
 
-<form onsubmit={handleSubmit}>
-	<label>
-		Name
-		<input type="text" bind:value={name} required />
-	</label>
-	<button type="submit" disabled={submitting}>{submitting ? 'Creating...' : 'Create ruleset'}</button>
-</form>
+<Card class="mt-6 max-w-md">
+	<CardHeader>
+		<CardTitle class="text-base">Ruleset details</CardTitle>
+	</CardHeader>
+	<CardContent>
+		<form onsubmit={handleSubmit} class="flex flex-col gap-4">
+			<div class="flex flex-col gap-2">
+				<Label for="name">Name</Label>
+				<Input id="name" type="text" bind:value={name} required />
+			</div>
+			<Button type="submit" disabled={submitting} class="w-fit">
+				{submitting ? 'Creating...' : 'Create ruleset'}
+			</Button>
+		</form>
+	</CardContent>
+</Card>
 
 {#if error}
-	<p class="error">{error}</p>
+	<p class="mt-4 text-sm font-medium text-destructive">{error}</p>
 {/if}
-
-<style>
-	.error {
-		color: #c00;
-	}
-	form {
-		display: flex;
-		flex-direction: column;
-		gap: 0.75rem;
-		max-width: 24rem;
-		margin-top: 1rem;
-	}
-	label {
-		display: flex;
-		flex-direction: column;
-		gap: 0.25rem;
-	}
-	input {
-		padding: 0.35rem;
-	}
-</style>


### PR DESCRIPTION
Closes #112

Migrate the rulesets domain pages to the shadcn-svelte + Tailwind v4 design system, mirroring the facilities reference (PR #109):

- **List** (`/rulesets`): raw `<table>` -> `Table` components; 'New ruleset' link -> `Button`.
- **Detail** (`/rulesets/[id]`): raw `<label><input>` form -> `Card` + `Input`/`Label`/`Button`; native `window.confirm` replaced with an in-app `Popover` confirm (Cancel / Delete pair) matching the facilities page.
- **New** (`/rulesets/new`): raw form -> `Card` + `Input`/`Label`/`Button`.

All e2e-visible text, labels, and roles are unchanged (Playwright still selects by `getByLabel`/`getByRole`). Updated `ui/e2e/ruleset.spec.ts` to drive deletion through the popover (click trigger, then `{ name: 'Delete', exact: true }`) instead of `page.on('dialog', ...)`.

**Verification:** `npm run check` (0 errors/warnings), `npm run build`, and `make e2e` — full Playwright suite green (15 passed).