### PR TITLE
UI: Pre-draft grading page (#126)

### DIFF
--- a/ui/e2e/draft-grades.spec.ts
+++ b/ui/e2e/draft-grades.spec.ts
@@ -1,0 +1,100 @@
+import { expect, test, type Page } from '@playwright/test';
+import { waitForHydration } from './helpers';
+
+// The Go backend runs with --dev-token from the repo root (see
+// playwright.config.ts), so POST /api/one_time_password returns the magic-link
+// token in the response body. Login with the user seeded by SeedDevData.
+async function login(page: Page) {
+	await page.goto('/login');
+	await page.waitForLoadState('networkidle');
+	await page.getByLabel('Email').fill('jdarthur@gatech.edu');
+	await page.getByRole('button', { name: 'Send login link' }).click();
+	const link = page.getByRole('main').getByRole('link', { name: 'Log in' });
+	await expect(link).toBeVisible();
+	await link.click();
+	await expect(page).toHaveURL('/');
+}
+
+// SeedDevData creates a format named "Men's Intraclub" with the possible
+// ratings "Men's 1", "Men's 2", "Men's 3" (ordered highest-skill first).
+const SEED_FORMAT = "Men's Intraclub";
+
+const API = 'http://127.0.0.1:8080/api';
+
+test('pre-draft grading page assigns grades and ranks players', async ({ page }) => {
+	await login(page);
+	const token = await page.evaluate(() => localStorage.getItem('intraclub_jwt') ?? '');
+	expect(token).toBeTruthy();
+
+	const unique = Date.now();
+
+	// Create a roster user to grade via the CSV import endpoint (the
+	// self-register route needs a configured mailer, which isn't available in
+	// the dev e2e environment).
+	const people = [{ first: `Casey${unique}`, last: 'Roster' }];
+	const csv = [
+		'First Name, Last Name, Email',
+		...people.map((p) => `${p.first}, ${p.last}, ${p.first.toLowerCase()}@example.com`)
+	].join('\n');
+	const importRes = await page.request.post(`${API}/import_users_from_csv`, {
+		form: { file: csv }
+	});
+	expect(importRes.ok()).toBeTruthy();
+	const importBody = await importRes.json();
+	const userIds = [...importBody.Created, ...importBody.AlreadyExisting].map(
+		(u: { id: string }) => u.id
+	);
+	expect(userIds).toHaveLength(people.length);
+
+	const formatRes = await page.request.get(`${API}/format`);
+	const formats = (await formatRes.json()).resource as { id: string; name: string }[];
+	const format = formats.find((f) => f.name === SEED_FORMAT);
+	expect(format).toBeTruthy();
+
+	const draftName = `Grades Draft ${unique}`;
+	const draftRes = await page.request.post(`${API}/draft`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { name: draftName, format: format!.id }
+	});
+	expect(draftRes.ok()).toBeTruthy();
+	const draftId = (await draftRes.json()).resource.id as string;
+
+	// Add the two roster players to the draft's available-to-draft list.
+	const assignRes = await page.request.post(`${API}/draft/${draftId}/assign_draftable_players`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { players: userIds }
+	});
+	expect(assignRes.ok()).toBeTruthy();
+
+	const rosterOne = `${people[0].first} ${people[0].last}`;
+
+	// --- Grade a player ---
+	await page.goto(`/drafts/${draftId}/grades`);
+	await expect(page.getByRole('heading', { name: draftName })).toBeVisible();
+	await waitForHydration(page);
+
+	// Men's 1 is the highest rating; Strong (modifier 2) -> numeric 9.
+	await page.locator('#modifier-0').selectOption({ label: 'Strong' });
+	await page.locator('#rating-0').selectOption({ label: "Men's 1" });
+	await page.getByRole('button', { name: 'Save grades' }).click();
+
+	// The grade persists: the entry shows "saved" and the ranking shows 9.00.
+	await expect(page.getByText('saved')).toBeVisible();
+	await expect(page.getByRole('table').getByText('9.00')).toBeVisible();
+
+	await page.reload();
+	await waitForHydration(page);
+	await expect(page.locator('#modifier-0')).toHaveValue('2');
+	await expect(page.locator('#rating-0')).toHaveValue(
+		(await page.request.get(`${API}/rating`).then((r) => r.json()))
+			.resource.find((x: { name: string }) => x.name === "Men's 1").id
+	);
+	await expect(page.getByText('saved')).toBeVisible();
+	await expect(page.getByRole('table').getByText('9.00')).toBeVisible();
+
+	// Clean up the draft so the table doesn't accumulate rows across runs.
+	const cleanup = await page.request.delete(`${API}/draft/${draftId}`, {
+		headers: { 'X-INTRACLUB-TOKEN': token }
+	});
+	expect(cleanup.ok()).toBeTruthy();
+});

--- a/ui/src/lib/auth.ts
+++ b/ui/src/lib/auth.ts
@@ -31,6 +31,29 @@ export function isLoggedIn(): boolean {
 	return getToken() !== null;
 }
 
+// decodeBase64Url decodes a base64url-encoded string (as used in JWT payloads).
+function decodeBase64Url(s: string): string {
+	const base64 = s.replace(/-/g, '+').replace(/_/g, '/');
+	const padded = base64 + '='.repeat((4 - (base64.length % 4)) % 4);
+	return atob(padded);
+}
+
+// getCurrentUserId returns the authenticated user's id from the stored JWT's
+// `sub` claim (the backend puts the user id there; see api/api_auth.go), or
+// null if there is no valid token.
+export function getCurrentUserId(): string | null {
+	const token = getToken();
+	if (!token) return null;
+	try {
+		const payload = token.split('.')[1];
+		if (!payload) return null;
+		const claims = JSON.parse(decodeBase64Url(payload));
+		return typeof claims.sub === 'string' ? claims.sub : null;
+	} catch {
+		return null;
+	}
+}
+
 let lastToken: string | null = null;
 let expiredHandled = false;
 

--- a/ui/src/routes/drafts/[id]/+page.svelte
+++ b/ui/src/routes/drafts/[id]/+page.svelte
@@ -276,7 +276,12 @@
 
 <div class="flex items-center gap-4">
 	<h1 class="text-2xl font-semibold tracking-tight">{draft?.name ?? 'Draft'}</h1>
-	<a href="/drafts" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to drafts</a>
+	<div class="ml-auto flex items-center gap-3">
+		<a href={`/drafts/${id()}/grades`} class="text-sm text-muted-foreground hover:text-foreground">
+			Pre-draft grades →
+		</a>
+		<a href="/drafts" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to drafts</a>
+	</div>
 </div>
 
 {#if loading}

--- a/ui/src/routes/drafts/[id]/grades/+page.svelte
+++ b/ui/src/routes/drafts/[id]/grades/+page.svelte
@@ -1,0 +1,346 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { page } from '$app/state';
+	import { getDraft } from '$lib/draft';
+	import type { Draft } from '$lib/draft';
+	import { listFormats, getFormatPossibleRatings } from '$lib/format';
+	import type { Format } from '$lib/format';
+	import type { Rating } from '$lib/rating';
+	import { listUsers, fullName } from '$lib/user';
+	import type { User } from '$lib/user';
+	import { getCurrentUserId } from '$lib/auth';
+	import { listDraftAvailablePlayers } from '$lib/draftAvailablePlayer';
+	import type { DraftAvailablePlayer } from '$lib/draftAvailablePlayer';
+	import {
+		listPreDraftGrades,
+		createPreDraftGrade,
+		updatePreDraftGrade
+	} from '$lib/preDraftGrade';
+	import type { PreDraftGrade, PreDraftModifier } from '$lib/preDraftGrade';
+	import { Badge } from '$lib/components/ui/badge/index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import {
+		Card,
+		CardContent,
+		CardHeader,
+		CardTitle
+	} from '$lib/components/ui/card/index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
+	import {
+		NativeSelect,
+		NativeSelectOption
+	} from '$lib/components/ui/native-select/index.js';
+	import {
+		Table,
+		TableBody,
+		TableCell,
+		TableHead,
+		TableHeader,
+		TableRow
+	} from '$lib/components/ui/table/index.js';
+
+	const id = () => page.params.id as string;
+
+	// The zero Go time marshals to this literal; treat it as "not set".
+	const ZERO_TIME = '0001-01-01T00:00:00Z';
+
+	// Modifier values: 0 = weak, 1 = average, 2 = strong.
+	const MODIFIERS: { value: string; label: string }[] = [
+		{ value: '0', label: 'Weak' },
+		{ value: '1', label: 'Average' },
+		{ value: '2', label: 'Strong' }
+	];
+
+	let draft = $state<Draft | null>(null);
+	let format = $state<Format | null>(null);
+	let possibleRatings = $state<Rating[]>([]);
+	let users = $state<User[]>([]);
+	// The current user is the grader; their id comes from the JWT's `sub`.
+	const currentUserId = getCurrentUserId();
+
+	let availablePlayers = $state<DraftAvailablePlayer[]>([]);
+	let grades = $state<PreDraftGrade[]>([]);
+
+	let loading = $state(true);
+	let loadError = $state('');
+	let actionError = $state('');
+	let saving = $state(false);
+
+	// One grade entry per available player, seeded from the current user's
+	// existing grade (there is at most one grade per player/grader/draft).
+	interface GradeEntry {
+		playerId: string;
+		modifier: string;
+		ratingId: string;
+		gradeId: string | null;
+	}
+	let entries = $state<GradeEntry[]>([]);
+
+	async function load() {
+		loading = true;
+		loadError = '';
+		actionError = '';
+		try {
+			const draftData = await getDraft(id());
+			const [formatList, userList, availableList, gradeList] = await Promise.all([
+				listFormats(),
+				listUsers(),
+				listDraftAvailablePlayers(),
+				listPreDraftGrades()
+			]);
+
+			draft = draftData;
+			users = userList;
+
+			const fmt = formatList.find((f) => f.id === draftData.format) ?? null;
+			format = fmt;
+			possibleRatings = fmt ? await getFormatPossibleRatings(fmt.id) : [];
+
+			const forThisDraft = availableList.filter((a) => a.draft_id === draftData.id);
+			availablePlayers = forThisDraft;
+			grades = gradeList.filter((g) => g.DraftId === draftData.id);
+
+			// Seed an entry per available player from the current user's grade.
+			entries = forThisDraft.map((a) => {
+				const mine = grades.find(
+					(g) => g.PlayerId === a.player_id && g.GraderId === currentUserId
+				);
+				return {
+					playerId: a.player_id,
+					modifier: mine ? String(mine.Modifier) : '',
+					ratingId: mine ? mine.Rating : '',
+					gradeId: mine ? mine.id : null
+				};
+			});
+		} catch (e) {
+			loadError = e instanceof Error ? e.message : 'Failed to load grading page';
+		} finally {
+			loading = false;
+		}
+	}
+
+	onMount(load);
+
+	function userName(userId: string): string {
+		const u = users.find((x) => x.id === userId);
+		return u ? fullName(u) : userId;
+	}
+
+	const isCompleted = $derived(
+		!!draft && !!draft.completed_at && draft.completed_at !== ZERO_TIME
+	);
+
+	// --- Aggregate ranking ---
+	// Mirrors model.PreDraftGrade.NumericRating / GetDraftAggregateForPlayer /
+	// GetSortedListOfAllPreDraftGradesDescending so captains can compare players.
+	const possibleRatingIds = $derived(possibleRatings.map((r) => r.id));
+
+	function numericRating(grade: PreDraftGrade, ratingIds: string[]): number {
+		const idx = ratingIds.indexOf(grade.Rating);
+		if (idx === -1) return -1;
+		const base = (ratingIds.length - idx - 1) * 3 + 1;
+		return base + grade.Modifier;
+	}
+
+	const ranking = $derived(
+		availablePlayers
+			.map((a) => {
+				const forPlayer = grades.filter((g) => g.PlayerId === a.player_id);
+				const sum = forPlayer.reduce((acc, g) => acc + numericRating(g, possibleRatingIds), 0);
+				const aggregate = forPlayer.length > 0 ? sum / forPlayer.length : 0;
+				return { playerId: a.player_id, aggregate, graded: forPlayer.length > 0 };
+			})
+			.sort((a, b) => b.aggregate - a.aggregate)
+	);
+
+	// --- Saving grades ---
+
+	function entryError(): string | null {
+		for (const entry of entries) {
+			const name = userName(entry.playerId);
+			if (entry.ratingId === '') return `Pick a rating for ${name}.`;
+			if (entry.modifier !== '0' && entry.modifier !== '1' && entry.modifier !== '2') {
+				return `Pick a modifier for ${name}.`;
+			}
+		}
+		return null;
+	}
+
+	async function handleSave() {
+		actionError = '';
+		if (isCompleted) {
+			actionError = 'This draft is already completed, so grades can no longer be changed.';
+			return;
+		}
+		const error = entryError();
+		if (error) {
+			actionError = error;
+			return;
+		}
+		saving = true;
+		try {
+			for (const entry of entries) {
+				const input = {
+					PlayerId: entry.playerId,
+					DraftId: draft!.id,
+					Modifier: Number(entry.modifier) as PreDraftModifier,
+					Rating: entry.ratingId
+				};
+				if (entry.gradeId) {
+					await updatePreDraftGrade(entry.gradeId, input);
+				} else {
+					await createPreDraftGrade(input);
+				}
+			}
+			await load();
+		} catch (e) {
+			actionError = e instanceof Error ? e.message : 'Failed to save grades';
+		} finally {
+			saving = false;
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>{draft ? `${draft.name} — Grades` : 'Pre-draft grades'}</title>
+</svelte:head>
+
+<div class="flex items-center gap-4">
+	<h1 class="text-2xl font-semibold tracking-tight">{draft?.name ?? 'Pre-draft grades'}</h1>
+	<a href={`/drafts/${id()}`} class="text-sm text-muted-foreground hover:text-foreground">
+		&larr; Draft setup
+	</a>
+</div>
+
+{#if loading}
+	<p class="mt-4 text-muted-foreground">Loading...</p>
+{:else if loadError}
+	<p class="mt-4 text-sm font-medium text-destructive">{loadError}</p>
+{:else if draft}
+	<div class="mt-4 flex items-center gap-4">
+		<Badge variant={isCompleted ? 'secondary' : 'default'}>
+			{isCompleted ? 'Draft completed' : 'Draft in progress'}
+		</Badge>
+		{#if isCompleted}
+			<p class="text-sm text-muted-foreground">
+				Grades can no longer be changed once the draft is completed.
+			</p>
+		{/if}
+	</div>
+
+	{#if actionError}
+		<p class="mt-4 text-sm font-medium text-destructive">{actionError}</p>
+	{/if}
+
+	<div class="mt-6 grid gap-6 lg:grid-cols-2">
+		<!-- Grade assignment -->
+		<Card>
+			<CardHeader>
+				<CardTitle class="text-base">Assign grades</CardTitle>
+			</CardHeader>
+			<CardContent>
+				<p class="text-sm text-muted-foreground">
+					For each draftable player, pick a rating from this draft's format and mark them
+					as a weak, average, or strong version of that rating.
+				</p>
+				{#if availablePlayers.length === 0}
+					<p class="mt-4 text-sm text-muted-foreground">No draftable players yet.</p>
+				{:else}
+					<form
+						class="mt-4 flex flex-col gap-4"
+						onsubmit={(e) => {
+							e.preventDefault();
+							handleSave();
+						}}
+					>
+						{#each entries as entry, i}
+							<div class="rounded-lg border px-3 py-3">
+								<div class="flex items-center justify-between gap-4">
+									<Label for={`modifier-${i}`} class="font-medium">
+										{userName(entry.playerId)}
+									</Label>
+									{#if entry.gradeId}
+										<Badge variant="outline">saved</Badge>
+									{/if}
+								</div>
+								<div class="mt-3 flex flex-col gap-3 sm:flex-row sm:items-center">
+									<NativeSelect
+										id={`modifier-${i}`}
+										class="sm:w-40"
+										disabled={isCompleted}
+										value={entry.modifier}
+										onchange={(e) => {
+											entry.modifier = (e.currentTarget as HTMLSelectElement).value;
+										}}
+									>
+										<NativeSelectOption value="" disabled>Modifier…</NativeSelectOption>
+										{#each MODIFIERS as m}
+											<NativeSelectOption value={m.value}>{m.label}</NativeSelectOption>
+										{/each}
+									</NativeSelect>
+									<NativeSelect
+										id={`rating-${i}`}
+										class="sm:w-48"
+										disabled={isCompleted}
+										value={entry.ratingId}
+										onchange={(e) => {
+											entry.ratingId = (e.currentTarget as HTMLSelectElement).value;
+										}}
+									>
+										<NativeSelectOption value="" disabled>Rating…</NativeSelectOption>
+										{#each possibleRatings as r}
+											<NativeSelectOption value={r.id}>{r.name}</NativeSelectOption>
+										{/each}
+									</NativeSelect>
+								</div>
+							</div>
+						{/each}
+						<div class="mt-2">
+							<Button type="submit" disabled={saving || isCompleted}>
+								{saving ? 'Saving...' : 'Save grades'}
+							</Button>
+						</div>
+					</form>
+				{/if}
+			</CardContent>
+		</Card>
+
+		<!-- Aggregate ranking -->
+		<Card>
+			<CardHeader>
+				<CardTitle class="text-base">Ranking</CardTitle>
+			</CardHeader>
+			<CardContent>
+				<p class="text-sm text-muted-foreground">
+					Aggregate of all grades, highest first, to help captains evaluate the field.
+				</p>
+				{#if ranking.length === 0}
+					<p class="mt-4 text-sm text-muted-foreground">No draftable players to rank yet.</p>
+				{:else}
+					<div class="mt-4 overflow-hidden rounded-lg border">
+						<Table>
+							<TableHeader>
+								<TableRow>
+									<TableHead>Rank</TableHead>
+									<TableHead>Player</TableHead>
+									<TableHead>Score</TableHead>
+								</TableRow>
+							</TableHeader>
+							<TableBody>
+								{#each ranking as row, i}
+									<TableRow>
+										<TableCell>{i + 1}</TableCell>
+										<TableCell>{userName(row.playerId)}</TableCell>
+										<TableCell>
+											{row.graded ? row.aggregate.toFixed(2) : '—'}
+										</TableCell>
+									</TableRow>
+								{/each}
+							</TableBody>
+						</Table>
+					</div>
+				{/if}
+			</CardContent>
+		</Card>
+	</div>
+{/if}


### PR DESCRIPTION
## Summary
Implements #126 — the pre-draft grading page at `/drafts/[id]/grades`.

- Assign a weak/average/strong modifier against a rating from the draft's format for each draftable player (`PreDraftGrade` CRUD, one grade per player/grader/draft via `UniquenessEquivalent`).
- Show the aggregate ranking (mirrors `GetSortedListOfAllPreDraftGradesDescending`) to help captains evaluate.
- Enforces the "draft not yet completed" rule from `PreDraftGrade.DynamicallyValid` (inputs/save disabled once completed).
- Links the page from the draft setup page header.

## Details
- The current grader is identified by decoding the JWT `sub` claim (`getCurrentUserId()` in `auth.ts`); the `/api/whoami` route requires a `User` body, so it can't be used as a plain GET.
- Aggregate ranking is computed client-side from all grades, replicating the backend `NumericRating` + average + descending sort.

## Verification
- `npm run check`: 0 errors / 0 warnings.
- `make e2e`: 18/18 passed over two consecutive full runs (new `draft-grades.spec.ts` included).