### PR TITLE
UI: draft list & create pages (#124)

### DIFF
--- a/ui/e2e/draft.spec.ts
+++ b/ui/e2e/draft.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test, type Page } from '@playwright/test';
+import { waitForHydration } from './helpers';
+
+// The Go backend runs with --dev-token from the repo root (see
+// playwright.config.ts), so POST /api/one_time_password returns the magic-link
+// token in the response body. Login with the user seeded by SeedDevData.
+async function login(page: Page) {
+	await page.goto('/login');
+	await page.waitForLoadState('networkidle');
+	await page.getByLabel('Email').fill('jdarthur@gatech.edu');
+	await page.getByRole('button', { name: 'Send login link' }).click();
+	const link = page.getByRole('main').getByRole('link', { name: 'Log in' });
+	await expect(link).toBeVisible();
+	await link.click();
+	await expect(page).toHaveURL('/');
+}
+
+// SeedDevData creates a format named "Men's Intraclub" owned by the seed user.
+const SEED_FORMAT = "Men's Intraclub";
+
+test('draft create navigates to its setup page and appears in the list', async ({ page }) => {
+	await login(page);
+
+	const unique = Date.now();
+	const draftName = `Test Draft ${unique}`;
+
+	// Create
+	await page.goto('/drafts');
+	await expect(page.getByRole('heading', { name: 'Drafts' })).toBeVisible();
+	await page.getByRole('link', { name: 'New draft' }).click();
+	await expect(page).toHaveURL(/\/drafts\/new$/);
+	await waitForHydration(page);
+
+	await page.getByLabel('Name').fill(draftName);
+	await page.getByLabel('Format').selectOption({ label: SEED_FORMAT });
+	await page.getByRole('button', { name: 'Create draft' }).click();
+
+	// Lands on the setup page (/drafts/[id]).
+	await expect(page).toHaveURL(/\/drafts\/[0-9a-f]+$/);
+	await expect(page.getByRole('heading', { name: draftName })).toBeVisible();
+
+	// The list reflects the new draft.
+	await page.goto('/drafts');
+	const row = page.getByRole('link', { name: draftName });
+	await expect(row).toBeVisible();
+
+	// Clean up the draft so the table doesn't accumulate rows across runs.
+	const draftId = (await row.getAttribute('href'))?.split('/').pop();
+	expect(draftId).toBeTruthy();
+	const res = await page.request.delete(`http://127.0.0.1:8080/api/draft/${draftId}`, {
+		headers: { 'X-INTRACLUB-TOKEN': await page.evaluate(() => localStorage.getItem('intraclub_jwt')) }
+	});
+	expect(res.ok()).toBeTruthy();
+});

--- a/ui/src/lib/components/NavBar.svelte
+++ b/ui/src/lib/components/NavBar.svelte
@@ -22,6 +22,7 @@
 			<a href="/rulesets" class="rounded-md px-2 py-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground">Rulesets</a>
 			<a href="/scoring-structures" class="rounded-md px-2 py-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground">Scoring Structures</a>
 			<a href="/playoff-structures" class="rounded-md px-2 py-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground">Playoff Structures</a>
+			<a href="/drafts" class="rounded-md px-2 py-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground">Drafts</a>
 			<a href="/photos" class="rounded-md px-2 py-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground">Photos</a>
 		</nav>
 		<div class="ml-auto flex items-center">

--- a/ui/src/lib/user.ts
+++ b/ui/src/lib/user.ts
@@ -1,0 +1,49 @@
+// User API client. User records are backed by the existing REST CRUD routes
+// generated from `model.User` (see main.go):
+//
+//	GET    /api/user      -> { resource: User[] }
+//	GET    /api/user/:id  -> { resource: User }
+//
+// Only reads are exposed (GET one / GET many); writes go through the dedicated
+// registration/login routes. Record IDs are 16-char hex strings.
+import { authFetch } from '$lib/auth';
+
+export interface User {
+	id: string;
+	first_name: string;
+	last_name: string;
+	phone_number: string;
+	email: string;
+	verified: boolean;
+}
+
+const BASE = '/api/user';
+
+// unwrap parses a CrudCommon response (`{ resource: ... }`) and throws the
+// backend error message on non-2xx responses so callers can surface it.
+async function unwrap(res: Response): Promise<any> {
+	if (!res.ok) {
+		let message = `Request failed (${res.status})`;
+		try {
+			const body = await res.json();
+			if (body?.error) message = body.error;
+		} catch {
+			// non-JSON error body; fall back to the status message
+		}
+		throw new Error(message);
+	}
+	const body = await res.json();
+	return body?.resource;
+}
+
+export async function listUsers(): Promise<User[]> {
+	return unwrap(await authFetch(BASE));
+}
+
+export async function getUser(id: string): Promise<User> {
+	return unwrap(await authFetch(`${BASE}/${id}`));
+}
+
+export function fullName(user: Pick<User, 'first_name' | 'last_name'>): string {
+	return `${user.first_name} ${user.last_name}`.trim();
+}

--- a/ui/src/routes/drafts/+page.svelte
+++ b/ui/src/routes/drafts/+page.svelte
@@ -1,0 +1,98 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { listDrafts } from '$lib/draft';
+	import type { Draft } from '$lib/draft';
+	import { listFormats } from '$lib/format';
+	import { listUsers, fullName } from '$lib/user';
+	import { Badge } from '$lib/components/ui/badge/index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import {
+		Table,
+		TableBody,
+		TableCell,
+		TableHead,
+		TableHeader,
+		TableRow
+	} from '$lib/components/ui/table/index.js';
+
+	let drafts = $state<Draft[]>([]);
+	let formats = $state<Record<string, string>>({});
+	let users = $state<Record<string, string>>({});
+	let loading = $state(true);
+	let error = $state('');
+
+	// The zero Go time marshals to this literal; treat it as "not set".
+	const ZERO_TIME = '0001-01-01T00:00:00Z';
+
+	function isCompleted(draft: Draft): boolean {
+		return !!draft.completed_at && draft.completed_at !== ZERO_TIME;
+	}
+
+	onMount(async () => {
+		try {
+			const [draftList, formatList, userList] = await Promise.all([
+				listDrafts(),
+				listFormats(),
+				listUsers()
+			]);
+			drafts = draftList;
+			formats = Object.fromEntries(formatList.map((f) => [f.id, f.name]));
+			users = Object.fromEntries(userList.map((u) => [u.id, fullName(u)]));
+		} catch (e) {
+			error = e instanceof Error ? e.message : 'Failed to load drafts';
+		} finally {
+			loading = false;
+		}
+	});
+</script>
+
+<svelte:head>
+	<title>Drafts</title>
+</svelte:head>
+
+<div class="flex items-center justify-between gap-4">
+	<h1 class="text-2xl font-semibold tracking-tight">Drafts</h1>
+	<Button href="/drafts/new">New draft</Button>
+</div>
+
+{#if loading}
+	<p class="text-muted-foreground">Loading...</p>
+{:else if error}
+	<p class="text-sm font-medium text-destructive">{error}</p>
+{:else if drafts.length === 0}
+	<p class="text-muted-foreground">No drafts yet.</p>
+{:else}
+	<div class="mt-4 overflow-hidden rounded-lg border">
+		<Table>
+			<TableHeader>
+				<TableRow>
+					<TableHead>Name</TableHead>
+					<TableHead>Owner</TableHead>
+					<TableHead>Format</TableHead>
+					<TableHead>Status</TableHead>
+				</TableRow>
+			</TableHeader>
+			<TableBody>
+				{#each drafts as draft}
+					<TableRow>
+						<TableCell>
+							<a
+								href={`/drafts/${draft.id}`}
+								class="font-medium text-primary underline-offset-4 hover:underline"
+							>
+								{draft.name}
+							</a>
+						</TableCell>
+						<TableCell>{users[draft.owner] ?? draft.owner}</TableCell>
+						<TableCell>{formats[draft.format] ?? draft.format}</TableCell>
+						<TableCell>
+							<Badge variant={isCompleted(draft) ? 'secondary' : 'default'}>
+								{isCompleted(draft) ? 'Completed' : 'In progress'}
+							</Badge>
+						</TableCell>
+					</TableRow>
+				{/each}
+			</TableBody>
+		</Table>
+	</div>
+{/if}

--- a/ui/src/routes/drafts/[id]/+page.svelte
+++ b/ui/src/routes/drafts/[id]/+page.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { page } from '$app/state';
+	import { getDraft } from '$lib/draft';
+	import type { Draft } from '$lib/draft';
+
+	const id = () => page.params.id as string;
+
+	let draft = $state<Draft | null>(null);
+	let error = $state('');
+
+	onMount(async () => {
+		try {
+			draft = await getDraft(id());
+		} catch (e) {
+			error = e instanceof Error ? e.message : 'Failed to load draft';
+		}
+	});
+</script>
+
+<svelte:head>
+	<title>{draft ? draft.name : 'Draft'}</title>
+</svelte:head>
+
+{#if error}
+	<h1 class="text-2xl font-semibold tracking-tight">Draft</h1>
+	<p class="text-sm font-medium text-destructive">{error}</p>
+	<a href="/drafts" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to drafts</a>
+{:else if !draft}
+	<h1 class="text-2xl font-semibold tracking-tight">Draft</h1>
+	<p class="text-muted-foreground">Loading...</p>
+{:else}
+	<div class="flex items-center gap-4">
+		<h1 class="text-2xl font-semibold tracking-tight">{draft.name}</h1>
+		<a href="/drafts" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to drafts</a>
+	</div>
+
+	<p class="mt-4 text-muted-foreground">
+		This draft's setup is not yet available. Check back after the draft setup feature ships.
+	</p>
+{/if}

--- a/ui/src/routes/drafts/new/+page.svelte
+++ b/ui/src/routes/drafts/new/+page.svelte
@@ -1,0 +1,124 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { createDraft, listDraftOrderPatterns, setDraftOrderPattern } from '$lib/draft';
+	import type { DraftOrderPattern } from '$lib/draft';
+	import { listFormats } from '$lib/format';
+	import type { Format } from '$lib/format';
+	import { goto } from '$app/navigation';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
+	import {
+		NativeSelect,
+		NativeSelectOption
+	} from '$lib/components/ui/native-select/index.js';
+
+	let formats = $state<Format[]>([]);
+	let patterns = $state<DraftOrderPattern[]>([]);
+	let loadError = $state('');
+	let loading = $state(true);
+
+	let name = $state('');
+	let format = $state('');
+	let pattern = $state('');
+	let error = $state('');
+	let submitting = $state(false);
+
+	// The backend defaults a new draft's pattern to Snake; only send the
+	// explicit pattern set when the user picks something else.
+	const DEFAULT_PATTERN = 'Snake';
+
+	onMount(async () => {
+		try {
+			const [formatList, patternList] = await Promise.all([
+				listFormats(),
+				listDraftOrderPatterns()
+			]);
+			formats = formatList;
+			patterns = patternList;
+			pattern = DEFAULT_PATTERN;
+		} catch (e) {
+			loadError = e instanceof Error ? e.message : 'Failed to load draft options';
+		} finally {
+			loading = false;
+		}
+	});
+
+	async function handleSubmit(e: Event) {
+		e.preventDefault();
+		error = '';
+		submitting = true;
+		try {
+			const created = await createDraft({ name: name.trim(), format });
+			// If the pattern set fails the draft still exists, so navigate to it
+			// rather than stranding the user on the create form. The detail page
+			// defaults the pattern to Snake, which is the safe fallback.
+			if (pattern && pattern !== DEFAULT_PATTERN) {
+				try {
+					await setDraftOrderPattern(created.id, pattern);
+				} catch {
+					// pattern selection failed; proceed to the draft anyway
+				}
+			}
+			await goto(`/drafts/${created.id}`);
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Failed to create draft';
+		} finally {
+			submitting = false;
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>New draft</title>
+</svelte:head>
+
+<div class="flex items-center gap-4">
+	<h1 class="text-2xl font-semibold tracking-tight">New draft</h1>
+	<a href="/drafts" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to drafts</a>
+</div>
+
+{#if loading}
+	<p class="mt-4 text-muted-foreground">Loading...</p>
+{:else if loadError}
+	<p class="mt-4 text-sm font-medium text-destructive">{loadError}</p>
+{:else}
+	<Card class="mt-6 max-w-md">
+		<CardHeader>
+			<CardTitle class="text-base">Draft details</CardTitle>
+		</CardHeader>
+		<CardContent>
+			<form onsubmit={handleSubmit} class="flex flex-col gap-4">
+				<div class="flex flex-col gap-2">
+					<Label for="name">Name</Label>
+					<Input id="name" type="text" bind:value={name} required />
+				</div>
+				<div class="flex flex-col gap-2">
+					<Label for="format">Format</Label>
+					<NativeSelect id="format" bind:value={format} required class="w-full">
+						<NativeSelectOption value="" disabled>Select a format…</NativeSelectOption>
+						{#each formats as f}
+							<NativeSelectOption value={f.id}>{f.name}</NativeSelectOption>
+						{/each}
+					</NativeSelect>
+				</div>
+				<div class="flex flex-col gap-2">
+					<Label for="pattern">Draft order pattern</Label>
+					<NativeSelect id="pattern" bind:value={pattern} class="w-full">
+						{#each patterns as p}
+							<NativeSelectOption value={p.name}>{p.name}</NativeSelectOption>
+						{/each}
+					</NativeSelect>
+				</div>
+				<Button type="submit" disabled={submitting} class="w-fit">
+					{submitting ? 'Creating...' : 'Create draft'}
+				</Button>
+			</form>
+		</CardContent>
+	</Card>
+{/if}
+
+{#if error}
+	<p class="mt-4 text-sm font-medium text-destructive">{error}</p>
+{/if}


### PR DESCRIPTION
Closes #124

Implements the draft list (`/drafts`) and create (`/drafts/new`) pages.

- **`/drafts`** — table of drafts with name, owner, format, and completion status; each name links to the draft's page; `New draft` action.
- **`/drafts/new`** — form with name, format (from `GET /api/format`), and draft order pattern (from `GET /api/draft_order_patterns`); owner is the token user (set server-side). Creating navigates to `/drafts/[id]`.
- Added a minimal `/drafts/[id]` placeholder page so create navigation works (full setup page is #125).
- Added a `Drafts` link to the nav bar and a new `user.ts` API client for resolving owner names.
- Added an e2e test covering draft create + list.

## Verification
- `npm run check` — 0 errors, 0 warnings
- `make e2e` — 16/16 green across 4 consecutive runs