### PR TITLE
UI: live draft board (#127)

### DIFF
--- a/ui/e2e/draft-board.spec.ts
+++ b/ui/e2e/draft-board.spec.ts
@@ -1,0 +1,178 @@
+import { expect, test, type Page } from '@playwright/test';
+import { waitForHydration } from './helpers';
+
+// The Go backend runs with --dev-token from the repo root (see
+// playwright.config.ts), so POST /api/one_time_password returns the magic-link
+// token in the response body. Login with the user seeded by SeedDevData.
+async function login(page: Page) {
+	await page.goto('/login');
+	await page.waitForLoadState('networkidle');
+	await page.getByLabel('Email').fill('jdarthur@gatech.edu');
+	await page.getByRole('button', { name: 'Send login link' }).click();
+	const link = page.getByRole('main').getByRole('link', { name: 'Log in' });
+	await expect(link).toBeVisible();
+	await link.click();
+	await expect(page).toHaveURL('/');
+}
+
+// SeedDevData creates a format named "Men's Intraclub" with the possible
+// ratings "Men's 1", "Men's 2", "Men's 3" (ordered highest-skill first).
+const SEED_FORMAT = "Men's Intraclub";
+
+const API = 'http://127.0.0.1:8080/api';
+
+// tokenFor obtains a fresh JWT for an existing user via the dev-mode magic-link
+// flow, so the test can act as that captain when making selections.
+async function tokenFor(page: Page, email: string): Promise<string> {
+	const res = await page.request.post(`${API}/one_time_password`, { data: { email } });
+	expect(res.ok()).toBeTruthy();
+	const { token } = await res.json();
+	const jwtRes = await page.request.post(`${API}/token`, { data: { token } });
+	expect(jwtRes.ok()).toBeTruthy();
+	const { jwt } = await jwtRes.json();
+	return jwt;
+}
+
+test('live draft board gates picks to the on-clock captain and completes a draft', async ({
+	page
+}) => {
+	await login(page);
+	const token = await page.evaluate(() => localStorage.getItem('intraclub_jwt') ?? '');
+	expect(token).toBeTruthy();
+
+	const unique = Date.now();
+
+	// Two captains plus four roster players = 6 players across 2 teams (3 rounds).
+	const people = [
+		{ first: `Alex${unique}`, last: 'Captain' },
+		{ first: `Blake${unique}`, last: 'Captain' },
+		{ first: `Casey${unique}`, last: 'Roster' },
+		{ first: `Drew${unique}`, last: 'Roster' },
+		{ first: `Erin${unique}`, last: 'Roster' },
+		{ first: `Faye${unique}`, last: 'Roster' }
+	];
+	const csv = [
+		'First Name, Last Name, Email',
+		...people.map((p) => `${p.first}, ${p.last}, ${p.first.toLowerCase()}@example.com`)
+	].join('\n');
+	const importRes = await page.request.post(`${API}/import_users_from_csv`, {
+		form: { file: csv }
+	});
+	expect(importRes.ok()).toBeTruthy();
+	const importBody = await importRes.json();
+	const userIds = [...importBody.Created, ...importBody.AlreadyExisting].map(
+		(u: { id: string }) => u.id
+	);
+	expect(userIds).toHaveLength(people.length);
+	const [alexId, blakeId, caseyId, drewId, erinId, fayeId] = userIds;
+
+	const formatRes = await page.request.get(`${API}/format`);
+	const formats = (await formatRes.json()).resource as { id: string; name: string }[];
+	const format = formats.find((f) => f.name === SEED_FORMAT);
+	expect(format).toBeTruthy();
+
+	const draftName = `Board Draft ${unique}`;
+	const draftRes = await page.request.post(`${API}/draft`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { name: draftName, format: format!.id }
+	});
+	expect(draftRes.ok()).toBeTruthy();
+	const draftId = (await draftRes.json()).resource.id as string;
+
+	const alexName = `${people[0].first} ${people[0].last}`;
+	const blakeName = `${people[1].first} ${people[1].last}`;
+	const rosterOne = `${people[2].first} ${people[2].last}`;
+
+	// Set up the draft via the API: 2 captains, 4 roster players, rating cutoffs.
+	const initRes = await page.request.post(`${API}/draft/${draftId}/initialize`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { captains: [alexId, blakeId] }
+	});
+	expect(initRes.ok()).toBeTruthy();
+
+	const assignRes = await page.request.post(`${API}/draft/${draftId}/assign_draftable_players`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { players: [caseyId, drewId, erinId, fayeId] }
+	});
+	expect(assignRes.ok()).toBeTruthy();
+
+	const ratingsRes = await page.request.get(`${API}/format/${format!.id}/possible_ratings`, {
+		headers: { 'X-INTRACLUB-TOKEN': token }
+	});
+	expect(ratingsRes.ok()).toBeTruthy();
+	const ratings = (await ratingsRes.json()).resource as { id: string; name: string }[];
+	expect(ratings.length).toBeGreaterThanOrEqual(2);
+	// Pick 1 -> Men's 1; picks 2-5 -> Men's 2; pick 6 -> Men's 3.
+	await page.request.post(`${API}/draft/${draftId}/assign_rating_cutoff`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { rating: ratings[0].id, cutoff: 1 }
+	});
+	await page.request.post(`${API}/draft/${draftId}/assign_rating_cutoff`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { rating: ratings[1].id, cutoff: 5 }
+	});
+
+	// --- View the board as the commissioner (not a captain): locked out ---
+	await page.goto(`/drafts/${draftId}/draft`);
+	await expect(page.getByRole('heading', { name: draftName })).toBeVisible();
+	await waitForHydration(page);
+	await expect(page.getByText(`${alexName} is on the clock`)).toBeVisible();
+	// The commissioner cannot pick (the board is gated to the on-clock captain).
+	await expect(page.getByRole('button', { name: 'Select' }).first()).toBeDisabled();
+
+	// --- Captain 1 (Alex) is on the clock and can pick through the UI ---
+	const alexToken = await tokenFor(page, `${people[0].first.toLowerCase()}@example.com`);
+	await page.evaluate((t) => localStorage.setItem('intraclub_jwt', t), alexToken);
+	await page.goto(`/drafts/${draftId}/draft`);
+	await waitForHydration(page);
+	await expect(page.getByText("You're on the clock")).toBeVisible();
+
+	const rosterRow = page.locator('tr', { hasText: rosterOne });
+	await rosterRow.getByRole('button', { name: 'Select' }).click();
+	// The pick lands on the board and the clock advances to Blake.
+	await expect(page.getByText(`${blakeName} is on the clock`)).toBeVisible();
+	await expect(page.locator('table.draft-board').getByText(rosterOne)).toBeVisible();
+	// Casey is now taken, so their pick button is disabled.
+	await expect(rosterRow.getByRole('button', { name: 'Select' })).toBeDisabled();
+
+	// --- Complete the draft via the API, verifying illegal picks are rejected ---
+	const blakeToken = await tokenFor(page, `${people[1].first.toLowerCase()}@example.com`);
+
+	// Blake is on the clock for pick 2; Alex trying to pick again must fail.
+	const illegalRes = await page.request.post(`${API}/draft/${draftId}/select`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': alexToken },
+		data: { player_id: drewId }
+	});
+	expect(illegalRes.ok()).toBeFalsy();
+
+	// Snake order with 2 teams over 3 rounds: pick 1 Alex, then Blake, Blake,
+	// Alex, Alex, Blake. Casey was taken in pick 1 via the UI.
+	const pickOrder = [
+		{ captain: blakeToken, player: drewId },
+		{ captain: blakeToken, player: erinId },
+		{ captain: alexToken, player: fayeId },
+		{ captain: alexToken, player: alexId }, // Alex picks themselves
+		{ captain: blakeToken, player: blakeId } // Blake picks themselves
+	];
+	for (const { captain, player } of pickOrder) {
+		const res = await page.request.post(`${API}/draft/${draftId}/select`, {
+			headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': captain },
+			data: { player_id: player }
+		});
+		expect(res.ok(), `pick ${player} with expected captain failed: ${await res.text()}`).toBeTruthy();
+	}
+
+	// All 6 players have been drafted -> the board reflects completion.
+	await page.goto(`/drafts/${draftId}/draft`);
+	await waitForHydration(page);
+	await expect(page.getByText('Completed')).toBeVisible();
+	await expect(page.getByText(`All 6 players drafted.`)).toBeVisible();
+	// No selectable players remain.
+	await expect(page.getByRole('button', { name: 'Select' }).first()).toBeDisabled();
+
+	// Clean up the draft so the table doesn't accumulate rows across runs.
+	const cleanup = await page.request.delete(`${API}/draft/${draftId}`, {
+		headers: { 'X-INTRACLUB-TOKEN': token }
+	});
+	expect(cleanup.ok()).toBeTruthy();
+});

--- a/ui/src/routes/drafts/[id]/+page.svelte
+++ b/ui/src/routes/drafts/[id]/+page.svelte
@@ -277,6 +277,9 @@
 <div class="flex items-center gap-4">
 	<h1 class="text-2xl font-semibold tracking-tight">{draft?.name ?? 'Draft'}</h1>
 	<div class="ml-auto flex items-center gap-3">
+		<a href={`/drafts/${id()}/draft`} class="text-sm text-muted-foreground hover:text-foreground">
+			Live draft board →
+		</a>
 		<a href={`/drafts/${id()}/grades`} class="text-sm text-muted-foreground hover:text-foreground">
 			Pre-draft grades →
 		</a>

--- a/ui/src/routes/drafts/[id]/draft/+page.svelte
+++ b/ui/src/routes/drafts/[id]/draft/+page.svelte
@@ -1,0 +1,383 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { page } from '$app/state';
+	import { getDraft, selectPlayer } from '$lib/draft';
+	import type { Draft } from '$lib/draft';
+	import { listFormats, getFormatPossibleRatings } from '$lib/format';
+	import type { Format } from '$lib/format';
+	import type { Rating } from '$lib/rating';
+	import { listRatings } from '$lib/rating';
+	import { listUsers, fullName } from '$lib/user';
+	import type { User } from '$lib/user';
+	import { getCurrentUserId } from '$lib/auth';
+	import { listDraftCaptains } from '$lib/draftCaptain';
+	import type { DraftCaptain } from '$lib/draftCaptain';
+	import { listDraftAvailablePlayers } from '$lib/draftAvailablePlayer';
+	import type { DraftAvailablePlayer } from '$lib/draftAvailablePlayer';
+	import { listDraftPicks } from '$lib/draftPick';
+	import type { DraftPick } from '$lib/draftPick';
+	import { Badge } from '$lib/components/ui/badge/index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import {
+		Card,
+		CardContent,
+		CardHeader,
+		CardTitle
+	} from '$lib/components/ui/card/index.js';
+	import {
+		Table,
+		TableBody,
+		TableCell,
+		TableHead,
+		TableHeader,
+		TableRow
+	} from '$lib/components/ui/table/index.js';
+
+	const id = () => page.params.id as string;
+
+	// The zero Go time marshals to this literal; treat it as "not set".
+	const ZERO_TIME = '0001-01-01T00:00:00Z';
+
+	// The current user is the one acting; their id comes from the JWT's `sub`.
+	const currentUserId = getCurrentUserId();
+
+	let draft = $state<Draft | null>(null);
+	let format = $state<Format | null>(null);
+	let possibleRatings = $state<Rating[]>([]);
+	let ratingsById = $state<Record<string, Rating>>({});
+	let users = $state<User[]>([]);
+	let captains = $state<DraftCaptain[]>([]);
+	let availablePlayers = $state<DraftAvailablePlayer[]>([]);
+	let picks = $state<DraftPick[]>([]);
+
+	let loading = $state(true);
+	let loadError = $state('');
+	let actionError = $state('');
+	let picking = $state(false);
+
+	async function load() {
+		loading = true;
+		loadError = '';
+		actionError = '';
+		try {
+			const draftData = await getDraft(id());
+			const [formatList, userList, ratingList, captainList, availableList, pickList] =
+				await Promise.all([
+					listFormats(),
+					listUsers(),
+					listRatings(),
+					listDraftCaptains(),
+					listDraftAvailablePlayers(),
+					listDraftPicks()
+				]);
+
+			draft = draftData;
+			users = userList;
+			ratingsById = Object.fromEntries(ratingList.map((r) => [r.id, r]));
+
+			const fmt = formatList.find((f) => f.id === draftData.format) ?? null;
+			format = fmt;
+			possibleRatings = fmt ? await getFormatPossibleRatings(fmt.id) : [];
+
+			// Captains are presented in draft order (mirrors the backend's
+			// model.Draft.GetCaptains sort by DraftOrder).
+			captains = captainList
+				.filter((c) => c.draft_id === draftData.id)
+				.sort((a, b) => a.draft_order - b.draft_order);
+			availablePlayers = availableList.filter((a) => a.draft_id === draftData.id);
+			picks = pickList.filter((p) => p.draft_id === draftData.id);
+		} catch (e) {
+			loadError = e instanceof Error ? e.message : 'Failed to load draft board';
+		} finally {
+			loading = false;
+		}
+	}
+
+	onMount(load);
+
+	function userName(userId: string): string {
+		const u = users.find((x) => x.id === userId);
+		return u ? fullName(u) : userId;
+	}
+
+	const numTeams = $derived(captains.length);
+	const totalPlayers = $derived(availablePlayers.length);
+	const picksCount = $derived(picks.length);
+	// A draft is completed once every available player has been selected.
+	const isCompleted = $derived(
+		totalPlayers > 0 && picksCount >= totalPlayers
+	);
+
+	// The next selection index (number of picks already made) maps to a
+	// (round, pick) pair; see model.Draft.GetRoundAndPickFromPicks.
+	const rounds = $derived(numTeams > 0 ? Math.ceil(totalPlayers / numTeams) : 0);
+	const nextRound = $derived(numTeams > 0 ? Math.floor(picksCount / numTeams) + 1 : 1);
+	const nextPick = $derived(numTeams > 0 ? (picksCount % numTeams) + 1 : 1);
+
+	// --- Draft order pattern ---
+	// Mirrors model.DraftOrderPattern.GetCaptainOnTheClock for each pattern.
+	function lastPickDouble(round: number, pick: number, n: number): number {
+		if (round === 1) return pick - 1;
+		if (pick === 1) return lastPickDouble(round - 1, n, n);
+		return captainBefore(round, pick, n, n + 1);
+	}
+	function captainBefore(
+		currentRound: number,
+		currentPick: number,
+		n: number,
+		distance: number
+	): number {
+		let r = currentRound;
+		let p = currentPick;
+		for (let i = 0; i < distance; i++) {
+			p -= 1;
+			if (p === 0) {
+				r -= 1;
+				p = n;
+			}
+		}
+		return lastPickDouble(r, p, n);
+	}
+	function onClockCaptainIndex(): number {
+		if (numTeams === 0) return -1;
+		const n = numTeams;
+		const pattern = draft?.draft_order_pattern;
+		if (pattern === 'Last pick double') {
+			return lastPickDouble(nextRound, nextPick, n);
+		}
+		if (pattern === 'Straight-up') {
+			return nextPick - 1;
+		}
+		// Snake (default): even rounds draft in reverse order.
+		return nextRound % 2 === 0 ? n - nextPick : nextPick - 1;
+	}
+
+	const onClockIndex = $derived(onClockCaptainIndex());
+	const onClockCaptain = $derived(
+		onClockIndex >= 0 && onClockIndex < captains.length
+			? captains[onClockIndex].captain_id
+			: null
+	);
+	// A non-captain (e.g. the commissioner viewing) can watch but not pick.
+	const canPick = $derived(
+		!isCompleted &&
+			onClockCaptain !== null &&
+			currentUserId !== null &&
+			currentUserId === onClockCaptain
+	);
+
+	const selectedUserIds = $derived(new Set(picks.map((p) => p.user_id)));
+	const captainIds = $derived(new Set(captains.map((c) => c.captain_id)));
+
+	// A player is selectable if they haven't been taken and they are either the
+	// captain on the clock or not another captain at all (mirrors
+	// model.Draft.GetAllAvailableToSelect).
+	function isSelectable(playerId: string): boolean {
+		if (selectedUserIds.has(playerId)) return false;
+		if (captainIds.has(playerId) && playerId !== onClockCaptain) return false;
+		return true;
+	}
+
+	function pickStatus(playerId: string): string {
+		if (selectedUserIds.has(playerId)) return 'Selected';
+		if (captainIds.has(playerId)) return 'Captain';
+		return 'Available';
+	}
+
+	// --- Board grid (teams × rounds) ---
+	const board = $derived(
+		captains.map((captain, teamIndex) => {
+			const cells: (DraftPick | null)[] = [];
+			for (let r = 1; r <= rounds; r++) {
+				const pick = picks.find((p) => p.team_id === captain.team_id && p.round === r);
+				cells.push(pick ?? null);
+			}
+			return { teamIndex, captain, cells };
+		})
+	);
+
+	function ratingName(ratingId: string): string {
+		return ratingsById[ratingId]?.name ?? ratingId;
+	}
+
+	async function handlePick(playerId: string) {
+		actionError = '';
+		if (!canPick) return;
+		picking = true;
+		try {
+			await selectPlayer(id(), playerId);
+			await load();
+		} catch (e) {
+			actionError = e instanceof Error ? e.message : 'Failed to make the selection';
+		} finally {
+			picking = false;
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>{draft ? `${draft.name} — Live draft` : 'Live draft'}</title>
+</svelte:head>
+
+<div class="flex items-center gap-4">
+	<h1 class="text-2xl font-semibold tracking-tight">{draft?.name ?? 'Live draft'}</h1>
+	<div class="ml-auto flex items-center gap-3">
+		<a href={`/drafts/${id()}`} class="text-sm text-muted-foreground hover:text-foreground">
+			&larr; Draft setup
+		</a>
+	</div>
+</div>
+
+{#if loading}
+	<p class="mt-4 text-muted-foreground">Loading...</p>
+{:else if loadError}
+	<p class="mt-4 text-sm font-medium text-destructive">{loadError}</p>
+{:else if draft}
+	<!-- Status -->
+	<Card class="mt-6">
+		<CardHeader>
+			<CardTitle class="text-base">Draft status</CardTitle>
+		</CardHeader>
+		<CardContent>
+			<div class="flex flex-wrap items-center gap-4 text-sm">
+				<Badge variant={isCompleted ? 'secondary' : 'default'}>
+					{isCompleted ? 'Completed' : 'In progress'}
+				</Badge>
+				<Badge variant="outline">Pattern: {draft.draft_order_pattern || 'Snake'}</Badge>
+				{#if !isCompleted}
+					<span class="text-muted-foreground">
+						Round {nextRound} &middot; Pick {nextPick}
+					</span>
+					<span class="text-muted-foreground">
+						{onClockCaptain ? `${userName(onClockCaptain)} is on the clock` : 'Waiting for captains…'}
+					</span>
+				{:else}
+					<span class="text-muted-foreground">
+						All {totalPlayers} players drafted.
+					</span>
+				{/if}
+			</div>
+			{#if canPick}
+				<p class="mt-3 text-sm text-emerald-600">
+					You're on the clock — select a player below.
+				</p>
+			{:else if !isCompleted && onClockCaptain}
+				<p class="mt-3 text-sm text-muted-foreground">
+					Only {userName(onClockCaptain)} can pick right now.
+				</p>
+			{/if}
+		</CardContent>
+	</Card>
+
+	{#if actionError}
+		<p class="mt-4 text-sm font-medium text-destructive">{actionError}</p>
+	{/if}
+
+	<div class="mt-6 grid gap-6 lg:grid-cols-2">
+		<!-- Draft board grid -->
+		<Card>
+			<CardHeader>
+				<CardTitle class="text-base">Draft board</CardTitle>
+			</CardHeader>
+			<CardContent>
+				{#if numTeams === 0}
+					<p class="text-sm text-muted-foreground">
+						This draft hasn't been initialized yet — go to the setup page to add captains.
+					</p>
+				{:else if rounds === 0}
+					<p class="text-sm text-muted-foreground">
+						No draftable players yet.
+					</p>
+				{:else}
+					<div class="mt-2 overflow-x-auto rounded-lg border">
+						<table class="draft-board w-full text-sm">
+							<thead>
+								<tr class="border-b bg-muted/50 text-left">
+									<th class="px-3 py-2">Team</th>
+									{#each Array(rounds) as _, r}
+										<th class="px-3 py-2 text-center">Round {r + 1}</th>
+									{/each}
+								</tr>
+							</thead>
+							<tbody>
+								{#each board as row}
+									<tr class="border-b last:border-0">
+										<td class="whitespace-nowrap px-3 py-2">
+											<div class="font-medium">Team {row.teamIndex + 1}</div>
+											<div class="text-xs text-muted-foreground">
+												{userName(row.captain.captain_id)}
+											</div>
+										</td>
+										{#each row.cells as pick}
+											<td class="px-3 py-2 text-center align-top">
+												{#if pick}
+													<div class="text-xs">{userName(pick.user_id)}</div>
+													<div class="text-xs text-muted-foreground">
+														{ratingName(pick.rating)}
+													</div>
+												{:else}
+													<span class="text-muted-foreground">—</span>
+												{/if}
+											</td>
+										{/each}
+									</tr>
+								{/each}
+							</tbody>
+						</table>
+					</div>
+				{/if}
+			</CardContent>
+		</Card>
+
+		<!-- Pick area -->
+		<Card>
+			<CardHeader>
+				<CardTitle class="text-base">Make a pick</CardTitle>
+			</CardHeader>
+			<CardContent>
+				{#if availablePlayers.length === 0}
+					<p class="text-sm text-muted-foreground">No draftable players yet.</p>
+				{:else}
+					<div class="mt-2 overflow-hidden rounded-lg border">
+						<table class="w-full text-sm">
+							<thead>
+								<tr class="border-b bg-muted/50 text-left">
+									<th class="px-3 py-2">Player</th>
+									<th class="px-3 py-2">Status</th>
+									<th class="px-3 py-2"></th>
+								</tr>
+							</thead>
+							<tbody>
+								{#each availablePlayers as player}
+									{@const selectable = isSelectable(player.player_id)}
+									<tr class="border-b last:border-0">
+										<td class="px-3 py-2">{userName(player.player_id)}</td>
+										<td class="px-3 py-2 text-xs text-muted-foreground">
+											{pickStatus(player.player_id)}
+										</td>
+										<td class="px-3 py-2 text-right">
+											<Button
+												type="button"
+												size="sm"
+												variant="default"
+												disabled={!canPick || !selectable || picking}
+												onclick={() => handlePick(player.player_id)}
+											>
+												Select
+											</Button>
+										</td>
+									</tr>
+								{/each}
+							</tbody>
+						</table>
+					</div>
+					{#if !canPick && !isCompleted}
+						<p class="mt-3 text-xs text-muted-foreground">
+							Picks are locked until it's your turn.
+						</p>
+					{/if}
+				{/if}
+			</CardContent>
+		</Card>
+	</div>
+{/if}


### PR DESCRIPTION
Closes #127

Implements the interactive draft page `/drafts/[id]/draft`:
- Draft board grid (teams × rounds) showing selections made so far and each pick's assigned rating.
- Identifies the **captain on the clock** (mirrors `model.Draft.GetCaptainOnTheClock` across the snake / last-pick-double / straight-up patterns) and gates the pick action to that captain.
- Pick flow calls `SelectByCaptain` (`POST /api/draft/:id/select`); renders round/pick + assigned rating; disables already-selected players and other captains.
- Reflects the chosen draft order pattern.

Verification:
- `make e2e` green (19 tests, including a new draft-board spec that completes a full 6-pick simulated draft with no illegal picks).
- `make tests` (go test + vet) green.
- `npm run check` green.