### PR TITLE
feat: expose Draft & draft-related REST API (#123)

### DIFF
--- a/api/api_route.go
+++ b/api/api_route.go
@@ -190,6 +190,12 @@ func (r *routeWrapper[T]) Handle(c *gin.Context) {
 			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}
+		// run static (field-level) validation on the bound body so that
+		// invalid requests are rejected before any handler logic runs
+		if err := b.StaticallyValid(); err != nil {
+			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
 		apiRequest.Body = b
 	}
 

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"intraclub/database"
 	"intraclub/model"
 	"intraclub/route"
+	"intraclub/route/draft"
 	"intraclub/route/format"
 	"intraclub/route/ruleset"
 	"intraclub/route/user"
@@ -96,6 +97,8 @@ func main() {
 	amendRuleset.Handle(rg, ruleset.AmendRulesetName{})
 
 	rg.GET("/draft_order_patterns", model.GetDraftOrderPatterns)
+
+	draft.RegisterRoutes(rg, db)
 
 	playoffStructures := api.NewCrudCommon(model.NewPlayoffStructure, false, db)
 	playoffStructures.HandleRouteTypes(rg, api.CrudWrapperFunctionAll...)

--- a/model/draft.go
+++ b/model/draft.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
@@ -16,7 +17,7 @@ import (
 // to re-query the team from the database on each call
 type TeamCaptainAssignment struct {
 	TeamId    TeamId          `json:"team_id"`
-	CaptainId database.UserId `json:"captain_idt"`
+	CaptainId database.UserId `json:"captain_id"`
 }
 
 func getDraftContext() context.Context {
@@ -71,6 +72,19 @@ func (id DraftId) String() string {
 	return id.RecordId().String()
 }
 
+func (id DraftId) MarshalJSON() ([]byte, error) {
+	return id.RecordId().MarshalJSON()
+}
+
+func (id *DraftId) UnmarshalJSON(bytes []byte) error {
+	rid := id.RecordId()
+	if err := (*database.RecordId)(&rid).UnmarshalJSON(bytes); err != nil {
+		return err
+	}
+	*id = DraftId(rid)
+	return nil
+}
+
 type Draft struct {
 	ID                DraftId           `json:"id"`
 	Name              string            `json:"name"`                // descriptive name for the draft, e.g. "2025 Men's Intraclub". this will become the default name of the Season post-draft
@@ -100,6 +114,66 @@ func NewDraft() *Draft {
 	return &Draft{
 		DraftOrderPattern: DraftOrderPatternSnake{},
 	}
+}
+
+// draftJSON is the wire representation of a Draft. The DraftOrderPattern is an
+// interface field that JSON cannot (de)serialize directly, so it is exposed by
+// its Name() string (e.g. "Snake") on the wire and reconstructed from that name
+// on reads.
+type draftJSON struct {
+	ID                DraftId         `json:"id"`
+	Name              string          `json:"name"`
+	Owner             database.UserId `json:"owner"`
+	Format            FormatId        `json:"format"`
+	CompletedAt       time.Time       `json:"completed_at"`
+	DraftOrderPattern string          `json:"draft_order_pattern"`
+}
+
+// MarshalJSON serializes a Draft with its DraftOrderPattern represented by
+// Name() instead of an opaque interface value.
+func (d *Draft) MarshalJSON() ([]byte, error) {
+	return json.Marshal(draftJSON{
+		ID:                d.ID,
+		Name:              d.Name,
+		Owner:             d.Owner,
+		Format:            d.Format,
+		CompletedAt:       d.CompletedAt,
+		DraftOrderPattern: draftOrderPatternName(d.DraftOrderPattern),
+	})
+}
+
+// UnmarshalJSON reconstructs a Draft from its wire form, resolving the
+// DraftOrderPattern from the provided Name() string (defaulting to Snake if
+// omitted).
+func (d *Draft) UnmarshalJSON(data []byte) error {
+	var aux draftJSON
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	d.ID = aux.ID
+	d.Name = aux.Name
+	d.Owner = aux.Owner
+	d.Format = aux.Format
+	d.CompletedAt = aux.CompletedAt
+	if aux.DraftOrderPattern == "" {
+		d.DraftOrderPattern = DraftOrderPatternSnake{}
+		return nil
+	}
+	pattern, err := DraftOrderPatternFromString(aux.DraftOrderPattern)
+	if err != nil {
+		return err
+	}
+	d.DraftOrderPattern = pattern
+	return nil
+}
+
+// draftOrderPatternName returns the Name() of a DraftOrderPattern, defaulting
+// to an empty string when the pattern is nil.
+func draftOrderPatternName(p DraftOrderPattern) string {
+	if p == nil {
+		return ""
+	}
+	return p.Name()
 }
 
 // SetInterfaceField reconstructs the DraftOrderPattern interface field from its

--- a/model/facility.go
+++ b/model/facility.go
@@ -28,6 +28,15 @@ func (id FacilityId) MarshalJSON() ([]byte, error) {
 	return id.RecordId().MarshalJSON()
 }
 
+func (id *FacilityId) UnmarshalJSON(bytes []byte) error {
+	rid := id.RecordId()
+	if err := (*database.RecordId)(&rid).UnmarshalJSON(bytes); err != nil {
+		return err
+	}
+	*id = FacilityId(rid)
+	return nil
+}
+
 // Facility is a physical location where a Season is played.
 // It is owned by a particular UserId, but is publicly
 // accessible to all users (so that multiple seasons may

--- a/model/format.go
+++ b/model/format.go
@@ -12,9 +12,13 @@ import (
 
 type FormatId database.RecordId
 
-func (id FormatId) UnmarshalJSON(bytes []byte) error {
+func (id *FormatId) UnmarshalJSON(bytes []byte) error {
 	rid := id.RecordId()
-	return (*database.RecordId)(&rid).UnmarshalJSON(bytes)
+	if err := (*database.RecordId)(&rid).UnmarshalJSON(bytes); err != nil {
+		return err
+	}
+	*id = FormatId(rid)
+	return nil
 }
 
 func (id FormatId) MarshalJSON() ([]byte, error) {

--- a/model/rating.go
+++ b/model/rating.go
@@ -15,9 +15,13 @@ var RatingThree = "Lower-skilled player who might be prone to mistakes or beatab
 
 type RatingId database.RecordId
 
-func (id RatingId) UnmarshalJSON(bytes []byte) error {
+func (id *RatingId) UnmarshalJSON(bytes []byte) error {
 	rid := id.RecordId()
-	return (*database.RecordId)(&rid).UnmarshalJSON(bytes)
+	if err := (*database.RecordId)(&rid).UnmarshalJSON(bytes); err != nil {
+		return err
+	}
+	*id = RatingId(rid)
+	return nil
 }
 
 func (id RatingId) MarshalJSON() ([]byte, error) {

--- a/model/team.go
+++ b/model/team.go
@@ -18,6 +18,19 @@ func (t TeamId) String() string {
 	return t.RecordId().String()
 }
 
+func (t TeamId) MarshalJSON() ([]byte, error) {
+	return t.RecordId().MarshalJSON()
+}
+
+func (t *TeamId) UnmarshalJSON(bytes []byte) error {
+	rid := t.RecordId()
+	if err := (*database.RecordId)(&rid).UnmarshalJSON(bytes); err != nil {
+		return err
+	}
+	*t = TeamId(rid)
+	return nil
+}
+
 type TeamRole string
 
 const (

--- a/route/draft/draft.go
+++ b/route/draft/draft.go
@@ -1,0 +1,380 @@
+package draft
+
+import (
+	"errors"
+	"net/http"
+	"time"
+
+	"intraclub/api"
+	"intraclub/database"
+	"intraclub/model"
+
+	"github.com/gin-gonic/gin"
+)
+
+// BaseRoute is the base API route for Draft records.
+var BaseRoute = "/draft"
+
+// loadEditableDraft fetches the Draft referenced by the request's path ID and
+// verifies the requesting user (from the token) is authorized to edit it
+// (owner / sysadmin). This mirrors the access-control pattern used by the
+// Format and Ruleset custom routes.
+func loadEditableDraft[T database.Validatable](req api.Request[T]) (*model.Draft, int, error) {
+	if req.Token == nil {
+		return nil, http.StatusUnauthorized, errors.New("token is required")
+	}
+
+	draft, err := database.GetExistingRecordById(req.Context, req.DatabaseProvider, &model.Draft{}, req.PathId)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+
+	wac := database.NewWithAccessControl[*model.Draft](req.Context, req.DatabaseProvider, req.Token.UserId)
+	if !wac.CanUserEdit(draft) {
+		return nil, http.StatusForbidden, errors.New("not authorized to modify this draft")
+	}
+
+	return draft, http.StatusOK, nil
+}
+
+// EmptyBody is used by routes that do not accept a request body.
+type EmptyBody struct{}
+
+func (b *EmptyBody) StaticallyValid() error {
+	return nil
+}
+
+// InitializeBody is the request body for InitializeDraft.
+type InitializeBody struct {
+	// Captains are the UserIds who will captain the draft's teams, in draft
+	// order.
+	Captains []database.UserId `json:"captains"`
+}
+
+// StaticallyValid ensures at least one captain was provided.
+func (b *InitializeBody) StaticallyValid() error {
+	if len(b.Captains) == 0 {
+		return errors.New("captains must not be empty")
+	}
+	return nil
+}
+
+// InitializeDraft creates the draft's teams, DraftCaptain assignments and
+// DraftAvailablePlayer rows from the provided captain list (see
+// model.Draft.Initialize).
+type InitializeDraft struct{}
+
+func (c InitializeDraft) Path() (api.HttpMethod, string) {
+	return api.HttpMethodPost, api.AppendPathId(BaseRoute) + "/initialize"
+}
+
+func (c InitializeDraft) RequestBody() (*InitializeBody, bool) {
+	return &InitializeBody{}, true
+}
+
+func (c InitializeDraft) Handler(req api.Request[*InitializeBody]) (any, int, error) {
+	if err := req.Body.StaticallyValid(); err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	draft, status, err := loadEditableDraft(req)
+	if err != nil {
+		return nil, status, err
+	}
+
+	if err := draft.Initialize(req.Context, req.DatabaseProvider, req.Body.Captains); err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+
+	return gin.H{api.ResourceKey: draft}, http.StatusOK, nil
+}
+
+// AssignDraftablePlayersBody is the request body for AssignDraftablePlayers.
+type AssignDraftablePlayersBody struct {
+	// Players are the UserIds to add to the draft's available-to-draft list.
+	Players []database.UserId `json:"players"`
+}
+
+// StaticallyValid ensures at least one player was provided.
+func (b *AssignDraftablePlayersBody) StaticallyValid() error {
+	if len(b.Players) == 0 {
+		return errors.New("players must not be empty")
+	}
+	return nil
+}
+
+// AssignDraftablePlayers adds players to the draft's available-to-draft list
+// (see model.Draft.AssignDraftablePlayers).
+type AssignDraftablePlayers struct{}
+
+func (c AssignDraftablePlayers) Path() (api.HttpMethod, string) {
+	return api.HttpMethodPost, api.AppendPathId(BaseRoute) + "/assign_draftable_players"
+}
+
+func (c AssignDraftablePlayers) RequestBody() (*AssignDraftablePlayersBody, bool) {
+	return &AssignDraftablePlayersBody{}, true
+}
+
+func (c AssignDraftablePlayers) Handler(req api.Request[*AssignDraftablePlayersBody]) (any, int, error) {
+	if err := req.Body.StaticallyValid(); err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	draft, status, err := loadEditableDraft(req)
+	if err != nil {
+		return nil, status, err
+	}
+
+	if err := draft.AssignDraftablePlayers(req.Context, req.DatabaseProvider, req.Body.Players); err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+
+	return gin.H{api.ResourceKey: draft}, http.StatusOK, nil
+}
+
+// AssignRatingCutoffBody is the request body for AssignRatingCutoff.
+type AssignRatingCutoffBody struct {
+	// Rating is the RatingId to assign a cutoff index to.
+	Rating database.RecordId `json:"rating"`
+	// Cutoff is the last selection index matching this rating.
+	Cutoff int `json:"cutoff"`
+}
+
+// StaticallyValid ensures the cutoff is a positive index.
+func (b *AssignRatingCutoffBody) StaticallyValid() error {
+	if b.Cutoff <= 0 {
+		return errors.New("cutoff must be greater than zero")
+	}
+	return nil
+}
+
+// AssignRatingCutoff creates the DraftRatingCutoff row assigning a cutoff index
+// to a rating for the draft (see model.Draft.AssignRatingCutoff).
+type AssignRatingCutoff struct{}
+
+func (c AssignRatingCutoff) Path() (api.HttpMethod, string) {
+	return api.HttpMethodPost, api.AppendPathId(BaseRoute) + "/assign_rating_cutoff"
+}
+
+func (c AssignRatingCutoff) RequestBody() (*AssignRatingCutoffBody, bool) {
+	return &AssignRatingCutoffBody{}, true
+}
+
+func (c AssignRatingCutoff) Handler(req api.Request[*AssignRatingCutoffBody]) (any, int, error) {
+	if err := req.Body.StaticallyValid(); err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	draft, status, err := loadEditableDraft(req)
+	if err != nil {
+		return nil, status, err
+	}
+
+	row, err := draft.AssignRatingCutoff(req.Context, req.DatabaseProvider, model.RatingId(req.Body.Rating), req.Body.Cutoff)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+
+	return gin.H{api.ResourceKey: row}, http.StatusOK, nil
+}
+
+// SelectBody is the request body for SelectByCaptain.
+type SelectBody struct {
+	// PlayerId is the UserId being selected by the captain on the clock.
+	PlayerId database.UserId `json:"player_id"`
+}
+
+// StaticallyValid ensures a player was provided.
+func (b *SelectBody) StaticallyValid() error {
+	if b.PlayerId == database.InvalidUserId {
+		return errors.New("player_id must not be empty")
+	}
+	return nil
+}
+
+// SelectByCaptain makes a draft pick on behalf of the authenticated captain
+// (see model.Draft.SelectByCaptain). The requesting user must be a captain
+// assigned to this draft and the captain currently on the clock.
+type SelectByCaptain struct{}
+
+func (c SelectByCaptain) Path() (api.HttpMethod, string) {
+	return api.HttpMethodPost, api.AppendPathId(BaseRoute) + "/select"
+}
+
+func (c SelectByCaptain) RequestBody() (*SelectBody, bool) {
+	return &SelectBody{}, true
+}
+
+func (c SelectByCaptain) Handler(req api.Request[*SelectBody]) (any, int, error) {
+	if err := req.Body.StaticallyValid(); err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	if req.Token == nil {
+		return nil, http.StatusUnauthorized, errors.New("token is required")
+	}
+
+	draft, err := database.GetExistingRecordById(req.Context, req.DatabaseProvider, &model.Draft{}, req.PathId)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+
+	// The requesting user must be a captain assigned to this draft.
+	captains, err := draft.GetCaptains(req.Context, req.DatabaseProvider)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	isCaptain := false
+	for _, c := range captains {
+		if c.CaptainId == req.Token.UserId {
+			isCaptain = true
+			break
+		}
+	}
+	if !isCaptain {
+		return nil, http.StatusForbidden, errors.New("only a draft captain may make a selection")
+	}
+
+	if err := draft.SelectByCaptain(req.Context, req.Body.PlayerId, req.Token.UserId, req.DatabaseProvider); err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+
+	return gin.H{api.ResourceKey: draft}, http.StatusOK, nil
+}
+
+// AssignDraftedPlayersToTeams finalizes a completed draft by assigning each
+// drafted player to their team with their draft rating (see
+// model.Draft.AssignDraftedPlayersToTeams).
+type AssignDraftedPlayersToTeams struct{}
+
+func (c AssignDraftedPlayersToTeams) Path() (api.HttpMethod, string) {
+	return api.HttpMethodPost, api.AppendPathId(BaseRoute) + "/assign_drafted_players_to_teams"
+}
+
+func (c AssignDraftedPlayersToTeams) RequestBody() (*EmptyBody, bool) {
+	return &EmptyBody{}, false
+}
+
+func (c AssignDraftedPlayersToTeams) Handler(req api.Request[*EmptyBody]) (any, int, error) {
+	draft, status, err := loadEditableDraft(req)
+	if err != nil {
+		return nil, status, err
+	}
+
+	if err := draft.AssignDraftedPlayersToTeams(req.Context, req.DatabaseProvider); err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+
+	return gin.H{api.ResourceKey: draft}, http.StatusOK, nil
+}
+
+// CreateSeasonBody is the request body for CreateSeason.
+type CreateSeasonBody struct {
+	// Name is the name given to the new Season.
+	Name string `json:"name"`
+	// Facility is the FacilityId the Season is played at.
+	Facility database.RecordId `json:"facility"`
+	// StartTime is the daily kickoff time in 24-hour "HH:MM" format (e.g. "08:30").
+	StartTime string `json:"start_time"`
+}
+
+// StaticallyValid ensures the season's name is present.
+func (b *CreateSeasonBody) StaticallyValid() error {
+	if b.Name == "" {
+		return errors.New("name must not be empty")
+	}
+	return nil
+}
+
+// CreateSeason creates the Season associated with a completed draft (see
+// model.Draft.CreateSeason).
+type CreateSeason struct{}
+
+func (c CreateSeason) Path() (api.HttpMethod, string) {
+	return api.HttpMethodPost, api.AppendPathId(BaseRoute) + "/create_season"
+}
+
+func (c CreateSeason) RequestBody() (*CreateSeasonBody, bool) {
+	return &CreateSeasonBody{}, true
+}
+
+func (c CreateSeason) Handler(req api.Request[*CreateSeasonBody]) (any, int, error) {
+	if err := req.Body.StaticallyValid(); err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	draft, status, err := loadEditableDraft(req)
+	if err != nil {
+		return nil, status, err
+	}
+
+	hour, minute, err := parseStartTime(req.Body.StartTime)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+
+	season, err := draft.CreateSeason(req.Context, req.DatabaseProvider, req.Body.Name, model.FacilityId(req.Body.Facility), model.NewStartTime(hour, minute))
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+
+	return gin.H{api.ResourceKey: season}, http.StatusOK, nil
+}
+
+// SetDraftOrderPatternBody is the request body for SetDraftOrderPattern. The
+// Draft.DraftOrderPattern field is an interface and cannot be deserialized
+// directly, so it is selected by its Name() string (e.g. "Snake").
+type SetDraftOrderPatternBody struct {
+	// DraftOrderPattern is the Name() of one of the draft order patterns
+	// returned by GET /api/draft_order_patterns.
+	DraftOrderPattern string `json:"draft_order_pattern"`
+}
+
+// StaticallyValid ensures a pattern name was provided.
+func (b *SetDraftOrderPatternBody) StaticallyValid() error {
+	if b.DraftOrderPattern == "" {
+		return errors.New("draft_order_pattern must not be empty")
+	}
+	return nil
+}
+
+// SetDraftOrderPattern sets the draft's DraftOrderPattern by its Name() string.
+type SetDraftOrderPattern struct{}
+
+func (c SetDraftOrderPattern) Path() (api.HttpMethod, string) {
+	return api.HttpMethodPut, api.AppendPathId(BaseRoute) + "/draft_order_pattern"
+}
+
+func (c SetDraftOrderPattern) RequestBody() (*SetDraftOrderPatternBody, bool) {
+	return &SetDraftOrderPatternBody{}, true
+}
+
+func (c SetDraftOrderPattern) Handler(req api.Request[*SetDraftOrderPatternBody]) (any, int, error) {
+	if err := req.Body.StaticallyValid(); err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	draft, status, err := loadEditableDraft(req)
+	if err != nil {
+		return nil, status, err
+	}
+
+	pattern, err := model.DraftOrderPatternFromString(req.Body.DraftOrderPattern)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+
+	draft.DraftOrderPattern = pattern
+	if err := database.UpdateOne(req.Context, req.DatabaseProvider, draft); err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+
+	return gin.H{api.ResourceKey: draft}, http.StatusOK, nil
+}
+
+// parseStartTime parses a 24-hour "HH:MM" string into its hour and minute
+// components.
+func parseStartTime(raw string) (hour int, minute int, err error) {
+	if raw == "" {
+		return 0, 0, errors.New("start_time must not be empty")
+	}
+	t, err := time.Parse("15:04", raw)
+	if err != nil {
+		return 0, 0, errors.New("start_time must be in 24-hour HH:MM format (e.g. 08:30)")
+	}
+	return t.Hour(), t.Minute(), nil
+}

--- a/route/draft/draft.go
+++ b/route/draft/draft.go
@@ -73,9 +73,6 @@ func (c InitializeDraft) RequestBody() (*InitializeBody, bool) {
 }
 
 func (c InitializeDraft) Handler(req api.Request[*InitializeBody]) (any, int, error) {
-	if err := req.Body.StaticallyValid(); err != nil {
-		return nil, http.StatusBadRequest, err
-	}
 	draft, status, err := loadEditableDraft(req)
 	if err != nil {
 		return nil, status, err
@@ -115,9 +112,6 @@ func (c AssignDraftablePlayers) RequestBody() (*AssignDraftablePlayersBody, bool
 }
 
 func (c AssignDraftablePlayers) Handler(req api.Request[*AssignDraftablePlayersBody]) (any, int, error) {
-	if err := req.Body.StaticallyValid(); err != nil {
-		return nil, http.StatusBadRequest, err
-	}
 	draft, status, err := loadEditableDraft(req)
 	if err != nil {
 		return nil, status, err
@@ -159,9 +153,6 @@ func (c AssignRatingCutoff) RequestBody() (*AssignRatingCutoffBody, bool) {
 }
 
 func (c AssignRatingCutoff) Handler(req api.Request[*AssignRatingCutoffBody]) (any, int, error) {
-	if err := req.Body.StaticallyValid(); err != nil {
-		return nil, http.StatusBadRequest, err
-	}
 	draft, status, err := loadEditableDraft(req)
 	if err != nil {
 		return nil, status, err
@@ -203,9 +194,6 @@ func (c SelectByCaptain) RequestBody() (*SelectBody, bool) {
 }
 
 func (c SelectByCaptain) Handler(req api.Request[*SelectBody]) (any, int, error) {
-	if err := req.Body.StaticallyValid(); err != nil {
-		return nil, http.StatusBadRequest, err
-	}
 	if req.Token == nil {
 		return nil, http.StatusUnauthorized, errors.New("token is required")
 	}
@@ -295,9 +283,6 @@ func (c CreateSeason) RequestBody() (*CreateSeasonBody, bool) {
 }
 
 func (c CreateSeason) Handler(req api.Request[*CreateSeasonBody]) (any, int, error) {
-	if err := req.Body.StaticallyValid(); err != nil {
-		return nil, http.StatusBadRequest, err
-	}
 	draft, status, err := loadEditableDraft(req)
 	if err != nil {
 		return nil, status, err
@@ -345,9 +330,6 @@ func (c SetDraftOrderPattern) RequestBody() (*SetDraftOrderPatternBody, bool) {
 }
 
 func (c SetDraftOrderPattern) Handler(req api.Request[*SetDraftOrderPatternBody]) (any, int, error) {
-	if err := req.Body.StaticallyValid(); err != nil {
-		return nil, http.StatusBadRequest, err
-	}
 	draft, status, err := loadEditableDraft(req)
 	if err != nil {
 		return nil, status, err

--- a/route/draft/draft_test.go
+++ b/route/draft/draft_test.go
@@ -1,0 +1,567 @@
+package draft
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/rand/v2"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"intraclub/api"
+	"intraclub/database"
+	"intraclub/model"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// test setup helpers (mirror model/*_test.go helpers)
+// ---------------------------------------------------------------------------
+
+func newStoredUser(t *testing.T, db database.Provider) *model.User {
+	t.Helper()
+	user := model.NewUser()
+	user.Email = model.EmailAddress(fmt.Sprintf("user%d@email.com", rand.Uint64()))
+	user.FirstName = fmt.Sprintf("Test %d", rand.Uint64())
+	user.LastName = "User"
+	user.PhoneNumber = model.PhoneNumber(fmt.Sprintf("%d", 100_000_0000+rand.Uint32N(999_999_999)))
+	v, err := database.CreateOne(context.Background(), db, user)
+	require.NoError(t, err)
+	return v
+}
+
+func newStoredRating(t *testing.T, db database.Provider) *model.Rating {
+	t.Helper()
+	user := newStoredUser(t, db)
+	r := model.NewRating()
+	r.UserId = user.ID
+	r.Name = fmt.Sprintf("Rating %s", database.NewRecordId())
+	r.Description = "test description"
+	v, err := database.CreateOne(context.Background(), db, r)
+	require.NoError(t, err)
+	return v
+}
+
+// newDefaultFormat creates a stored Format with two lines whose unique ratings
+// become the format's possible ratings.
+func newDefaultFormat(t *testing.T, db database.Provider) *model.Format {
+	t.Helper()
+	user := newStoredUser(t, db)
+	f := model.NewFormat()
+	f.UserId = user.ID
+	f.Name = "default format"
+	created, err := database.CreateOne(context.Background(), db, f)
+	require.NoError(t, err)
+
+	lines := []model.FormatLine{
+		model.FormatLine{Player1Rating: newStoredRating(t, db).ID, Player2Rating: newStoredRating(t, db).ID},
+		model.FormatLine{Player1Rating: newStoredRating(t, db).ID, Player2Rating: newStoredRating(t, db).ID},
+	}
+	var ratings model.RatingList
+	for _, l := range lines {
+		ratings = appendUniqueRating(ratings, l.Player1Rating)
+		ratings = appendUniqueRating(ratings, l.Player2Rating)
+	}
+	require.NoError(t, created.SetPossibleRatings(context.Background(), db, ratings))
+	require.NoError(t, created.SetLines(context.Background(), db, lines))
+	return created
+}
+
+func appendUniqueRating(ratings model.RatingList, r model.RatingId) model.RatingList {
+	for _, existing := range ratings {
+		if existing == r {
+			return ratings
+		}
+	}
+	return append(ratings, r)
+}
+
+func newFacility(t *testing.T, db database.Provider, owner database.UserId) *model.Facility {
+	t.Helper()
+	facility := model.NewFacility()
+	facility.UserId = owner
+	facility.Name = fmt.Sprintf("Test facility %s", database.NewRecordId())
+	facility.Address = fmt.Sprintf("%s Test Rd.", database.NewRecordId())
+	facility.NumberOfCourts = 5
+	v, err := database.CreateOne(context.Background(), db, facility)
+	require.NoError(t, err)
+	return v
+}
+
+// newTestRouter builds a gin engine with the full draft REST surface registered
+// (as in main.go) and the auth globals wired up so real tokens validate.
+func newTestRouter(t *testing.T, db database.Provider) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	api.UserType = &model.User{}
+	database.SysAdminCheck = model.IsUserSystemAdministrator
+
+	router := gin.New()
+	group := router.Group("/api")
+	RegisterRoutes(group, db)
+	return router
+}
+
+// testKeyOnce generates a single JWT keypair shared by every token minted in a
+// test process, so tokens issued by different helpers all verify.
+var (
+	testKeyOnce sync.Once
+	testPubKey  *ecdsa.PublicKey
+	testPrivKey *ecdsa.PrivateKey
+)
+
+// newToken returns a signed JWT for the given user ID without touching key
+// files on disk.
+func newToken(t *testing.T, userId database.UserId) string {
+	t.Helper()
+	testKeyOnce.Do(func() {
+		pub, priv, err := api.GenerateKeyPair()
+		require.NoError(t, err)
+		testPubKey = pub
+		testPrivKey = priv
+	})
+	api.JwtPublicKey = testPubKey
+	api.JwtPrivateKey = testPrivKey
+	token, err := api.GenerateToken(userId.RecordId())
+	require.NoError(t, err)
+	return token
+}
+
+// doJSON performs an authenticated HTTP request against the router.
+func doJSON(t *testing.T, router *gin.Engine, method, path string, body any, token string) *httptest.ResponseRecorder {
+	t.Helper()
+	var reader io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		require.NoError(t, err)
+		reader = bytes.NewReader(b)
+	}
+	req, err := http.NewRequest(method, path, reader)
+	require.NoError(t, err)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if token != "" {
+		req.Header.Set(api.AuthTokenHeaderValue, token)
+	}
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+// createDraftViaHTTP creates a draft through the CRUD route as the owner.
+func createDraftViaHTTP(t *testing.T, router *gin.Engine, owner database.UserId, formatID model.FormatId, name string) string {
+	t.Helper()
+	w := doJSON(t, router, http.MethodPost, "/api/draft", map[string]any{
+		"name":   name,
+		"format": formatID.String(),
+	}, newToken(t, owner))
+	require.Equal(t, http.StatusOK, w.Code, "create draft: %s", w.Body.String())
+
+	var resp struct {
+		Resource *model.Draft `json:"resource"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.NotNil(t, resp.Resource)
+	return resp.Resource.ID.String()
+}
+
+// ---------------------------------------------------------------------------
+// CRUD endpoints
+// ---------------------------------------------------------------------------
+
+func TestDraftCRUD(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	commissioner := newStoredUser(t, db)
+	format := newDefaultFormat(t, db)
+
+	draftID := createDraftViaHTTP(t, router, commissioner.ID, format.ID, "CRUD Draft")
+
+	// GET one
+	w := doJSON(t, router, http.MethodGet, "/api/draft/"+draftID, nil, newToken(t, commissioner.ID))
+	require.Equal(t, http.StatusOK, w.Code)
+	var one struct {
+		Resource *model.Draft `json:"resource"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &one))
+	require.Equal(t, draftID, one.Resource.ID.String())
+	require.Equal(t, commissioner.ID, one.Resource.GetOwner())
+
+	// GET many
+	w = doJSON(t, router, http.MethodGet, "/api/draft", nil, newToken(t, commissioner.ID))
+	require.Equal(t, http.StatusOK, w.Code)
+	var many struct {
+		Resource []*model.Draft `json:"resource"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &many))
+	require.Len(t, many.Resource, 1)
+
+	// PUT update
+	w = doJSON(t, router, http.MethodPut, "/api/draft/"+draftID, map[string]any{
+		"id":     draftID,
+		"name":   "Renamed Draft",
+		"format": format.ID.String(),
+	}, newToken(t, commissioner.ID))
+	require.Equal(t, http.StatusOK, w.Code, "update draft: %s", w.Body.String())
+
+	// DELETE
+	w = doJSON(t, router, http.MethodDelete, "/api/draft/"+draftID, nil, newToken(t, commissioner.ID))
+	require.Equal(t, http.StatusOK, w.Code)
+
+	w = doJSON(t, router, http.MethodGet, "/api/draft/"+draftID, nil, newToken(t, commissioner.ID))
+	require.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestDraftJoinModelCRUD(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	commissioner := newStoredUser(t, db)
+	format := newDefaultFormat(t, db)
+	draftID := createDraftViaHTTP(t, router, commissioner.ID, format.ID, "Join CRUD")
+	player := newStoredUser(t, db)
+
+	// Create a DraftAvailablePlayer via CRUD.
+	w := doJSON(t, router, http.MethodPost, "/api/draft_available_player", map[string]any{
+		"draft_id":  draftID,
+		"player_id": player.ID.String(),
+	}, newToken(t, commissioner.ID))
+	require.Equal(t, http.StatusOK, w.Code, "create available player: %s", w.Body.String())
+	var created struct {
+		Resource *model.DraftAvailablePlayer `json:"resource"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &created))
+	require.NotNil(t, created.Resource)
+
+	// GET one
+	w = doJSON(t, router, http.MethodGet, "/api/draft_available_player/"+created.Resource.ID.String(), nil, newToken(t, commissioner.ID))
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// GET many
+	w = doJSON(t, router, http.MethodGet, "/api/draft_available_player", nil, newToken(t, commissioner.ID))
+	require.Equal(t, http.StatusOK, w.Code)
+	var many struct {
+		Resource []*model.DraftAvailablePlayer `json:"resource"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &many))
+	require.Len(t, many.Resource, 1)
+
+	// DELETE
+	w = doJSON(t, router, http.MethodDelete, "/api/draft_available_player/"+created.Resource.ID.String(), nil, newToken(t, commissioner.ID))
+	require.Equal(t, http.StatusOK, w.Code)
+}
+
+// ---------------------------------------------------------------------------
+// custom action endpoints
+// ---------------------------------------------------------------------------
+
+// mustParseRecordID converts a hex-string record ID back into a RecordId.
+func mustParseRecordID(t *testing.T, s string) database.RecordId {
+	t.Helper()
+	id, err := database.RecordIdFromString(s)
+	require.NoError(t, err)
+	return id
+}
+
+// completeDraftViaHTTP drives the draft to completion through the select
+// endpoint, authenticating each pick as the captain on the clock. It mirrors
+// the model test helper's ordering: each captain first picks themselves (in
+// draft order), then the remaining non-captain players are drafted.
+func completeDraftViaHTTP(t *testing.T, router *gin.Engine, db database.Provider, draftID string, captainTokens map[database.UserId]string) {
+	t.Helper()
+	draftIDR := mustParseRecordID(t, draftID)
+
+	// 1) each captain picks themselves, in draft order
+	draft, err := database.GetExistingRecordById(context.Background(), db, &model.Draft{}, draftIDR)
+	require.NoError(t, err)
+	captains, err := draft.GetCaptains(context.Background(), db)
+	require.NoError(t, err)
+	for _, c := range captains {
+		token, ok := captainTokens[c.CaptainId]
+		require.True(t, ok, "no token for captain %s", c.CaptainId)
+		w := doJSON(t, router, http.MethodPost, "/api/draft/"+draftID+"/select", map[string]any{
+			"player_id": c.CaptainId.String(),
+		}, token)
+		require.Equal(t, http.StatusOK, w.Code, "captain self-select: %s", w.Body.String())
+	}
+
+	// 2) draft the remaining players until the draft is complete
+	for {
+		draft, err = database.GetExistingRecordById(context.Background(), db, &model.Draft{}, draftIDR)
+		require.NoError(t, err)
+		if draft.IsDraftCompleted(context.Background(), db) {
+			return
+		}
+		onTheClock, err := draft.GetCaptainOnTheClock(context.Background(), db)
+		require.NoError(t, err)
+		available := draft.GetAllAvailableToSelect(onTheClock, db)
+		require.NotEmpty(t, available, "no players available to select")
+
+		token, ok := captainTokens[onTheClock]
+		require.True(t, ok, "no token for on-the-clock captain %s", onTheClock)
+		w := doJSON(t, router, http.MethodPost, "/api/draft/"+draftID+"/select", map[string]any{
+			"player_id": available[0].String(),
+		}, token)
+		require.Equal(t, http.StatusOK, w.Code, "select pick: %s", w.Body.String())
+	}
+}
+
+func TestDraftFullFlow(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	commissioner := newStoredUser(t, db)
+	format := newDefaultFormat(t, db)
+
+	// Captains and extra players.
+	captains := make([]*model.User, 4)
+	captainTokens := make(map[database.UserId]string)
+	for i := 0; i < 4; i++ {
+		c := newStoredUser(t, db)
+		captains[i] = c
+		captainTokens[c.ID] = newToken(t, c.ID)
+	}
+	extraPlayers := []*model.User{newStoredUser(t, db), newStoredUser(t, db)}
+
+	// Create the draft and select the draft order pattern by name.
+	draftID := createDraftViaHTTP(t, router, commissioner.ID, format.ID, "Full Flow Draft")
+	w := doJSON(t, router, http.MethodPut, "/api/draft/"+draftID+"/draft_order_pattern", map[string]any{
+		"draft_order_pattern": "Snake",
+	}, newToken(t, commissioner.ID))
+	require.Equal(t, http.StatusOK, w.Code, "set pattern: %s", w.Body.String())
+
+	// Initialize (creates teams + DraftCaptain + captain DraftAvailablePlayer rows).
+	captainIDs := make([]string, len(captains))
+	for i, c := range captains {
+		captainIDs[i] = c.ID.String()
+	}
+	w = doJSON(t, router, http.MethodPost, "/api/draft/"+draftID+"/initialize", map[string]any{
+		"captains": captainIDs,
+	}, newToken(t, commissioner.ID))
+	require.Equal(t, http.StatusOK, w.Code, "initialize: %s", w.Body.String())
+
+	// Assign additional draftable players.
+	extraIDs := make([]string, len(extraPlayers))
+	for i, p := range extraPlayers {
+		extraIDs[i] = p.ID.String()
+	}
+	w = doJSON(t, router, http.MethodPost, "/api/draft/"+draftID+"/assign_draftable_players", map[string]any{
+		"players": extraIDs,
+	}, newToken(t, commissioner.ID))
+	require.Equal(t, http.StatusOK, w.Code, "assign draftable players: %s", w.Body.String())
+
+	// Assign rating cutoffs for every rating except the lowest (the draft's
+	// DynamicallyValid requires a complete, increasing set).
+	possibleRatings, err := format.GetPossibleRatings(context.Background(), db)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(possibleRatings), 2)
+	for i, r := range possibleRatings[:len(possibleRatings)-1] {
+		w = doJSON(t, router, http.MethodPost, "/api/draft/"+draftID+"/assign_rating_cutoff", map[string]any{
+			"rating": r.String(),
+			"cutoff": i + 1,
+		}, newToken(t, commissioner.ID))
+		require.Equal(t, http.StatusOK, w.Code, "assign rating cutoff: %s", w.Body.String())
+	}
+
+	// Drive the draft to completion via the select endpoint.
+	completeDraftViaHTTP(t, router, db, draftID, captainTokens)
+
+	// Verify the draft is now completed.
+	draft, err := database.GetExistingRecordById(context.Background(), db, &model.Draft{}, mustParseRecordID(t, draftID))
+	require.NoError(t, err)
+	require.True(t, draft.IsDraftCompleted(context.Background(), db))
+
+	// Assign drafted players to teams.
+	w = doJSON(t, router, http.MethodPost, "/api/draft/"+draftID+"/assign_drafted_players_to_teams", nil, newToken(t, commissioner.ID))
+	require.Equal(t, http.StatusOK, w.Code, "assign drafted players: %s", w.Body.String())
+
+	// Create the season.
+	facility := newFacility(t, db, commissioner.ID)
+	w = doJSON(t, router, http.MethodPost, "/api/draft/"+draftID+"/create_season", map[string]any{
+		"name":       "Season from draft",
+		"facility":   facility.ID.String(),
+		"start_time": "08:30",
+	}, newToken(t, commissioner.ID))
+	require.Equal(t, http.StatusOK, w.Code, "create season: %s", w.Body.String())
+	var seasonResp struct {
+		Resource *model.Season `json:"resource"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &seasonResp))
+	require.NotNil(t, seasonResp.Resource)
+	require.Equal(t, "Season from draft", seasonResp.Resource.Name)
+
+	// The join rows produced by the draft actions are readable via CRUD.
+	for _, path := range []string{"/api/draft_captain", "/api/draft_pick", "/api/draft_rating_cutoff"} {
+		w = doJSON(t, router, http.MethodGet, path, nil, newToken(t, commissioner.ID))
+		require.Equal(t, http.StatusOK, w.Code, "GET %s: %s", path, w.Body.String())
+		var list struct {
+			Resource []json.RawMessage `json:"resource"`
+		}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &list))
+		require.NotEmpty(t, list.Resource, "expected rows from %s", path)
+	}
+}
+
+func TestDraftRatingCutoffCRUD(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	commissioner := newStoredUser(t, db)
+	format := newDefaultFormat(t, db)
+	draftID := createDraftViaHTTP(t, router, commissioner.ID, format.ID, "Cutoff CRUD")
+
+	rating := newStoredRating(t, db)
+	w := doJSON(t, router, http.MethodPost, "/api/draft_rating_cutoff", map[string]any{
+		"draft_id":     draftID,
+		"rating_id":    rating.ID.String(),
+		"cutoff_index": 2,
+	}, newToken(t, commissioner.ID))
+	require.Equal(t, http.StatusOK, w.Code, "create cutoff: %s", w.Body.String())
+	var created struct {
+		Resource *model.DraftRatingCutoff `json:"resource"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &created))
+	require.NotNil(t, created.Resource)
+
+	// GET one
+	w = doJSON(t, router, http.MethodGet, "/api/draft_rating_cutoff/"+created.Resource.ID.String(), nil, newToken(t, commissioner.ID))
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// DELETE
+	w = doJSON(t, router, http.MethodDelete, "/api/draft_rating_cutoff/"+created.Resource.ID.String(), nil, newToken(t, commissioner.ID))
+	require.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestPreDraftGradeCRUD(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	commissioner := newStoredUser(t, db)
+	format := newDefaultFormat(t, db)
+	draftID := createDraftViaHTTP(t, router, commissioner.ID, format.ID, "Grade CRUD")
+
+	// The graded player must be on the draft's available list.
+	player := newStoredUser(t, db)
+	_, err := database.CreateOne(context.Background(), db, &model.DraftAvailablePlayer{
+		DraftId:  model.DraftId(mustParseRecordID(t, draftID)),
+		PlayerId: player.ID,
+	})
+	require.NoError(t, err)
+
+	possibleRatings, err := format.GetPossibleRatings(context.Background(), db)
+	require.NoError(t, err)
+	require.NotEmpty(t, possibleRatings)
+
+	w := doJSON(t, router, http.MethodPost, "/api/pre_draft_grade", map[string]any{
+		"PlayerId": player.ID.String(),
+		"DraftId":  draftID,
+		"Modifier": 0,
+		"Rating":   possibleRatings[0].String(),
+	}, newToken(t, commissioner.ID))
+	require.Equal(t, http.StatusOK, w.Code, "create grade: %s", w.Body.String())
+	var created struct {
+		Resource *model.PreDraftGrade `json:"resource"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &created))
+	require.NotNil(t, created.Resource)
+	// The grader is set from the token on creation.
+	require.Equal(t, commissioner.ID, created.Resource.GraderId)
+
+	// GET one
+	w = doJSON(t, router, http.MethodGet, "/api/pre_draft_grade/"+created.Resource.ID.String(), nil, newToken(t, commissioner.ID))
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// DELETE
+	w = doJSON(t, router, http.MethodDelete, "/api/pre_draft_grade/"+created.Resource.ID.String(), nil, newToken(t, commissioner.ID))
+	require.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestDraftInitializeAuthorization(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	commissioner := newStoredUser(t, db)
+	format := newDefaultFormat(t, db)
+	draftID := createDraftViaHTTP(t, router, commissioner.ID, format.ID, "Auth Draft")
+
+	// A non-owner user may not initialize the draft.
+	outsider := newStoredUser(t, db)
+	captain := newStoredUser(t, db)
+	w := doJSON(t, router, http.MethodPost, "/api/draft/"+draftID+"/initialize", map[string]any{
+		"captains": []string{captain.ID.String()},
+	}, newToken(t, outsider.ID))
+	require.Equal(t, http.StatusForbidden, w.Code)
+}
+
+// TestDraftInitializeEmptyCaptains verifies that body validation is enforced
+// over the wire: an initialize request with no captains is rejected.
+func TestDraftInitializeEmptyCaptains(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	commissioner := newStoredUser(t, db)
+	format := newDefaultFormat(t, db)
+	draftID := createDraftViaHTTP(t, router, commissioner.ID, format.ID, "Empty Captains")
+
+	w := doJSON(t, router, http.MethodPost, "/api/draft/"+draftID+"/initialize", map[string]any{
+		"captains": []string{},
+	}, newToken(t, commissioner.ID))
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestDraftSelectAuthorization(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	commissioner := newStoredUser(t, db)
+	format := newDefaultFormat(t, db)
+	draftID := createDraftViaHTTP(t, router, commissioner.ID, format.ID, "Select Auth Draft")
+
+	// A non-captain may not make a selection.
+	outsider := newStoredUser(t, db)
+	player := newStoredUser(t, db)
+	w := doJSON(t, router, http.MethodPost, "/api/draft/"+draftID+"/select", map[string]any{
+		"player_id": player.ID.String(),
+	}, newToken(t, outsider.ID))
+	require.Equal(t, http.StatusForbidden, w.Code)
+}
+
+// ---------------------------------------------------------------------------
+// body validation
+// ---------------------------------------------------------------------------
+
+func TestInitializeBodyValidation(t *testing.T) {
+	b := &InitializeBody{}
+	require.Error(t, b.StaticallyValid())
+	b.Captains = []database.UserId{database.UserId(database.NewRecordId())}
+	require.NoError(t, b.StaticallyValid())
+}
+
+func TestSelectBodyValidation(t *testing.T) {
+	b := &SelectBody{}
+	require.Error(t, b.StaticallyValid())
+	b.PlayerId = database.UserId(database.NewRecordId())
+	require.NoError(t, b.StaticallyValid())
+}
+
+func TestAssignRatingCutoffBodyValidation(t *testing.T) {
+	b := &AssignRatingCutoffBody{Cutoff: 0}
+	require.Error(t, b.StaticallyValid())
+	b.Cutoff = 1
+	require.NoError(t, b.StaticallyValid())
+}
+
+func TestSetDraftOrderPatternBodyValidation(t *testing.T) {
+	b := &SetDraftOrderPatternBody{}
+	require.Error(t, b.StaticallyValid())
+	b.DraftOrderPattern = "Snake"
+	require.NoError(t, b.StaticallyValid())
+}
+
+func TestCreateSeasonBodyValidation(t *testing.T) {
+	b := &CreateSeasonBody{}
+	require.Error(t, b.StaticallyValid())
+	b.Name = "season"
+	require.NoError(t, b.StaticallyValid())
+}

--- a/route/draft/routes.go
+++ b/route/draft/routes.go
@@ -1,0 +1,47 @@
+package draft
+
+import (
+	"intraclub/api"
+	"intraclub/database"
+	"intraclub/model"
+
+	"github.com/gin-gonic/gin"
+)
+
+// RegisterRoutes wires up the Draft REST surface: standard CRUD for the draft
+// and its join models (mirroring formats/ratings) plus the custom draft action
+// endpoints.
+func RegisterRoutes(e *gin.RouterGroup, db database.Provider) {
+	drafts := api.NewCrudCommon(model.NewDraft, false, db)
+	drafts.HandleRouteTypes(e, api.CrudWrapperFunctionAll...)
+
+	availablePlayers := api.NewCrudCommon(func() *model.DraftAvailablePlayer { return &model.DraftAvailablePlayer{} }, false, db)
+	availablePlayers.HandleRouteTypes(e, api.CrudWrapperFunctionAll...)
+
+	captains := api.NewCrudCommon(func() *model.DraftCaptain { return &model.DraftCaptain{} }, false, db)
+	captains.HandleRouteTypes(e, api.CrudWrapperFunctionAll...)
+
+	picks := api.NewCrudCommon(func() *model.DraftPick { return &model.DraftPick{} }, false, db)
+	picks.HandleRouteTypes(e, api.CrudWrapperFunctionAll...)
+
+	ratingCutoffs := api.NewCrudCommon(func() *model.DraftRatingCutoff { return &model.DraftRatingCutoff{} }, false, db)
+	ratingCutoffs.HandleRouteTypes(e, api.CrudWrapperFunctionAll...)
+
+	preDraftGrades := api.NewCrudCommon(model.NewPreDraftGrade, false, db)
+	preDraftGrades.HandleRouteTypes(e, api.CrudWrapperFunctionAll...)
+
+	initFamily := api.RouteFamily[*InitializeBody]{DatabaseProvider: db}
+	initFamily.Handle(e, InitializeDraft{})
+	playersFamily := api.RouteFamily[*AssignDraftablePlayersBody]{DatabaseProvider: db}
+	playersFamily.Handle(e, AssignDraftablePlayers{})
+	cutoffFamily := api.RouteFamily[*AssignRatingCutoffBody]{DatabaseProvider: db}
+	cutoffFamily.Handle(e, AssignRatingCutoff{})
+	selectFamily := api.RouteFamily[*SelectBody]{DatabaseProvider: db}
+	selectFamily.Handle(e, SelectByCaptain{})
+	assignFamily := api.RouteFamily[*EmptyBody]{DatabaseProvider: db}
+	assignFamily.Handle(e, AssignDraftedPlayersToTeams{})
+	seasonFamily := api.RouteFamily[*CreateSeasonBody]{DatabaseProvider: db}
+	seasonFamily.Handle(e, CreateSeason{})
+	patternFamily := api.RouteFamily[*SetDraftOrderPatternBody]{DatabaseProvider: db}
+	patternFamily.Handle(e, SetDraftOrderPattern{})
+}

--- a/ui/src/lib/draft.ts
+++ b/ui/src/lib/draft.ts
@@ -1,0 +1,200 @@
+// Draft API client. Draft records are backed by the REST routes registered in
+// route/draft (see main.go):
+//
+//	GET    /api/draft                -> { resource: Draft[] }
+//	GET    /api/draft/:id            -> { resource: Draft }
+//	POST   /api/draft                -> { resource: Draft }   (owner = token user)
+//	PUT    /api/draft/:id            -> { resource: Draft }
+//	DELETE /api/draft/:id            -> { resource: Draft }
+//
+// Custom action endpoints drive the draft lifecycle:
+//
+//	PUT    /api/draft/:id/draft_order_pattern   body: { draft_order_pattern }
+//	POST   /api/draft/:id/initialize            body: { captains }
+//	POST   /api/draft/:id/assign_draftable_players body: { players }
+//	POST   /api/draft/:id/assign_rating_cutoff  body: { rating, cutoff }
+//	POST   /api/draft/:id/select                body: { player_id }
+//	POST   /api/draft/:id/assign_drafted_players_to_teams
+//	POST   /api/draft/:id/create_season         body: { name, facility, start_time }
+//
+// `draft_order_pattern` is exposed on the wire as the pattern's Name() string
+// (e.g. "Snake") rather than an opaque interface value. Record IDs are 16-char
+// hex strings; an empty string represents "not set" (InvalidRecordId).
+import { authFetch } from '$lib/auth';
+
+export interface Draft {
+	id: string;
+	name: string;
+	owner: string;
+	format: string;
+	completed_at: string;
+	draft_order_pattern: string;
+}
+
+// DraftOrderPattern describes one selectable draft order pattern, as returned
+// by GET /api/draft_order_patterns.
+export interface DraftOrderPattern {
+	name: string;
+	description: string;
+	example: number[][];
+}
+
+const BASE = '/api/draft';
+const ORDER_PATTERNS = '/api/draft_order_patterns';
+
+// unwrap parses a CrudCommon response (`{ resource: ... }`) and throws the
+// backend error message on non-2xx responses so callers can surface it.
+async function unwrap(res: Response): Promise<any> {
+	if (!res.ok) {
+		let message = `Request failed (${res.status})`;
+		try {
+			const body = await res.json();
+			if (body?.error) message = body.error;
+		} catch {
+			// non-JSON error body; fall back to the status message
+		}
+		throw new Error(message);
+	}
+	const body = await res.json();
+	return body?.resource;
+}
+
+export async function listDrafts(): Promise<Draft[]> {
+	return unwrap(await authFetch(BASE));
+}
+
+export async function getDraft(id: string): Promise<Draft> {
+	return unwrap(await authFetch(`${BASE}/${id}`));
+}
+
+// DraftInput omits `draft_order_pattern`: the pattern defaults to Snake on
+// create and is set via setDraftOrderPattern.
+export interface DraftInput {
+	name: string;
+	format: string;
+}
+
+export async function createDraft(input: DraftInput): Promise<Draft> {
+	return unwrap(
+		await authFetch(BASE, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(input)
+		})
+	);
+}
+
+export async function updateDraft(id: string, input: DraftInput): Promise<Draft> {
+	return unwrap(
+		await authFetch(`${BASE}/${id}`, {
+			method: 'PUT',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(input)
+		})
+	);
+}
+
+export async function deleteDraft(id: string): Promise<void> {
+	const res = await authFetch(`${BASE}/${id}`, { method: 'DELETE' });
+	if (!res.ok) {
+		let message = `Delete failed (${res.status})`;
+		try {
+			const body = await res.json();
+			if (body?.error) message = body.error;
+		} catch {
+			// non-JSON error body; fall back to the status message
+		}
+		throw new Error(message);
+	}
+}
+
+// listDraftOrderPatterns returns the selectable draft order patterns.
+export async function listDraftOrderPatterns(): Promise<DraftOrderPattern[]> {
+	return unwrap(await authFetch(ORDER_PATTERNS));
+}
+
+// setDraftOrderPattern selects a draft's DraftOrderPattern by its Name()
+// string (e.g. "Snake").
+export async function setDraftOrderPattern(id: string, draftOrderPattern: string): Promise<Draft> {
+	return unwrap(
+		await authFetch(`${BASE}/${id}/draft_order_pattern`, {
+			method: 'PUT',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ draft_order_pattern: draftOrderPattern })
+		})
+	);
+}
+
+// initializeDraft creates the draft's teams + DraftCaptain +
+// DraftAvailablePlayer rows from the provided captain ids (in draft order).
+export async function initializeDraft(id: string, captains: string[]): Promise<Draft> {
+	return unwrap(
+		await authFetch(`${BASE}/${id}/initialize`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ captains })
+		})
+	);
+}
+
+// assignDraftablePlayers adds players to the draft's available-to-draft list.
+export async function assignDraftablePlayers(id: string, players: string[]): Promise<Draft> {
+	return unwrap(
+		await authFetch(`${BASE}/${id}/assign_draftable_players`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ players })
+		})
+	);
+}
+
+// assignRatingCutoff assigns a cutoff index to a rating for the draft.
+export async function assignRatingCutoff(id: string, rating: string, cutoff: number): Promise<void> {
+	await unwrap(
+		await authFetch(`${BASE}/${id}/assign_rating_cutoff`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ rating, cutoff })
+		})
+	);
+}
+
+// selectPlayer makes a draft pick on behalf of the authenticated captain.
+export async function selectPlayer(id: string, playerId: string): Promise<Draft> {
+	return unwrap(
+		await authFetch(`${BASE}/${id}/select`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ player_id: playerId })
+		})
+	);
+}
+
+// assignDraftedPlayersToTeams finalizes a completed draft, assigning each
+// drafted player to their team with their draft rating.
+export async function assignDraftedPlayersToTeams(id: string): Promise<Draft> {
+	return unwrap(
+		await authFetch(`${BASE}/${id}/assign_drafted_players_to_teams`, {
+			method: 'POST'
+		})
+	);
+}
+
+// CreateSeasonInput captures the fields needed to create a Season from a
+// completed draft. start_time is a 24-hour "HH:MM" string (e.g. "08:30").
+export interface CreateSeasonInput {
+	name: string;
+	facility: string;
+	start_time: string;
+}
+
+// createSeason creates the Season associated with a completed draft.
+export async function createSeason(id: string, input: CreateSeasonInput): Promise<any> {
+	return unwrap(
+		await authFetch(`${BASE}/${id}/create_season`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(input)
+		})
+	);
+}

--- a/ui/src/lib/draftAvailablePlayer.ts
+++ b/ui/src/lib/draftAvailablePlayer.ts
@@ -1,0 +1,89 @@
+// DraftAvailablePlayer API client. Records are backed by the REST CRUD routes
+// generated from `model.DraftAvailablePlayer` (see route/draft):
+//
+//	GET    /api/draft_available_player        -> { resource: DraftAvailablePlayer[] }
+//	GET    /api/draft_available_player/:id    -> { resource: DraftAvailablePlayer }
+//	POST   /api/draft_available_player        -> { resource: DraftAvailablePlayer }
+//	PUT    /api/draft_available_player/:id    -> { resource: DraftAvailablePlayer }
+//	DELETE /api/draft_available_player/:id    -> { resource: DraftAvailablePlayer }
+//
+// A DraftAvailablePlayer links a Draft to a User who is eligible to be
+// drafted. Record IDs are 16-char hex strings.
+import { authFetch } from '$lib/auth';
+
+export interface DraftAvailablePlayer {
+	id: string;
+	draft_id: string;
+	player_id: string;
+	created_at: string;
+	updated_at: string;
+}
+
+const BASE = '/api/draft_available_player';
+
+async function unwrap(res: Response): Promise<any> {
+	if (!res.ok) {
+		let message = `Request failed (${res.status})`;
+		try {
+			const body = await res.json();
+			if (body?.error) message = body.error;
+		} catch {
+			// non-JSON error body; fall back to the status message
+		}
+		throw new Error(message);
+	}
+	const body = await res.json();
+	return body?.resource;
+}
+
+export async function listDraftAvailablePlayers(): Promise<DraftAvailablePlayer[]> {
+	return unwrap(await authFetch(BASE));
+}
+
+export async function getDraftAvailablePlayer(id: string): Promise<DraftAvailablePlayer> {
+	return unwrap(await authFetch(`${BASE}/${id}`));
+}
+
+export interface DraftAvailablePlayerInput {
+	draft_id: string;
+	player_id: string;
+}
+
+export async function createDraftAvailablePlayer(
+	input: DraftAvailablePlayerInput
+): Promise<DraftAvailablePlayer> {
+	return unwrap(
+		await authFetch(BASE, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(input)
+		})
+	);
+}
+
+export async function updateDraftAvailablePlayer(
+	id: string,
+	input: DraftAvailablePlayerInput
+): Promise<DraftAvailablePlayer> {
+	return unwrap(
+		await authFetch(`${BASE}/${id}`, {
+			method: 'PUT',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(input)
+		})
+	);
+}
+
+export async function deleteDraftAvailablePlayer(id: string): Promise<void> {
+	const res = await authFetch(`${BASE}/${id}`, { method: 'DELETE' });
+	if (!res.ok) {
+		let message = `Delete failed (${res.status})`;
+		try {
+			const body = await res.json();
+			if (body?.error) message = body.error;
+		} catch {
+			// non-JSON error body; fall back to the status message
+		}
+		throw new Error(message);
+	}
+}

--- a/ui/src/lib/draftCaptain.ts
+++ b/ui/src/lib/draftCaptain.ts
@@ -1,0 +1,91 @@
+// DraftCaptain API client. Records are backed by the REST CRUD routes
+// generated from `model.DraftCaptain` (see route/draft):
+//
+//	GET    /api/draft_captain        -> { resource: DraftCaptain[] }
+//	GET    /api/draft_captain/:id    -> { resource: DraftCaptain }
+//	POST   /api/draft_captain        -> { resource: DraftCaptain }
+//	PUT    /api/draft_captain/:id    -> { resource: DraftCaptain }
+//	DELETE /api/draft_captain/:id    -> { resource: DraftCaptain }
+//
+// A DraftCaptain links a Draft to a Team and its captain, with a draft order.
+// Record IDs are 16-char hex strings.
+import { authFetch } from '$lib/auth';
+
+export interface DraftCaptain {
+	id: string;
+	draft_id: string;
+	team_id: string;
+	captain_id: string;
+	draft_order: number;
+	created_at: string;
+	updated_at: string;
+}
+
+const BASE = '/api/draft_captain';
+
+async function unwrap(res: Response): Promise<any> {
+	if (!res.ok) {
+		let message = `Request failed (${res.status})`;
+		try {
+			const body = await res.json();
+			if (body?.error) message = body.error;
+		} catch {
+			// non-JSON error body; fall back to the status message
+		}
+		throw new Error(message);
+	}
+	const body = await res.json();
+	return body?.resource;
+}
+
+export async function listDraftCaptains(): Promise<DraftCaptain[]> {
+	return unwrap(await authFetch(BASE));
+}
+
+export async function getDraftCaptain(id: string): Promise<DraftCaptain> {
+	return unwrap(await authFetch(`${BASE}/${id}`));
+}
+
+export interface DraftCaptainInput {
+	draft_id: string;
+	team_id: string;
+	captain_id: string;
+	draft_order: number;
+}
+
+export async function createDraftCaptain(input: DraftCaptainInput): Promise<DraftCaptain> {
+	return unwrap(
+		await authFetch(BASE, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(input)
+		})
+	);
+}
+
+export async function updateDraftCaptain(
+	id: string,
+	input: DraftCaptainInput
+): Promise<DraftCaptain> {
+	return unwrap(
+		await authFetch(`${BASE}/${id}`, {
+			method: 'PUT',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(input)
+		})
+	);
+}
+
+export async function deleteDraftCaptain(id: string): Promise<void> {
+	const res = await authFetch(`${BASE}/${id}`, { method: 'DELETE' });
+	if (!res.ok) {
+		let message = `Delete failed (${res.status})`;
+		try {
+			const body = await res.json();
+			if (body?.error) message = body.error;
+		} catch {
+			// non-JSON error body; fall back to the status message
+		}
+		throw new Error(message);
+	}
+}

--- a/ui/src/lib/draftPick.ts
+++ b/ui/src/lib/draftPick.ts
@@ -1,0 +1,92 @@
+// DraftPick API client. Records are backed by the REST CRUD routes generated
+// from `model.DraftPick` (see route/draft):
+//
+//	GET    /api/draft_pick        -> { resource: DraftPick[] }
+//	GET    /api/draft_pick/:id    -> { resource: DraftPick }
+//	POST   /api/draft_pick        -> { resource: DraftPick }
+//	PUT    /api/draft_pick/:id    -> { resource: DraftPick }
+//	DELETE /api/draft_pick/:id    -> { resource: DraftPick }
+//
+// A DraftPick records which user a team selected in a given round/pick, and the
+// rating they consequently received. Record IDs are 16-char hex strings.
+import { authFetch } from '$lib/auth';
+
+export interface DraftPick {
+	id: string;
+	draft_id: string;
+	team_id: string;
+	user_id: string;
+	round: number;
+	pick: number;
+	rating: string;
+	created_at: string;
+	updated_at: string;
+}
+
+const BASE = '/api/draft_pick';
+
+async function unwrap(res: Response): Promise<any> {
+	if (!res.ok) {
+		let message = `Request failed (${res.status})`;
+		try {
+			const body = await res.json();
+			if (body?.error) message = body.error;
+		} catch {
+			// non-JSON error body; fall back to the status message
+		}
+		throw new Error(message);
+	}
+	const body = await res.json();
+	return body?.resource;
+}
+
+export async function listDraftPicks(): Promise<DraftPick[]> {
+	return unwrap(await authFetch(BASE));
+}
+
+export async function getDraftPick(id: string): Promise<DraftPick> {
+	return unwrap(await authFetch(`${BASE}/${id}`));
+}
+
+export interface DraftPickInput {
+	draft_id: string;
+	team_id: string;
+	user_id: string;
+	round: number;
+	pick: number;
+	rating: string;
+}
+
+export async function createDraftPick(input: DraftPickInput): Promise<DraftPick> {
+	return unwrap(
+		await authFetch(BASE, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(input)
+		})
+	);
+}
+
+export async function updateDraftPick(id: string, input: DraftPickInput): Promise<DraftPick> {
+	return unwrap(
+		await authFetch(`${BASE}/${id}`, {
+			method: 'PUT',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(input)
+		})
+	);
+}
+
+export async function deleteDraftPick(id: string): Promise<void> {
+	const res = await authFetch(`${BASE}/${id}`, { method: 'DELETE' });
+	if (!res.ok) {
+		let message = `Delete failed (${res.status})`;
+		try {
+			const body = await res.json();
+			if (body?.error) message = body.error;
+		} catch {
+			// non-JSON error body; fall back to the status message
+		}
+		throw new Error(message);
+	}
+}

--- a/ui/src/lib/draftRatingCutoff.ts
+++ b/ui/src/lib/draftRatingCutoff.ts
@@ -1,0 +1,90 @@
+// DraftRatingCutoff API client. Records are backed by the REST CRUD routes
+// generated from `model.DraftRatingCutoff` (see route/draft):
+//
+//	GET    /api/draft_rating_cutoff        -> { resource: DraftRatingCutoff[] }
+//	GET    /api/draft_rating_cutoff/:id    -> { resource: DraftRatingCutoff }
+//	POST   /api/draft_rating_cutoff        -> { resource: DraftRatingCutoff }
+//	PUT    /api/draft_rating_cutoff/:id    -> { resource: DraftRatingCutoff }
+//	DELETE /api/draft_rating_cutoff/:id    -> { resource: DraftRatingCutoff }
+//
+// A DraftRatingCutoff assigns a cutoff index (the last selection index matching
+// that rating) to a rating for a particular Draft. Record IDs are 16-char hex
+// strings.
+import { authFetch } from '$lib/auth';
+
+export interface DraftRatingCutoff {
+	id: string;
+	draft_id: string;
+	rating_id: string;
+	cutoff_index: number;
+}
+
+const BASE = '/api/draft_rating_cutoff';
+
+async function unwrap(res: Response): Promise<any> {
+	if (!res.ok) {
+		let message = `Request failed (${res.status})`;
+		try {
+			const body = await res.json();
+			if (body?.error) message = body.error;
+		} catch {
+			// non-JSON error body; fall back to the status message
+		}
+		throw new Error(message);
+	}
+	const body = await res.json();
+	return body?.resource;
+}
+
+export async function listDraftRatingCutoffs(): Promise<DraftRatingCutoff[]> {
+	return unwrap(await authFetch(BASE));
+}
+
+export async function getDraftRatingCutoff(id: string): Promise<DraftRatingCutoff> {
+	return unwrap(await authFetch(`${BASE}/${id}`));
+}
+
+export interface DraftRatingCutoffInput {
+	draft_id: string;
+	rating_id: string;
+	cutoff_index: number;
+}
+
+export async function createDraftRatingCutoff(
+	input: DraftRatingCutoffInput
+): Promise<DraftRatingCutoff> {
+	return unwrap(
+		await authFetch(BASE, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(input)
+		})
+	);
+}
+
+export async function updateDraftRatingCutoff(
+	id: string,
+	input: DraftRatingCutoffInput
+): Promise<DraftRatingCutoff> {
+	return unwrap(
+		await authFetch(`${BASE}/${id}`, {
+			method: 'PUT',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(input)
+		})
+	);
+}
+
+export async function deleteDraftRatingCutoff(id: string): Promise<void> {
+	const res = await authFetch(`${BASE}/${id}`, { method: 'DELETE' });
+	if (!res.ok) {
+		let message = `Delete failed (${res.status})`;
+		try {
+			const body = await res.json();
+			if (body?.error) message = body.error;
+		} catch {
+			// non-JSON error body; fall back to the status message
+		}
+		throw new Error(message);
+	}
+}

--- a/ui/src/lib/preDraftGrade.ts
+++ b/ui/src/lib/preDraftGrade.ts
@@ -1,0 +1,98 @@
+// PreDraftGrade API client. Records are backed by the REST CRUD routes
+// generated from `model.PreDraftGrade` (see route/draft):
+//
+//	GET    /api/pre_draft_grade        -> { resource: PreDraftGrade[] }
+//	GET    /api/pre_draft_grade/:id    -> { resource: PreDraftGrade }
+//	POST   /api/pre_draft_grade        -> { resource: PreDraftGrade }
+//	PUT    /api/pre_draft_grade/:id    -> { resource: PreDraftGrade }
+//	DELETE /api/pre_draft_grade/:id    -> { resource: PreDraftGrade }
+//
+// A PreDraftGrade is a grade a grader gives a player before the draft,
+// expressed as a rating plus a modifier (weak/average/strong). Note: the
+// model exposes these fields without JSON tags, so their wire keys are the
+// capitalized Go field names (`PlayerId`, `DraftId`, `GraderId`, `Modifier`,
+// `Rating`). `GraderId` is set from the authenticated user on create. Record
+// IDs are 16-char hex strings.
+import { authFetch } from '$lib/auth';
+
+export interface PreDraftGrade {
+	id: string;
+	PlayerId: string;
+	DraftId: string;
+	GraderId: string;
+	Modifier: number;
+	Rating: string;
+}
+
+// Modifier values: 0 = weak, 1 = average, 2 = strong.
+export type PreDraftModifier = 0 | 1 | 2;
+
+const BASE = '/api/pre_draft_grade';
+
+async function unwrap(res: Response): Promise<any> {
+	if (!res.ok) {
+		let message = `Request failed (${res.status})`;
+		try {
+			const body = await res.json();
+			if (body?.error) message = body.error;
+		} catch {
+			// non-JSON error body; fall back to the status message
+		}
+		throw new Error(message);
+	}
+	const body = await res.json();
+	return body?.resource;
+}
+
+export async function listPreDraftGrades(): Promise<PreDraftGrade[]> {
+	return unwrap(await authFetch(BASE));
+}
+
+export async function getPreDraftGrade(id: string): Promise<PreDraftGrade> {
+	return unwrap(await authFetch(`${BASE}/${id}`));
+}
+
+export interface PreDraftGradeInput {
+	PlayerId: string;
+	DraftId: string;
+	Modifier: PreDraftModifier;
+	Rating: string;
+	// GraderId is omitted: it is set from the authenticated user on create.
+}
+
+export async function createPreDraftGrade(input: PreDraftGradeInput): Promise<PreDraftGrade> {
+	return unwrap(
+		await authFetch(BASE, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(input)
+		})
+	);
+}
+
+export async function updatePreDraftGrade(
+	id: string,
+	input: PreDraftGradeInput
+): Promise<PreDraftGrade> {
+	return unwrap(
+		await authFetch(`${BASE}/${id}`, {
+			method: 'PUT',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(input)
+		})
+	);
+}
+
+export async function deletePreDraftGrade(id: string): Promise<void> {
+	const res = await authFetch(`${BASE}/${id}`, { method: 'DELETE' });
+	if (!res.ok) {
+		let message = `Delete failed (${res.status})`;
+		try {
+			const body = await res.json();
+			if (body?.error) message = body.error;
+		} catch {
+			// non-JSON error body; fall back to the status message
+		}
+		throw new Error(message);
+	}
+}


### PR DESCRIPTION
Implements #123: exposes the Draft REST surface so the UI can be built.

## What changed
- **CRUD routes** for Draft, DraftAvailablePlayer, DraftCaptain, DraftPick, DraftRatingCutoff, PreDraftGrade (via NewCrudCommon, registered in main.go).
- **Custom action endpoints** (route/draft, via RouteFamily):
  - POST /draft/:id/initialize
  - POST /draft/:id/assign_draftable_players
  - POST /draft/:id/assign_rating_cutoff
  - POST /draft/:id/select (SelectByCaptain)
  - POST /draft/:id/assign_drafted_players_to_teams
  - POST /draft/:id/create_season
  - PUT /draft/:id/draft_order_pattern (selects the pattern by Name() string)
- **DraftOrderPattern interface** is now serialized/deserialized on the wire by its Name() string (custom MarshalJSON/UnmarshalJSON), defaulting to Snake.
- **ID JSON marshaling fixes**: FormatId/RatingId had value-receiver UnmarshalJSON that never wrote back; DraftId/TeamId/FacilityId had no unmarshal. These were required for the CRUD request bodies to bind. Now all serialize/deserialize as 16-char hex strings.
- **UI client libs** following lib/format.ts: draft.ts (CRUD + all custom actions + listDraftOrderPatterns), draftAvailablePlayer.ts, draftCaptain.ts, draftPick.ts, draftRatingCutoff.ts, preDraftGrade.ts.

## Tests
- Backend tests in route/draft/draft_test.go exercise every CRUD route and every custom endpoint over HTTP with real JWTs (create -> initialize -> assign -> pick -> finalize -> create season), plus authorization failures (non-owner initialize, non-captain select) and wire-level body validation.
- make tests (go test ./... + go vet ./...) green. npm run check green.

## Decisions to review
- **SelectByCaptain authz**: requires the requesting user to be a draft captain (403 otherwise); all other draft actions require owner/sysadmin edit.
- The ID-marshaling and Draft-serialization changes are model-layer fixes beyond literal route registration but were required for the endpoints to function.
