### PR TITLE
UI: add user CSV import page

### DIFF
--- a/ui/e2e/user-import.spec.ts
+++ b/ui/e2e/user-import.spec.ts
@@ -1,0 +1,52 @@
+import { expect, test, type Page } from '@playwright/test';
+import { waitForHydration } from './helpers';
+
+// The Go backend runs with --dev-token from the repo root (see
+// playwright.config.ts), so POST /api/one_time_password returns the magic-link
+// token in the response body. Login with the user seeded by SeedDevData.
+async function login(page: Page) {
+	await page.goto('/login');
+	await page.waitForLoadState('networkidle');
+	await page.getByLabel('Email').fill('jdarthur@gatech.edu');
+	await page.getByRole('button', { name: 'Send login link' }).click();
+	const link = page.getByRole('main').getByRole('link', { name: 'Log in' });
+	await expect(link).toBeVisible();
+	await link.click();
+	await expect(page).toHaveURL('/');
+}
+
+test('user CSV import: creates users and reports already-existing ones', async ({ page }) => {
+	await login(page);
+
+	const unique = Date.now();
+	const csv = [
+		'First Name, Last Name, Email',
+		`Alice, Import${unique}, alice${unique}@example.com`,
+		`Bob, Import${unique}, bob${unique}@example.com`
+	].join('\n');
+
+	// First import: both users are new.
+	await page.goto('/users/import');
+	await waitForHydration(page);
+	await page.getByLabel('CSV contents').fill(csv);
+	await page.getByRole('button', { name: 'Import users' }).click();
+	await expect(page.getByText(`Created (2)`)).toBeVisible();
+	await expect(page.getByText(`Alice Import${unique}`)).toBeVisible();
+	await expect(page.getByText(`Bob Import${unique}`)).toBeVisible();
+
+	// Re-import the same CSV: both emails already exist.
+	await page.goto('/users/import');
+	await waitForHydration(page);
+	await page.getByLabel('CSV contents').fill(csv);
+	await page.getByRole('button', { name: 'Import users' }).click();
+	await expect(page.getByText(`Created (0)`)).toBeVisible();
+	await expect(page.getByText(`Already existing (2)`)).toBeVisible();
+	await expect(page.getByText(`Alice Import${unique}`)).toBeVisible();
+
+	// Invalid CSV (missing required header) surfaces the backend error.
+	await page.goto('/users/import');
+	await waitForHydration(page);
+	await page.getByLabel('CSV contents').fill('First Name\nOnlyFirstName');
+	await page.getByRole('button', { name: 'Import users' }).click();
+	await expect(page.getByText(/expected 3 headers|not in the expected headers/i)).toBeVisible();
+});

--- a/ui/src/lib/components/NavBar.svelte
+++ b/ui/src/lib/components/NavBar.svelte
@@ -24,6 +24,7 @@
 			<a href="/playoff-structures" class="rounded-md px-2 py-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground">Playoff Structures</a>
 			<a href="/drafts" class="rounded-md px-2 py-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground">Drafts</a>
 			<a href="/photos" class="rounded-md px-2 py-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground">Photos</a>
+			<a href="/users/import" class="rounded-md px-2 py-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground">Users</a>
 		</nav>
 		<div class="ml-auto flex items-center">
 			{#if loggedIn}

--- a/ui/src/lib/user.ts
+++ b/ui/src/lib/user.ts
@@ -44,6 +44,40 @@ export async function getUser(id: string): Promise<User> {
 	return unwrap(await authFetch(`${BASE}/${id}`));
 }
 
+/**
+ * Result of POST /api/import_users_from_csv. Field names are capitalized
+ * because the backend's `route.CsvImportResult` struct has no JSON tags.
+ */
+export interface CsvImportResult {
+	CreatedCount: number;
+	Created: User[];
+	AlreadyExisting: User[];
+}
+
+/**
+ * Import users from CSV text. The backend expects the CSV as a urlencoded form
+ * field named `file` (headers: `First Name`, `Last Name`, `Email`). Users whose
+ * email already exists are skipped and returned in `AlreadyExisting`.
+ */
+export async function importUsersFromCsv(csv: string): Promise<CsvImportResult> {
+	const res = await authFetch('/api/import_users_from_csv', {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+		body: new URLSearchParams({ file: csv })
+	});
+	if (!res.ok) {
+		let message = `Request failed (${res.status})`;
+		try {
+			const body = await res.json();
+			if (body?.error) message = body.error;
+		} catch {
+			// non-JSON error body; fall back to the status message
+		}
+		throw new Error(message);
+	}
+	return (await res.json()) as CsvImportResult;
+}
+
 export function fullName(user: Pick<User, 'first_name' | 'last_name'>): string {
 	return `${user.first_name} ${user.last_name}`.trim();
 }

--- a/ui/src/routes/users/import/+page.svelte
+++ b/ui/src/routes/users/import/+page.svelte
@@ -1,0 +1,101 @@
+<script lang="ts">
+	import { importUsersFromCsv, type User } from '$lib/user';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card/index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
+	import { Textarea } from '$lib/components/ui/textarea/index.js';
+
+	let csv = $state('');
+	let error = $state('');
+	let submitting = $state(false);
+	let result = $state<{ created: User[]; existing: User[] } | null>(null);
+
+	async function handleSubmit(e: Event) {
+		e.preventDefault();
+		error = '';
+		result = null;
+		submitting = true;
+		try {
+			const res = await importUsersFromCsv(csv);
+			result = { created: res.Created, existing: res.AlreadyExisting };
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Failed to import users';
+		} finally {
+			submitting = false;
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>Import users</title>
+</svelte:head>
+
+<div class="flex items-center gap-4">
+	<h1 class="text-2xl font-semibold tracking-tight">Import users</h1>
+</div>
+
+<Card class="mt-6 max-w-xl">
+	<CardHeader>
+		<CardTitle class="text-base">CSV import</CardTitle>
+	</CardHeader>
+	<CardContent>
+		<form onsubmit={handleSubmit} class="flex flex-col gap-4">
+			<div class="flex flex-col gap-2">
+				<Label for="csv">CSV contents</Label>
+				<Textarea
+					id="csv"
+					bind:value={csv}
+					rows={10}
+					placeholder={'First Name, Last Name, Email\nAda, Lovelace, ada@example.com\nGrace, Hopper, grace@example.com'}
+					required
+				/>
+				<p class="text-sm text-muted-foreground">
+					Headers must be <code>First Name, Last Name, Email</code> (any order). Users whose
+					email already exists are skipped.
+				</p>
+			</div>
+			<Button type="submit" disabled={submitting} class="w-fit">
+				{submitting ? 'Importing...' : 'Import users'}
+			</Button>
+		</form>
+	</CardContent>
+</Card>
+
+{#if error}
+	<p class="mt-4 text-sm font-medium text-destructive">{error}</p>
+{/if}
+
+{#if result}
+	<div class="mt-6 space-y-6">
+		<div>
+			<h2 class="text-lg font-semibold tracking-tight">Created ({result.created.length})</h2>
+			{#if result.created.length === 0}
+				<p class="text-sm text-muted-foreground">No new users were created.</p>
+			{:else}
+				<ul class="mt-2 space-y-1 text-sm">
+					{#each result.created as user}
+						<li>
+							{user.first_name} {user.last_name}
+							<span class="text-muted-foreground">&lt;{user.email}&gt;</span>
+						</li>
+					{/each}
+				</ul>
+			{/if}
+		</div>
+		<div>
+			<h2 class="text-lg font-semibold tracking-tight">Already existing ({result.existing.length})</h2>
+			{#if result.existing.length === 0}
+				<p class="text-sm text-muted-foreground">No existing users matched.</p>
+			{:else}
+				<ul class="mt-2 space-y-1 text-sm">
+					{#each result.existing as user}
+						<li>
+							{user.first_name} {user.last_name}
+							<span class="text-muted-foreground">&lt;{user.email}&gt;</span>
+						</li>
+					{/each}
+				</ul>
+			{/if}
+		</div>
+	</div>
+{/if}


### PR DESCRIPTION
Implements ticket #135.

## Changes
- **`ui/src/routes/users/import/+page.svelte`**: new page with a textarea for
  CSV contents (`First Name, Last Name, Email`), a submit button, and result
  rendering that shows created vs. already-existing users plus backend error
  messages.
- **`ui/src/lib/user.ts`**: `importUsersFromCsv(csv)` client helper that POSTs
  the CSV as a urlencoded `file` form field to `/api/import_users_from_csv`
  via `authFetch` and parses the capitalized response fields.
- **`ui/src/lib/components/NavBar.svelte`**: "Users" nav link to `/users/import`.
- **`ui/e2e/user-import.spec.ts`**: smoke test covering create, re-import
  (already-existing), and invalid-CSV error display.

## Verification
- `npm run check` (svelte-check + typecheck): 0 errors, 0 warnings.
- `make e2e`: full parallel Playwright suite green (21/21) on two consecutive
  clean-DB runs.