### PR TITLE
UI: migrate Photos pages to shadcn-svelte

### DIFF
--- a/ui/e2e/photo.spec.ts
+++ b/ui/e2e/photo.spec.ts
@@ -15,6 +15,13 @@ async function login(page: Page) {
 	await expect(page).toHaveURL('/');
 }
 
+// Delete now confirms through an in-app shadcn Popover (no native window.confirm):
+// click the trigger, then the "Delete" button inside the popover.
+async function confirmDelete(page: Page) {
+	await page.getByRole('button', { name: 'Delete photo' }).click();
+	await page.getByRole('button', { name: 'Delete', exact: true }).click();
+}
+
 // A 1x1 transparent PNG. The backend stores raw bytes and doesn't decode the
 // image, so this is enough to exercise the upload path end to end.
 const PNG_1PX =
@@ -66,11 +73,10 @@ test('photo CRUD: upload, view, update, delete', async ({ page }) => {
 		.filter({ hasText: `${altText} Updated` });
 	await expect(row).toBeVisible();
 
-	// Delete (accept the confirm dialog)
+	// Delete (confirm via the popover)
 	await row.click();
 	await expect(page.getByRole('heading', { name: 'Photo' })).toBeVisible();
-	page.on('dialog', (d) => d.accept());
-	await page.getByRole('button', { name: 'Delete photo' }).click();
+	await confirmDelete(page);
 	await expect(page).toHaveURL('/photos');
 	await expect(page.getByRole('link', { name: `${altText} Updated` })).toHaveCount(0);
 });

--- a/ui/src/routes/photos/+page.svelte
+++ b/ui/src/routes/photos/+page.svelte
@@ -2,6 +2,15 @@
 	import { onMount } from 'svelte';
 	import { listPhotos, dataUrlFor, photoTypeLabels } from '$lib/photo';
 	import type { Photo } from '$lib/photo';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import {
+		Table,
+		TableBody,
+		TableCell,
+		TableHead,
+		TableHeader,
+		TableRow
+	} from '$lib/components/ui/table/index.js';
 
 	let photos = $state<Photo[]>([]);
 	let loading = $state(true);
@@ -26,55 +35,53 @@
 	<title>Photos</title>
 </svelte:head>
 
-<h1>Photos</h1>
-<a href="/photos/new">New photo</a>
+<div class="flex items-center justify-between gap-4">
+	<h1 class="text-2xl font-semibold tracking-tight">Photos</h1>
+	<Button href="/photos/new">New photo</Button>
+</div>
 
 {#if loading}
-	<p>Loading...</p>
+	<p class="text-muted-foreground">Loading...</p>
 {:else if error}
-	<p class="error">{error}</p>
+	<p class="text-sm font-medium text-destructive">{error}</p>
 {:else if photos.length === 0}
-	<p>No photos yet.</p>
+	<p class="text-muted-foreground">No photos yet.</p>
 {:else}
-	<table>
-		<thead>
-			<tr>
-				<th>Thumbnail</th>
-				<th>Alt text</th>
-				<th>Type</th>
-			</tr>
-		</thead>
-		<tbody>
-			{#each photos as photo}
-				<tr>
-					<td class="thumb">
-						<a href={`/photos/${photo.id}`}>
-							<img src={dataUrlFor(photo)} alt={photo.alt_text || 'Photo thumbnail'} />
-						</a>
-					</td>
-					<td><a href={`/photos/${photo.id}`}>{photo.alt_text || '(no alt text)'}</a></td>
-					<td>{photoTypeLabel(photo.file_type)}</td>
-				</tr>
-			{/each}
-		</tbody>
-	</table>
+	<div class="mt-4 overflow-hidden rounded-lg border">
+		<Table>
+			<TableHeader>
+				<TableRow>
+					<TableHead>Thumbnail</TableHead>
+					<TableHead>Alt text</TableHead>
+					<TableHead>Type</TableHead>
+				</TableRow>
+			</TableHeader>
+			<TableBody>
+				{#each photos as photo}
+					<TableRow>
+						<TableCell>
+							<a href={`/photos/${photo.id}`}>
+								<img class="thumb-img" src={dataUrlFor(photo)} alt={photo.alt_text || 'Photo thumbnail'} />
+							</a>
+						</TableCell>
+						<TableCell>
+							<a
+								href={`/photos/${photo.id}`}
+								class="font-medium text-primary underline-offset-4 hover:underline"
+							>
+								{photo.alt_text || '(no alt text)'}
+							</a>
+						</TableCell>
+						<TableCell>{photoTypeLabel(photo.file_type)}</TableCell>
+					</TableRow>
+				{/each}
+			</TableBody>
+		</Table>
+	</div>
 {/if}
 
 <style>
-	.error {
-		color: #c00;
-	}
-	table {
-		border-collapse: collapse;
-		margin-top: 1rem;
-	}
-	th,
-	td {
-		border: 1px solid #ccc;
-		padding: 0.4rem 0.8rem;
-		text-align: left;
-	}
-	.thumb img {
+	.thumb-img {
 		display: block;
 		width: 48px;
 		height: 48px;

--- a/ui/src/routes/photos/[id]/+page.svelte
+++ b/ui/src/routes/photos/[id]/+page.svelte
@@ -12,6 +12,19 @@
 		type Photo,
 		type PhotoType
 	} from '$lib/photo';
+	import { Button, buttonVariants } from '$lib/components/ui/button/index.js';
+	import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
+	import { NativeSelect, NativeSelectOption } from '$lib/components/ui/native-select/index.js';
+	import {
+		Popover,
+		PopoverClose,
+		PopoverContent,
+		PopoverHeader,
+		PopoverTitle,
+		PopoverTrigger
+	} from '$lib/components/ui/popover/index.js';
 
 	const id = () => page.params.id as string;
 
@@ -23,6 +36,7 @@
 	let error = $state('');
 	let saving = $state(false);
 	let deleting = $state(false);
+	let deleteOpen = $state(false);
 
 	onMount(load);
 
@@ -80,7 +94,7 @@
 	}
 
 	async function handleDelete() {
-		if (!confirm('Delete this photo?')) return;
+		deleteOpen = false;
 		error = '';
 		deleting = true;
 		try {
@@ -98,15 +112,17 @@
 </svelte:head>
 
 {#if loadError}
-	<h1>Photo</h1>
-	<p class="error">{loadError}</p>
-	<a href="/photos">&larr; Back to photos</a>
+	<h1 class="text-2xl font-semibold tracking-tight">Photo</h1>
+	<p class="text-sm font-medium text-destructive">{loadError}</p>
+	<a href="/photos" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to photos</a>
 {:else if !photo}
-	<h1>Photo</h1>
-	<p>Loading...</p>
+	<h1 class="text-2xl font-semibold tracking-tight">Photo</h1>
+	<p class="text-muted-foreground">Loading...</p>
 {:else}
-	<h1>Photo</h1>
-	<a href="/photos">&larr; Back to photos</a>
+	<div class="flex items-center gap-4">
+		<h1 class="text-2xl font-semibold tracking-tight">Photo</h1>
+		<a href="/photos" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to photos</a>
+	</div>
 
 	<img class="detail" src={dataUrlFor(photo)} alt={photo.alt_text || 'Photo'} />
 
@@ -125,42 +141,63 @@
 		</div>
 	</dl>
 
-	<h2>Edit</h2>
-	<form onsubmit={handleSave}>
-		<label>
-			Alt text
-			<input type="text" bind:value={altText} />
-		</label>
-		<label>
-			File
-			<input type="file" accept="image/*" onchange={onFileChange} />
-		</label>
-		<label>
-			File type
-			<select bind:value={fileType}>
-				<option value={0}>png</option>
-				<option value={1}>jpg</option>
-				<option value={2}>jpeg</option>
-				<option value={3}>gif</option>
-				<option value={4}>webp</option>
-			</select>
-		</label>
-		<button type="submit" disabled={saving}>{saving ? 'Saving...' : 'Save changes'}</button>
-	</form>
+	<Card class="mt-6 max-w-md">
+		<CardHeader>
+			<CardTitle class="text-base">Edit photo</CardTitle>
+		</CardHeader>
+		<CardContent>
+			<form onsubmit={handleSave} class="flex flex-col gap-4">
+				<div class="flex flex-col gap-2">
+					<Label for="altText">Alt text</Label>
+					<Input id="altText" type="text" bind:value={altText} />
+				</div>
+				<div class="flex flex-col gap-2">
+					<Label for="file">File</Label>
+					<Input id="file" type="file" accept="image/*" onchange={onFileChange} />
+				</div>
+				<div class="flex flex-col gap-2">
+					<Label for="fileType">File type</Label>
+					<NativeSelect id="fileType" bind:value={fileType} class="w-full">
+						<NativeSelectOption value={0}>png</NativeSelectOption>
+						<NativeSelectOption value={1}>jpg</NativeSelectOption>
+						<NativeSelectOption value={2}>jpeg</NativeSelectOption>
+						<NativeSelectOption value={3}>gif</NativeSelectOption>
+						<NativeSelectOption value={4}>webp</NativeSelectOption>
+					</NativeSelect>
+				</div>
+				<Button type="submit" disabled={saving} class="w-fit">
+					{saving ? 'Saving...' : 'Save changes'}
+				</Button>
+			</form>
+		</CardContent>
+	</Card>
 
-	<button type="button" onclick={handleDelete} disabled={deleting} class="danger">
-		{deleting ? 'Deleting...' : 'Delete photo'}
-	</button>
+	<div class="mt-4">
+		<Popover bind:open={deleteOpen}>
+			<PopoverTrigger disabled={deleting} class={buttonVariants({ variant: 'destructive' })}>
+				{deleting ? 'Deleting...' : 'Delete photo'}
+			</PopoverTrigger>
+			<PopoverContent class="w-80">
+				<PopoverHeader>
+					<PopoverTitle>Delete photo?</PopoverTitle>
+					<p class="text-sm text-muted-foreground">
+						This permanently removes this photo and cannot be undone.
+					</p>
+				</PopoverHeader>
+				<div class="flex justify-end gap-2">
+					<PopoverClose class={buttonVariants({ variant: 'outline', size: 'sm' })}>Cancel</PopoverClose>
+					<Button variant="destructive" size="sm" onclick={handleDelete}>Delete</Button>
+				</div>
+			</PopoverContent>
+		</Popover>
+	</div>
 
 	{#if error}
-		<p class="error">{error}</p>
+		<p class="mt-4 text-sm font-medium text-destructive">{error}</p>
 	{/if}
 {/if}
 
 <style>
-	.error {
-		color: #c00;
-	}
 	.detail {
 		max-width: 360px;
 		max-height: 240px;
@@ -179,25 +216,5 @@
 	}
 	.meta dd {
 		margin: 0;
-	}
-	form {
-		display: flex;
-		flex-direction: column;
-		gap: 0.75rem;
-		max-width: 24rem;
-		margin-top: 0.5rem;
-	}
-	label {
-		display: flex;
-		flex-direction: column;
-		gap: 0.25rem;
-	}
-	input,
-	select {
-		padding: 0.35rem;
-	}
-	.danger {
-		margin-top: 1rem;
-		color: #c00;
 	}
 </style>

--- a/ui/src/routes/photos/new/+page.svelte
+++ b/ui/src/routes/photos/new/+page.svelte
@@ -2,6 +2,11 @@
 	import { createPhoto, photoTypeFromExtension, photoTypeLabels } from '$lib/photo';
 	import { goto } from '$app/navigation';
 	import type { PhotoType } from '$lib/photo';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
+	import { NativeSelect, NativeSelectOption } from '$lib/components/ui/native-select/index.js';
 
 	let altText = $state('');
 	let contents = $state('');
@@ -51,53 +56,42 @@
 	<title>New photo</title>
 </svelte:head>
 
-<h1>New photo</h1>
-<a href="/photos">&larr; Back to photos</a>
+<div class="flex items-center gap-4">
+	<h1 class="text-2xl font-semibold tracking-tight">New photo</h1>
+	<a href="/photos" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to photos</a>
+</div>
 
-<form onsubmit={handleSubmit}>
-	<label>
-		File
-		<input type="file" accept="image/*" onchange={onFileChange} required />
-	</label>
-	<label>
-		Alt text
-		<input type="text" bind:value={altText} />
-	</label>
-	<label>
-		File type
-		<select bind:value={fileType}>
-			<option value={0}>png</option>
-			<option value={1}>jpg</option>
-			<option value={2}>jpeg</option>
-			<option value={3}>gif</option>
-			<option value={4}>webp</option>
-		</select>
-	</label>
-	<button type="submit" disabled={submitting}>{submitting ? 'Creating...' : 'Create photo'}</button>
-</form>
+<Card class="mt-6 max-w-md">
+	<CardHeader>
+		<CardTitle class="text-base">Upload a photo</CardTitle>
+	</CardHeader>
+	<CardContent>
+		<form onsubmit={handleSubmit} class="flex flex-col gap-4">
+			<div class="flex flex-col gap-2">
+				<Label for="file">File</Label>
+				<Input id="file" type="file" accept="image/*" onchange={onFileChange} required />
+			</div>
+			<div class="flex flex-col gap-2">
+				<Label for="altText">Alt text</Label>
+				<Input id="altText" type="text" bind:value={altText} />
+			</div>
+			<div class="flex flex-col gap-2">
+				<Label for="fileType">File type</Label>
+				<NativeSelect id="fileType" bind:value={fileType} class="w-full">
+					<NativeSelectOption value={0}>png</NativeSelectOption>
+					<NativeSelectOption value={1}>jpg</NativeSelectOption>
+					<NativeSelectOption value={2}>jpeg</NativeSelectOption>
+					<NativeSelectOption value={3}>gif</NativeSelectOption>
+					<NativeSelectOption value={4}>webp</NativeSelectOption>
+				</NativeSelect>
+			</div>
+			<Button type="submit" disabled={submitting} class="w-fit">
+				{submitting ? 'Creating...' : 'Create photo'}
+			</Button>
+		</form>
+	</CardContent>
+</Card>
 
 {#if error}
-	<p class="error">{error}</p>
+	<p class="mt-4 text-sm font-medium text-destructive">{error}</p>
 {/if}
-
-<style>
-	.error {
-		color: #c00;
-	}
-	form {
-		display: flex;
-		flex-direction: column;
-		gap: 0.75rem;
-		max-width: 24rem;
-		margin-top: 1rem;
-	}
-	label {
-		display: flex;
-		flex-direction: column;
-		gap: 0.25rem;
-	}
-	input,
-	select {
-		padding: 0.35rem;
-	}
-</style>


### PR DESCRIPTION
Closes #115

Migrate the Photos domain pages to the shadcn-svelte + Tailwind v4 design system, matching the facilities reference (PR #109).

- `photos/+page.svelte`: raw `<table>` -> Table components; 'New photo' link -> Button
- `photos/[id]/+page.svelte`: detail form -> Card + Input/Label/Button + NativeSelect; destructive delete via in-app Popover confirm (replaces window.confirm)
- `photos/new/+page.svelte`: new form -> Card + Input/Label/Button + NativeSelect
- `photo.spec.ts`: delete now clicks the trigger then the in-app Delete button via the `confirmDelete` helper

All e2e-visible text, labels, and roles unchanged.

Verified: `npm run check` (0 errors/0 warnings), `npm run build`, `make e2e` (15/15 pass).