### PR TITLE
UI: migrate Playoff Structures pages to shadcn-svelte

### DIFF
--- a/ui/e2e/playoff-structure.spec.ts
+++ b/ui/e2e/playoff-structure.spec.ts
@@ -15,6 +15,13 @@ async function login(page: Page) {
 	await expect(page).toHaveURL('/');
 }
 
+// Delete now confirms through an in-app shadcn Popover (no native window.confirm):
+// click the trigger, then the "Delete" button inside the popover.
+async function confirmDelete(page: Page) {
+	await page.getByRole('button', { name: 'Delete playoff structure' }).click();
+	await page.getByRole('button', { name: 'Delete', exact: true }).click();
+}
+
 test('playoff structure CRUD: create, view, update, delete', async ({ page }) => {
 	await login(page);
 
@@ -46,11 +53,10 @@ test('playoff structure CRUD: create, view, update, delete', async ({ page }) =>
 	await page.goto('/playoff-structures');
 	await expect(recordLink).toHaveText('0 byes / 4 teams');
 
-	// Delete (accept the confirm dialog)
+	// Delete (confirm via the popover)
 	await recordLink.click();
 	await expect(page).toHaveURL(/\/playoff-structures\/[0-9a-f]+$/);
-	page.on('dialog', (d) => d.accept());
-	await page.getByRole('button', { name: 'Delete playoff structure' }).click();
+	await confirmDelete(page);
 	await expect(page).toHaveURL('/playoff-structures');
 	await expect(recordLink).toHaveCount(0);
 });

--- a/ui/src/routes/playoff-structures/+page.svelte
+++ b/ui/src/routes/playoff-structures/+page.svelte
@@ -2,6 +2,15 @@
 	import { onMount } from 'svelte';
 	import { listPlayoffStructures } from '$lib/playoffStructure';
 	import type { PlayoffStructure } from '$lib/playoffStructure';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import {
+		Table,
+		TableBody,
+		TableCell,
+		TableHead,
+		TableHeader,
+		TableRow
+	} from '$lib/components/ui/table/index.js';
 
 	let structures = $state<PlayoffStructure[]>([]);
 	let loading = $state(true);
@@ -22,44 +31,39 @@
 	<title>Playoff Structures</title>
 </svelte:head>
 
-<h1>Playoff Structures</h1>
-<a href="/playoff-structures/new">New playoff structure</a>
+<div class="flex items-center justify-between gap-4">
+	<h1 class="text-2xl font-semibold tracking-tight">Playoff Structures</h1>
+	<Button href="/playoff-structures/new">New playoff structure</Button>
+</div>
 
 {#if loading}
-	<p>Loading...</p>
+	<p class="text-muted-foreground">Loading...</p>
 {:else if error}
-	<p class="error">{error}</p>
+	<p class="text-sm font-medium text-destructive">{error}</p>
 {:else if structures.length === 0}
-	<p>No playoff structures yet.</p>
+	<p class="text-muted-foreground">No playoff structures yet.</p>
 {:else}
-	<table>
-		<thead>
-			<tr>
-				<th>Playoff structure</th>
-			</tr>
-		</thead>
-		<tbody>
-			{#each structures as structure}
-				<tr>
-					<td><a href={`/playoff-structures/${structure.id}`}>{structure.byes} byes / {structure.number_of_teams} teams</a></td>
-				</tr>
-			{/each}
-		</tbody>
-	</table>
+	<div class="mt-4 overflow-hidden rounded-lg border">
+		<Table>
+			<TableHeader>
+				<TableRow>
+					<TableHead>Playoff structure</TableHead>
+				</TableRow>
+			</TableHeader>
+			<TableBody>
+				{#each structures as structure}
+					<TableRow>
+						<TableCell>
+							<a
+								href={`/playoff-structures/${structure.id}`}
+								class="font-medium text-primary underline-offset-4 hover:underline"
+							>
+								{structure.byes} byes / {structure.number_of_teams} teams
+							</a>
+						</TableCell>
+					</TableRow>
+				{/each}
+			</TableBody>
+		</Table>
+	</div>
 {/if}
-
-<style>
-	.error {
-		color: #c00;
-	}
-	table {
-		border-collapse: collapse;
-		margin-top: 1rem;
-	}
-	th,
-	td {
-		border: 1px solid #ccc;
-		padding: 0.4rem 0.8rem;
-		text-align: left;
-	}
-</style>

--- a/ui/src/routes/playoff-structures/[id]/+page.svelte
+++ b/ui/src/routes/playoff-structures/[id]/+page.svelte
@@ -8,6 +8,18 @@
 		deletePlayoffStructure
 	} from '$lib/playoffStructure';
 	import type { PlayoffStructure } from '$lib/playoffStructure';
+	import { Button, buttonVariants } from '$lib/components/ui/button/index.js';
+	import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
+	import {
+		Popover,
+		PopoverClose,
+		PopoverContent,
+		PopoverHeader,
+		PopoverTitle,
+		PopoverTrigger
+	} from '$lib/components/ui/popover/index.js';
 
 	const id = () => page.params.id as string;
 
@@ -18,6 +30,7 @@
 	let error = $state('');
 	let saving = $state(false);
 	let deleting = $state(false);
+	let deleteOpen = $state(false);
 
 	onMount(load);
 
@@ -53,7 +66,7 @@
 	}
 
 	async function handleDelete() {
-		if (!confirm('Delete this playoff structure?')) return;
+		deleteOpen = false;
 		error = '';
 		deleting = true;
 		try {
@@ -72,82 +85,66 @@
 </svelte:head>
 
 {#if loadError}
-	<h1>Playoff Structure</h1>
-	<p class="error">{loadError}</p>
-	<a href="/playoff-structures">&larr; Back to playoff structures</a>
+	<h1 class="text-2xl font-semibold tracking-tight">Playoff Structure</h1>
+	<p class="text-sm font-medium text-destructive">{loadError}</p>
+	<a
+		href="/playoff-structures"
+		class="text-sm text-muted-foreground hover:text-foreground"
+	>&larr; Back to playoff structures</a>
 {:else if !structure}
-	<h1>Playoff Structure</h1>
-	<p>Loading...</p>
+	<h1 class="text-2xl font-semibold tracking-tight">Playoff Structure</h1>
+	<p class="text-muted-foreground">Loading...</p>
 {:else}
-	<h1>Playoff Structure</h1>
-	<a href="/playoff-structures">&larr; Back to playoff structures</a>
+	<div class="flex items-center gap-4">
+		<h1 class="text-2xl font-semibold tracking-tight">Playoff Structure</h1>
+		<a
+			href="/playoff-structures"
+			class="text-sm text-muted-foreground hover:text-foreground"
+		>&larr; Back to playoff structures</a>
+	</div>
 
-	<dl class="meta">
-		<div>
-			<dt>Byes</dt>
-			<dd>{structure.byes}</dd>
-		</div>
-		<div>
-			<dt>Number of teams</dt>
-			<dd>{structure.number_of_teams}</dd>
-		</div>
-	</dl>
+	<Card class="mt-6 max-w-md">
+		<CardHeader>
+			<CardTitle class="text-base">Playoff structure details</CardTitle>
+		</CardHeader>
+		<CardContent>
+			<form onsubmit={handleSave} class="flex flex-col gap-4">
+				<div class="flex flex-col gap-2">
+					<Label for="byes">Byes</Label>
+					<Input id="byes" type="number" min="0" bind:value={byes} required />
+				</div>
+				<div class="flex flex-col gap-2">
+					<Label for="numberOfTeams">Number of teams</Label>
+					<Input id="numberOfTeams" type="number" min="2" bind:value={numberOfTeams} required />
+				</div>
+				<Button type="submit" disabled={saving} class="w-fit">
+					{saving ? 'Saving...' : 'Save changes'}
+				</Button>
+			</form>
+		</CardContent>
+	</Card>
 
-	<h2>Edit</h2>
-	<form onsubmit={handleSave}>
-		<label>
-			Byes
-			<input type="number" min="0" bind:value={byes} required />
-		</label>
-		<label>
-			Number of teams
-			<input type="number" min="2" bind:value={numberOfTeams} required />
-		</label>
-		<button type="submit" disabled={saving}>{saving ? 'Saving...' : 'Save changes'}</button>
-	</form>
-
-	<button type="button" onclick={handleDelete} disabled={deleting} class="danger">
-		{deleting ? 'Deleting...' : 'Delete playoff structure'}
-	</button>
+	<div class="mt-4">
+		<Popover bind:open={deleteOpen}>
+			<PopoverTrigger disabled={deleting} class={buttonVariants({ variant: 'destructive' })}>
+				{deleting ? 'Deleting...' : 'Delete playoff structure'}
+			</PopoverTrigger>
+			<PopoverContent class="w-80">
+				<PopoverHeader>
+					<PopoverTitle>Delete playoff structure?</PopoverTitle>
+					<p class="text-sm text-muted-foreground">
+						This permanently removes this playoff structure and cannot be undone.
+					</p>
+				</PopoverHeader>
+				<div class="flex justify-end gap-2">
+					<PopoverClose class={buttonVariants({ variant: 'outline', size: 'sm' })}>Cancel</PopoverClose>
+					<Button variant="destructive" size="sm" onclick={handleDelete}>Delete</Button>
+				</div>
+			</PopoverContent>
+		</Popover>
+	</div>
 
 	{#if error}
-		<p class="error">{error}</p>
+		<p class="mt-4 text-sm font-medium text-destructive">{error}</p>
 	{/if}
 {/if}
-
-<style>
-	.error {
-		color: #c00;
-	}
-	.meta {
-		display: flex;
-		gap: 1.5rem;
-		margin: 1rem 0;
-	}
-	.meta dt {
-		font-size: 0.85rem;
-		color: #666;
-	}
-	.meta dd {
-		margin: 0;
-	}
-	form {
-		display: flex;
-		flex-direction: column;
-		gap: 0.75rem;
-		max-width: 24rem;
-		margin-top: 0.5rem;
-	}
-	label {
-		display: flex;
-		flex-direction: column;
-		gap: 0.25rem;
-	}
-	input {
-		padding: 0.35rem;
-	}
-	.danger {
-		margin-top: 1rem;
-		color: #c00;
-	}
-</style>

--- a/ui/src/routes/playoff-structures/new/+page.svelte
+++ b/ui/src/routes/playoff-structures/new/+page.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
 	import { createPlayoffStructure } from '$lib/playoffStructure';
 	import { goto } from '$app/navigation';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
 
 	let byes = $state<string>('0');
 	let numberOfTeams = $state<string>('8');
@@ -29,42 +33,35 @@
 	<title>New playoff structure</title>
 </svelte:head>
 
-<h1>New playoff structure</h1>
-<a href="/playoff-structures">&larr; Back to playoff structures</a>
+<div class="flex items-center gap-4">
+	<h1 class="text-2xl font-semibold tracking-tight">New playoff structure</h1>
+	<a
+		href="/playoff-structures"
+		class="text-sm text-muted-foreground hover:text-foreground"
+	>&larr; Back to playoff structures</a>
+</div>
 
-<form onsubmit={handleSubmit}>
-	<label>
-		Byes
-		<input type="number" min="0" bind:value={byes} required />
-	</label>
-	<label>
-		Number of teams
-		<input type="number" min="2" bind:value={numberOfTeams} required />
-	</label>
-	<button type="submit" disabled={submitting}>{submitting ? 'Creating...' : 'Create playoff structure'}</button>
-</form>
+<Card class="mt-6 max-w-md">
+	<CardHeader>
+		<CardTitle class="text-base">Playoff structure details</CardTitle>
+	</CardHeader>
+	<CardContent>
+		<form onsubmit={handleSubmit} class="flex flex-col gap-4">
+			<div class="flex flex-col gap-2">
+				<Label for="byes">Byes</Label>
+				<Input id="byes" type="number" min="0" bind:value={byes} required />
+			</div>
+			<div class="flex flex-col gap-2">
+				<Label for="numberOfTeams">Number of teams</Label>
+				<Input id="numberOfTeams" type="number" min="2" bind:value={numberOfTeams} required />
+			</div>
+			<Button type="submit" disabled={submitting} class="w-fit">
+				{submitting ? 'Creating...' : 'Create playoff structure'}
+			</Button>
+		</form>
+	</CardContent>
+</Card>
 
 {#if error}
-	<p class="error">{error}</p>
+	<p class="mt-4 text-sm font-medium text-destructive">{error}</p>
 {/if}
-
-<style>
-	.error {
-		color: #c00;
-	}
-	form {
-		display: flex;
-		flex-direction: column;
-		gap: 0.75rem;
-		max-width: 24rem;
-		margin-top: 1rem;
-	}
-	label {
-		display: flex;
-		flex-direction: column;
-		gap: 0.25rem;
-	}
-	input {
-		padding: 0.35rem;
-	}
-</style>


### PR DESCRIPTION
Closes #114

Migrate the playoff-structures domain pages to the shadcn-svelte + Tailwind v4 design system established for facilities (PR #109).

- List page: raw `<table>` -> Table components; "New playoff structure" link -> Button.
- Detail/new forms: raw `<label><input>` -> Card + Input/Label/Button.
- Delete now confirms via an in-app shadcn Popover (Cancel/Delete) instead of `window.confirm`, matching `facilities/[id]`.
- e2e spec drives the trigger then the in-app **Delete** button (exact match) via a `confirmDelete` helper.

Verified: `npm run check` (0 errors/warnings), `npm run build`, and `make e2e` (full suite green, run twice).