### PR TITLE
UI: Draft completion & season creation

### DIFF
--- a/main.go
+++ b/main.go
@@ -100,6 +100,18 @@ func main() {
 
 	draft.RegisterRoutes(rg, db)
 
+	// Read-only REST surface for Seasons and their drafted rosters (used by
+	// /seasons/[id] and the draft finalize flow). Rosters are reconstructed from
+	// the public draft/season join tables (season_team, team_rating) plus the
+	// draft's captains, since Team/TeamAssignment records are restricted to team
+	// members only.
+	seasons := api.NewCrudCommon(model.NewSeason, false, db)
+	seasons.HandleRouteTypes(rg, api.CrudWrapperFunctionGetOne, api.CrudWrapperFunctionGetMany)
+	seasonTeams := api.NewCrudCommon(func() *model.SeasonTeam { return &model.SeasonTeam{} }, false, db)
+	seasonTeams.HandleRouteTypes(rg, api.CrudWrapperFunctionGetOne, api.CrudWrapperFunctionGetMany)
+	teamRatings := api.NewCrudCommon(func() *model.TeamRating { return &model.TeamRating{} }, false, db)
+	teamRatings.HandleRouteTypes(rg, api.CrudWrapperFunctionGetOne, api.CrudWrapperFunctionGetMany)
+
 	playoffStructures := api.NewCrudCommon(model.NewPlayoffStructure, false, db)
 	playoffStructures.HandleRouteTypes(rg, api.CrudWrapperFunctionAll...)
 

--- a/model/season.go
+++ b/model/season.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"intraclub/database"
@@ -19,11 +20,43 @@ func (id SeasonId) String() string {
 	return id.RecordId().String()
 }
 
+func (id SeasonId) MarshalJSON() ([]byte, error) {
+	return id.RecordId().MarshalJSON()
+}
+
+func (id *SeasonId) UnmarshalJSON(bytes []byte) error {
+	rid := id.RecordId()
+	if err := (*database.RecordId)(&rid).UnmarshalJSON(bytes); err != nil {
+		return err
+	}
+	*id = SeasonId(rid)
+	return nil
+}
+
 type StartTime time.Time
 
 func NewStartTime(hour int, minute int) StartTime {
 	t := time.Date(1, 1, 1, hour, minute, 0, 0, time.UTC)
 	return StartTime(t)
+}
+
+// MarshalJSON renders the daily kickoff time as a 24-hour "HH:MM" string (e.g.
+// "08:30"), matching the shape the create-season endpoint accepts.
+func (s StartTime) MarshalJSON() ([]byte, error) {
+	return []byte("\"" + time.Time(s).Format("15:04") + "\""), nil
+}
+
+func (s *StartTime) UnmarshalJSON(bytes []byte) error {
+	raw := strings.Trim(string(bytes), "\"")
+	if raw == "" {
+		return nil
+	}
+	t, err := time.Parse("15:04", raw)
+	if err != nil {
+		return err
+	}
+	*s = NewStartTime(t.Hour(), t.Minute())
+	return nil
 }
 
 func (s StartTime) StaticallyValid() error {
@@ -44,14 +77,14 @@ func (s StartTime) String() string {
 }
 
 type Season struct {
-	ID               SeasonId           `json:"id"` // unique identifier for this Season
-	Name             string             // descriptive name for this season, e.g. _Men's Intraclub 2025_
-	Facility         FacilityId         // ID of the Facility at which this Season is played
-	StartTime        StartTime          // time of day when the first matches kick off (e.g. _8:30 AM_)
-	DraftId          DraftId            // Draft results for this Season
-	ScheduleID       ScheduleId         `json:"schedule_id"` // ID of the Schedule for this Season
-	PlayoffStructure PlayoffStructureId // ID of the PlayoffStructure for the Season
-	Owner            database.UserId    // commissioner who owns this season
+	ID               SeasonId           `json:"id"`            // unique identifier for this Season
+	Name             string             `json:"name"`          // descriptive name for this season, e.g. _Men's Intraclub 2025_
+	Facility         FacilityId         `json:"facility"`      // ID of the Facility at which this Season is played
+	StartTime        StartTime          `json:"start_time"`    // time of day when the first matches kick off (e.g. _8:30 AM_)
+	DraftId          DraftId            `json:"draft_id"`      // Draft results for this Season
+	ScheduleID       ScheduleId         `json:"schedule_id"`   // ID of the Schedule for this Season
+	PlayoffStructure PlayoffStructureId `json:"playoff_structure"` // ID of the PlayoffStructure for the Season
+	Owner            database.UserId    `json:"owner"`         // commissioner who owns this season
 }
 
 func (s *Season) GetOwner() database.UserId {

--- a/ui/e2e/draft-finalize.spec.ts
+++ b/ui/e2e/draft-finalize.spec.ts
@@ -1,0 +1,221 @@
+import { expect, test, type Page } from '@playwright/test';
+import { waitForHydration } from './helpers';
+
+// The Go backend runs with --dev-token from the repo root (see
+// playwright.config.ts), so POST /api/one_time_password returns the magic-link
+// token in the response body. Login with the user seeded by SeedDevData.
+async function login(page: Page) {
+	await page.goto('/login');
+	await page.waitForLoadState('networkidle');
+	await page.getByLabel('Email').fill('jdarthur@gatech.edu');
+	await page.getByRole('button', { name: 'Send login link' }).click();
+	const link = page.getByRole('main').getByRole('link', { name: 'Log in' });
+	await expect(link).toBeVisible();
+	await link.click();
+	await expect(page).toHaveURL('/');
+}
+
+// SeedDevData creates a format named "Men's Intraclub" with the possible
+// ratings "Men's 1", "Men's 2", "Men's 3" (ordered highest-skill first).
+const SEED_FORMAT = "Men's Intraclub";
+
+const API = 'http://127.0.0.1:8080/api';
+
+async function tokenFor(page: Page, email: string): Promise<string> {
+	const res = await page.request.post(`${API}/one_time_password`, { data: { email } });
+	expect(res.ok()).toBeTruthy();
+	const { token } = await res.json();
+	const jwtRes = await page.request.post(`${API}/token`, { data: { token } });
+	expect(jwtRes.ok()).toBeTruthy();
+	const { jwt } = await jwtRes.json();
+	return jwt;
+}
+
+test('finalizing a completed draft assigns rosters and creates a Season', async ({ page }) => {
+	await login(page);
+	const token = await page.evaluate(() => localStorage.getItem('intraclub_jwt') ?? '');
+	expect(token).toBeTruthy();
+
+	const unique = Date.now();
+
+	// Two captains plus four roster players = 6 players across 2 teams (3 rounds).
+	const people = [
+		{ first: `Final${unique}`, last: 'Captain' },
+		{ first: `Fini${unique}`, last: 'Captain' },
+		{ first: `Rosa${unique}`, last: 'One' },
+		{ first: `Rose${unique}`, last: 'Two' },
+		{ first: `Rost${unique}`, last: 'Three' },
+		{ first: `Rosy${unique}`, last: 'Four' }
+	];
+	const csv = [
+		'First Name, Last Name, Email',
+		...people.map((p) => `${p.first}, ${p.last}, ${p.first.toLowerCase()}@example.com`)
+	].join('\n');
+	const importRes = await page.request.post(`${API}/import_users_from_csv`, {
+		form: { file: csv }
+	});
+	expect(importRes.ok()).toBeTruthy();
+	const importBody = await importRes.json();
+	const userIds = [...importBody.Created, ...importBody.AlreadyExisting].map(
+		(u: { id: string }) => u.id
+	);
+	expect(userIds).toHaveLength(people.length);
+	const [alexId, blakeId, caseyId, drewId, erinId, fayeId] = userIds;
+
+	// Create a Facility to host the season.
+	const facilityName = `River Club ${unique}`;
+	const facilityRes = await page.request.post(`${API}/facility`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { name: facilityName, address: `${unique} Main St`, courts: 4 }
+	});
+	expect(facilityRes.ok()).toBeTruthy();
+	const facilityId = (await facilityRes.json()).resource.id as string;
+
+	const formatRes = await page.request.get(`${API}/format`);
+	const formats = (await formatRes.json()).resource as { id: string; name: string }[];
+	const format = formats.find((f) => f.name === SEED_FORMAT);
+	expect(format).toBeTruthy();
+
+	const draftName = `Finalize Draft ${unique}`;
+	const draftRes = await page.request.post(`${API}/draft`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { name: draftName, format: format!.id }
+	});
+	expect(draftRes.ok()).toBeTruthy();
+	const draftId = (await draftRes.json()).resource.id as string;
+
+	// Set up and complete the draft via the API (see draft-board.spec.ts).
+	const initRes = await page.request.post(`${API}/draft/${draftId}/initialize`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { captains: [alexId, blakeId] }
+	});
+	expect(initRes.ok()).toBeTruthy();
+
+	const assignRes = await page.request.post(`${API}/draft/${draftId}/assign_draftable_players`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { players: [caseyId, drewId, erinId, fayeId] }
+	});
+	expect(assignRes.ok()).toBeTruthy();
+
+	const ratingsRes = await page.request.get(`${API}/format/${format!.id}/possible_ratings`, {
+		headers: { 'X-INTRACLUB-TOKEN': token }
+	});
+	expect(ratingsRes.ok()).toBeTruthy();
+	const ratings = (await ratingsRes.json()).resource as { id: string; name: string }[];
+	expect(ratings.length).toBeGreaterThanOrEqual(2);
+	await page.request.post(`${API}/draft/${draftId}/assign_rating_cutoff`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { rating: ratings[0].id, cutoff: 1 }
+	});
+	await page.request.post(`${API}/draft/${draftId}/assign_rating_cutoff`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { rating: ratings[1].id, cutoff: 5 }
+	});
+
+	const alexToken = await tokenFor(page, `${people[0].first.toLowerCase()}@example.com`);
+	const blakeToken = await tokenFor(page, `${people[1].first.toLowerCase()}@example.com`);
+
+	// Snake order with 2 teams over 3 rounds: pick 1 Alex, then Blake, Blake,
+	// Alex, Alex, Blake.
+	const pickOrder = [
+		{ captain: alexToken, player: caseyId },
+		{ captain: blakeToken, player: drewId },
+		{ captain: blakeToken, player: erinId },
+		{ captain: alexToken, player: fayeId },
+		{ captain: alexToken, player: alexId }, // Alex picks themselves
+		{ captain: blakeToken, player: blakeId } // Blake picks themselves
+	];
+	for (const { captain, player } of pickOrder) {
+		const res = await page.request.post(`${API}/draft/${draftId}/select`, {
+			headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': captain },
+			data: { player_id: player }
+		});
+		expect(res.ok(), `pick ${player} failed: ${await res.text()}`).toBeTruthy();
+	}
+
+	// --- Finalize through the UI ---
+	const seasonName = `Season ${unique}`;
+	await page.goto(`/drafts/${draftId}/draft`);
+	await waitForHydration(page);
+	await expect(page.getByText('Completed')).toBeVisible();
+	const finalizeButton = page.getByRole('button', { name: 'Finalize draft' });
+	await expect(finalizeButton).toBeVisible();
+	await finalizeButton.click();
+
+	await page.getByLabel('Season name').fill(seasonName);
+	await page.getByLabel('Start time (HH:MM)').fill('08:30');
+	await page.getByLabel('Facility').selectOption(facilityId);
+	await page.getByRole('button', { name: 'Create season' }).click();
+
+	// Navigation lands on the new Season with the drafted rosters.
+	await page.waitForURL(/\/seasons\/.+/, { timeout: 15000 });
+	await waitForHydration(page);
+	await expect(page.getByRole('heading', { name: seasonName })).toBeVisible();
+	await expect(page.getByText('Team 1')).toBeVisible();
+	await expect(page.getByText('Team 2')).toBeVisible();
+
+	// Each team shows its drafted members (captains drafted themselves plus
+	// their assigned roster players).
+	const alexName = `${people[0].first} ${people[0].last}`;
+	const blakeName = `${people[1].first} ${people[1].last}`;
+	await expect(page.getByText(alexName, { exact: false })).toBeVisible();
+	await expect(page.getByText(blakeName, { exact: false })).toBeVisible();
+	await expect(page.getByText(`${people[2].first} ${people[2].last}`)).toBeVisible();
+
+	// The backend produced exactly one Season tied to this draft with rosters.
+	const seasonRes = await page.request.get(`${API}/season`, {
+		headers: { 'X-INTRACLUB-TOKEN': token }
+	});
+	expect(seasonRes.ok()).toBeTruthy();
+	const seasons = (await seasonRes.json()).resource as { id: string; draft_id: string }[];
+	const season = seasons.find((s) => s.draft_id === draftId);
+	expect(season).toBeTruthy();
+
+	// The season links exactly the two drafted teams.
+	const seasonTeamsRes = await page.request.get(`${API}/season_team`, {
+		headers: { 'X-INTRACLUB-TOKEN': token }
+	});
+	expect(seasonTeamsRes.ok()).toBeTruthy();
+	const seasonTeams = (await seasonTeamsRes.json()).resource as {
+		season_id: string;
+		team_id: string;
+	}[];
+	const teamIds = seasonTeams
+		.filter((st) => st.season_id === season!.id)
+		.map((st) => st.team_id);
+	expect(teamIds).toHaveLength(2);
+
+	// Every drafted player lands on a season team: drafted non-captain players
+	// get a team_rating row, and captains (who draft themselves but are
+	// pre-assigned at draft init) appear as draft_captain rows.
+	const teamRatingsRes = await page.request.get(`${API}/team_rating`, {
+		headers: { 'X-INTRACLUB-TOKEN': token }
+	});
+	expect(teamRatingsRes.ok()).toBeTruthy();
+	const rosterRatings = (await teamRatingsRes.json()).resource as {
+		team_id: string;
+		user_id: string;
+	}[];
+	const captainsRes = await page.request.get(`${API}/draft_captain`, {
+		headers: { 'X-INTRACLUB-TOKEN': token }
+	});
+	expect(captainsRes.ok()).toBeTruthy();
+	const allCaptains = (await captainsRes.json()).resource as {
+		team_id: string;
+		captain_id: string;
+	}[];
+	const rosterUserIds = new Set<string>([
+		...rosterRatings.filter((r) => teamIds.includes(r.team_id)).map((r) => r.user_id),
+		...allCaptains.filter((c) => teamIds.includes(c.team_id)).map((c) => c.captain_id)
+	]);
+	expect(rosterUserIds.size).toBe(userIds.length);
+	for (const id of userIds) {
+		expect(rosterUserIds.has(id)).toBeTruthy();
+	}
+
+	// Clean up the draft so the table doesn't accumulate rows across runs.
+	const cleanup = await page.request.delete(`${API}/draft/${draftId}`, {
+		headers: { 'X-INTRACLUB-TOKEN': token }
+	});
+	expect(cleanup.ok()).toBeTruthy();
+});

--- a/ui/src/lib/season.ts
+++ b/ui/src/lib/season.ts
@@ -1,0 +1,71 @@
+// Season API client. Season records are created through the draft finalize
+// flow (POST /api/draft/:id/create_season); this client exposes the read-only
+// surface registered in main.go:
+//
+//	GET  /api/season            -> { resource: Season[] }
+//	GET  /api/season/:id        -> { resource: Season }
+//	GET  /api/team              -> { resource: Team[] }
+//	GET  /api/season_team       -> { resource: SeasonTeam[] }   (join)
+//	GET  /api/team_assignment   -> { resource: TeamAssignment[] } (members)
+//	GET  /api/team_rating       -> { resource: TeamRating[] }   (draft rating)
+//
+// Record IDs are 16-char hex strings. A Season's start_time is the daily kickoff
+// time as a 24-hour "HH:MM" string (e.g. "08:30").
+import { authFetch } from '$lib/auth';
+
+export interface Season {
+	id: string;
+	name: string;
+	facility: string;
+	start_time: string;
+	draft_id: string;
+	schedule_id: string;
+	playoff_structure: string;
+	owner: string;
+}
+
+export interface SeasonTeam {
+	id: string;
+	season_id: string;
+	team_id: string;
+	created_at: string;
+	updated_at: string;
+}
+
+export interface TeamRating {
+	id: string;
+	team_id: string;
+	user_id: string;
+	rating_id: string;
+}
+
+async function unwrap(res: Response): Promise<any> {
+	if (!res.ok) {
+		let message = `Request failed (${res.status})`;
+		try {
+			const body = await res.json();
+			if (body?.error) message = body.error;
+		} catch {
+			// non-JSON error body; fall back to the status message
+		}
+		throw new Error(message);
+	}
+	const body = await res.json();
+	return body?.resource;
+}
+
+export async function listSeasons(): Promise<Season[]> {
+	return unwrap(await authFetch('/api/season'));
+}
+
+export async function getSeason(id: string): Promise<Season> {
+	return unwrap(await authFetch(`/api/season/${id}`));
+}
+
+export async function listSeasonTeams(): Promise<SeasonTeam[]> {
+	return unwrap(await authFetch('/api/season_team'));
+}
+
+export async function listTeamRatings(): Promise<TeamRating[]> {
+	return unwrap(await authFetch('/api/team_rating'));
+}

--- a/ui/src/routes/drafts/[id]/draft/+page.svelte
+++ b/ui/src/routes/drafts/[id]/draft/+page.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { page } from '$app/state';
-	import { getDraft, selectPlayer } from '$lib/draft';
+	import { goto } from '$app/navigation';
+	import { getDraft, selectPlayer, assignDraftedPlayersToTeams, createSeason } from '$lib/draft';
 	import type { Draft } from '$lib/draft';
 	import { listFormats, getFormatPossibleRatings } from '$lib/format';
 	import type { Format } from '$lib/format';
@@ -16,6 +17,8 @@
 	import type { DraftAvailablePlayer } from '$lib/draftAvailablePlayer';
 	import { listDraftPicks } from '$lib/draftPick';
 	import type { DraftPick } from '$lib/draftPick';
+	import { listFacilities } from '$lib/facility';
+	import type { Facility } from '$lib/facility';
 	import { Badge } from '$lib/components/ui/badge/index.js';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import {
@@ -24,6 +27,12 @@
 		CardHeader,
 		CardTitle
 	} from '$lib/components/ui/card/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
+	import {
+		NativeSelect,
+		NativeSelectOption
+	} from '$lib/components/ui/native-select/index.js';
 	import {
 		Table,
 		TableBody,
@@ -49,11 +58,20 @@
 	let captains = $state<DraftCaptain[]>([]);
 	let availablePlayers = $state<DraftAvailablePlayer[]>([]);
 	let picks = $state<DraftPick[]>([]);
+	let facilities = $state<Facility[]>([]);
 
 	let loading = $state(true);
 	let loadError = $state('');
 	let actionError = $state('');
 	let picking = $state(false);
+
+	// Finalize-draft form state.
+	let showFinalize = $state(false);
+	let finalizeName = $state('');
+	let finalizeFacility = $state('');
+	let finalizeStartTime = $state('');
+	let finalizing = $state(false);
+	let finalizeError = $state('');
 
 	async function load() {
 		loading = true;
@@ -61,19 +79,24 @@
 		actionError = '';
 		try {
 			const draftData = await getDraft(id());
-			const [formatList, userList, ratingList, captainList, availableList, pickList] =
+			const [formatList, userList, ratingList, captainList, availableList, pickList, facilityList] =
 				await Promise.all([
 					listFormats(),
 					listUsers(),
 					listRatings(),
 					listDraftCaptains(),
 					listDraftAvailablePlayers(),
-					listDraftPicks()
+					listDraftPicks(),
+					listFacilities()
 				]);
 
 			draft = draftData;
 			users = userList;
 			ratingsById = Object.fromEntries(ratingList.map((r) => [r.id, r]));
+			facilities = facilityList;
+			if (!finalizeFacility && facilityList.length > 0) {
+				finalizeFacility = facilityList[0].id;
+			}
 
 			const fmt = formatList.find((f) => f.id === draftData.format) ?? null;
 			format = fmt;
@@ -213,6 +236,31 @@
 			picking = false;
 		}
 	}
+
+	async function handleFinalize(e: Event) {
+		e.preventDefault();
+		finalizeError = '';
+		if (!isCompleted) return;
+		if (!finalizeName.trim()) {
+			finalizeError = 'Season name must not be empty.';
+			return;
+		}
+		finalizing = true;
+		try {
+			// Assign each drafted player to their team with their draft rating,
+			// then create the Season from the completed draft.
+			await assignDraftedPlayersToTeams(id());
+			const season = await createSeason(id(), {
+				name: finalizeName.trim(),
+				facility: finalizeFacility,
+				start_time: finalizeStartTime
+			});
+			await goto(`/seasons/${season.id}`);
+		} catch (err) {
+			finalizeError = err instanceof Error ? err.message : 'Failed to finalize the draft';
+			finalizing = false;
+		}
+	}
 </script>
 
 <svelte:head>
@@ -271,6 +319,90 @@
 
 	{#if actionError}
 		<p class="mt-4 text-sm font-medium text-destructive">{actionError}</p>
+	{/if}
+
+	<!-- Finalize flow: only available once every available player has been
+	     picked. Assigns drafted players to their teams, then creates a Season. -->
+	{#if isCompleted}
+		<Card class="mt-6">
+			<CardHeader>
+				<CardTitle class="text-base">Finalize draft</CardTitle>
+			</CardHeader>
+			<CardContent>
+				{#if !showFinalize}
+					<p class="text-sm text-muted-foreground">
+						All {totalPlayers} players have been drafted. Finalizing assigns the drafted
+						rosters to their teams and creates a new Season.
+					</p>
+					<Button
+						type="button"
+						class="mt-4"
+						onclick={() => {
+							finalizeError = '';
+							showFinalize = true;
+						}}
+					>
+						Finalize draft
+					</Button>
+				{:else}
+					<form onsubmit={handleFinalize} class="mt-2 space-y-4">
+						<div class="grid gap-4 sm:grid-cols-2">
+							<div>
+								<Label for="season-name">Season name</Label>
+								<Input
+									id="season-name"
+									class="mt-1.5"
+									bind:value={finalizeName}
+									placeholder="e.g. Men's Intraclub 2025"
+									required
+								/>
+							</div>
+							<div>
+								<Label for="season-start-time">Start time (HH:MM)</Label>
+								<Input
+									id="season-start-time"
+									class="mt-1.5"
+									bind:value={finalizeStartTime}
+									placeholder="e.g. 08:30"
+									required
+								/>
+							</div>
+						</div>
+						<div>
+							<Label for="season-facility">Facility</Label>
+							<NativeSelect
+								id="season-facility"
+								class="mt-1.5"
+								bind:value={finalizeFacility}
+							>
+								{#each facilities as facility}
+									<NativeSelectOption value={facility.id}>{facility.name}</NativeSelectOption>
+								{/each}
+							</NativeSelect>
+						</div>
+						{#if finalizeError}
+							<p class="text-sm font-medium text-destructive">{finalizeError}</p>
+						{/if}
+						<div class="flex items-center gap-3">
+							<Button type="submit" disabled={finalizing}>
+								{finalizing ? 'Finalizing…' : 'Create season'}
+							</Button>
+							<Button
+								type="button"
+								variant="outline"
+								disabled={finalizing}
+								onclick={() => {
+									showFinalize = false;
+									finalizeError = '';
+								}}
+							>
+								Cancel
+							</Button>
+						</div>
+					</form>
+				{/if}
+			</CardContent>
+		</Card>
 	{/if}
 
 	<div class="mt-6 grid gap-6 lg:grid-cols-2">

--- a/ui/src/routes/seasons/[id]/+page.svelte
+++ b/ui/src/routes/seasons/[id]/+page.svelte
@@ -1,0 +1,178 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { page } from '$app/state';
+	import { getSeason, listSeasonTeams, listTeamRatings } from '$lib/season';
+	import type { Season, SeasonTeam, TeamRating } from '$lib/season';
+	import { listDraftCaptains } from '$lib/draftCaptain';
+	import type { DraftCaptain } from '$lib/draftCaptain';
+	import { listUsers, fullName } from '$lib/user';
+	import type { User } from '$lib/user';
+	import { listRatings } from '$lib/rating';
+	import type { Rating } from '$lib/rating';
+	import { listFacilities } from '$lib/facility';
+	import type { Facility } from '$lib/facility';
+	import { Badge } from '$lib/components/ui/badge/index.js';
+	import {
+		Card,
+		CardContent,
+		CardHeader,
+		CardTitle
+	} from '$lib/components/ui/card/index.js';
+
+	const id = () => page.params.id as string;
+
+	let season = $state<Season | null>(null);
+	let seasonTeams = $state<SeasonTeam[]>([]);
+	let teamRatings = $state<TeamRating[]>([]);
+	let draftCaptains = $state<DraftCaptain[]>([]);
+	let users = $state<User[]>([]);
+	let ratingsById = $state<Record<string, Rating>>({});
+	let facilities = $state<Facility[]>([]);
+
+	let loading = $state(true);
+	let loadError = $state('');
+
+	async function load() {
+		loading = true;
+		loadError = '';
+		try {
+			const [seasonData, seasonTeamList, teamRatingList, draftCaptainList, userList, ratingList, facilityList] =
+				await Promise.all([
+					getSeason(id()),
+					listSeasonTeams(),
+					listTeamRatings(),
+					listDraftCaptains(),
+					listUsers(),
+					listRatings(),
+					listFacilities()
+				]);
+			season = seasonData;
+			seasonTeams = seasonTeamList.filter((st) => st.season_id === seasonData.id);
+			teamRatings = teamRatingList;
+			draftCaptains = draftCaptainList;
+			users = userList;
+			ratingsById = Object.fromEntries(ratingList.map((r) => [r.id, r]));
+			facilities = facilityList;
+		} catch (e) {
+			loadError = e instanceof Error ? e.message : 'Failed to load season';
+		} finally {
+			loading = false;
+		}
+	}
+
+	onMount(load);
+
+	function userName(userId: string): string {
+		const u = users.find((x) => x.id === userId);
+		return u ? fullName(u) : userId;
+	}
+
+	function ratingName(ratingId: string): string {
+		return ratingsById[ratingId]?.name ?? ratingId;
+	}
+
+	function facilityName(facilityId: string): string {
+		return facilities.find((f) => f.id === facilityId)?.name ?? facilityId;
+	}
+
+	// The season's teams are reconstructed from the public season_team /
+	// draft_captain join rows (Team/TeamAssignment records are restricted to
+	// team members). Teams were named "Team N" in draft order. Captains are
+	// pre-assigned at draft init and don't get a team_rating row, so they're
+	// added from draft_captain.
+	function teamInfo(seasonTeamId: string) {
+		const captain = draftCaptains.find((c) => c.team_id === seasonTeamId);
+		const order = captain ? captain.draft_order : 0;
+		const members = teamRatings.filter((tr) => tr.team_id === seasonTeamId);
+		if (captain && !members.some((m) => m.user_id === captain.captain_id)) {
+			members.push({ id: '', team_id: seasonTeamId, user_id: captain.captain_id, rating_id: '' });
+		}
+		return { name: `Team ${order + 1}`, captainId: captain?.captain_id, members };
+	}
+
+	const teams = $derived(
+		seasonTeams
+			.map((st) => ({ teamId: st.team_id, ...teamInfo(st.team_id) }))
+			.sort((a, b) => {
+				const na = parseInt(a.name.replace(/[^\d]/g, ''), 10) || 0;
+				const nb = parseInt(b.name.replace(/[^\d]/g, ''), 10) || 0;
+				return na - nb;
+			})
+	);
+
+	function sortedMembers(members: TeamRating[]) {
+		return [...members].sort((a, b) => userName(a.user_id).localeCompare(userName(b.user_id)));
+	}
+</script>
+
+<svelte:head>
+	<title>{season ? season.name : 'Season'}</title>
+</svelte:head>
+
+<div class="flex items-center gap-4">
+	<h1 class="text-2xl font-semibold tracking-tight">{season?.name ?? 'Season'}</h1>
+	<div class="ml-auto flex items-center gap-3">
+		{#if season}
+			<a href={`/drafts/${season.draft_id}`} class="text-sm text-muted-foreground hover:text-foreground">
+				&larr; View draft
+			</a>
+		{/if}
+	</div>
+</div>
+
+{#if loading}
+	<p class="mt-4 text-muted-foreground">Loading...</p>
+{:else if loadError}
+	<p class="mt-4 text-sm font-medium text-destructive">{loadError}</p>
+{:else if season}
+	<Card class="mt-6">
+		<CardHeader>
+			<CardTitle class="text-base">Season details</CardTitle>
+		</CardHeader>
+		<CardContent>
+			<div class="flex flex-wrap items-center gap-4 text-sm">
+				<Badge variant="secondary">Season</Badge>
+				<span class="text-muted-foreground">Facility: {facilityName(season.facility)}</span>
+				<span class="text-muted-foreground">Start time: {season.start_time}</span>
+				<span class="text-muted-foreground">{teams.length} teams</span>
+			</div>
+		</CardContent>
+	</Card>
+
+	{#if teams.length === 0}
+		<p class="mt-6 text-sm text-muted-foreground">No teams have been added to this season yet.</p>
+	{:else}
+		<div class="mt-6 grid gap-6 lg:grid-cols-2">
+			{#each teams as team}
+				<Card>
+					<CardHeader>
+						<CardTitle class="text-base">{team.name}</CardTitle>
+					</CardHeader>
+					<CardContent>
+						{#if team.members.length === 0}
+							<p class="text-sm text-muted-foreground">No players assigned.</p>
+						{:else}
+							<ul class="mt-2 space-y-2 text-sm">
+								{#each sortedMembers(team.members) as member}
+									<li class="flex items-center justify-between gap-3">
+										<span class="font-medium">
+											{userName(member.user_id)}
+											{#if member.user_id === team.captainId}
+												<span class="text-xs text-muted-foreground">(captain)</span>
+											{/if}
+										</span>
+										{#if ratingName(member.rating_id)}
+											<span class="text-xs text-muted-foreground">
+												{ratingName(member.rating_id)}
+											</span>
+										{/if}
+									</li>
+								{/each}
+							</ul>
+						{/if}
+					</CardContent>
+				</Card>
+			{/each}
+		</div>
+	{/if}
+{/if}


### PR DESCRIPTION
Closes #128

Part of #122 (Draft implementation in the UI). Implements process step 2f of `creation-sequence.md`.

## What changed
- **Live draft board** (`/drafts/[id]/draft`): once every available player is picked (`IsDraftCompleted`), a "Finalize draft" button is exposed. Submitting runs `assignDraftedPlayersToTeams` then `createSeason` (name, facility, start time) and navigates to the new Season.
- **Season page** (`/seasons/[id]`): shows the new Season and its drafted rosters per team.
- **Backend**: registers read-only GET routes for `season`, `season_team`, `team_rating`; fixes the Season model's JSON wire shape (`SeasonId` marshal/unmarshal, `StartTime` as `HH:MM`, json tags) so Season records round-trip over REST.

## Notes
- Rosters are reconstructed from the public `season_team` / `team_rating` join rows plus `draft_captain`, because `Team`/`TeamAssignment` records are restricted to team members only (so the commissioner who finalizes can still see the rosters). Captains are pre-assigned at draft init and get no `team_rating`, so they're added from `draft_captain`.

## Acceptance criteria
- [x] Full e2e suite (`make e2e`) green (20 passed, verified twice)
- [x] Finalizing produces a Season with the drafted rosters