### PR TITLE
UI: draft results / rosters view (#129)

### DIFF
--- a/model/draft.go
+++ b/model/draft.go
@@ -56,10 +56,10 @@ func (t TeamCaptainAssignment) DynamicallyValid(ctx context.Context, db database
 // RatingId that the user will consequently have based on the rating
 // cutoff values assigned for the Draft
 type DraftSelection struct {
-	Round  int
-	Pick   int
-	User   *User
-	Rating RatingId
+	Round  int      `json:"round"`
+	Pick   int      `json:"pick"`
+	User   *User    `json:"user"`
+	Rating RatingId `json:"rating"`
 }
 
 type DraftId database.RecordId

--- a/route/draft/draft.go
+++ b/route/draft/draft.go
@@ -226,6 +226,64 @@ func (c SelectByCaptain) Handler(req api.Request[*SelectBody]) (any, int, error)
 	return gin.H{api.ResourceKey: draft}, http.StatusOK, nil
 }
 
+// DraftTeamResults groups one team's DraftSelection rows together with the
+// team's captain and draft order. It is one entry in the GetDraftResults
+// response.
+type DraftTeamResults struct {
+	TeamId     model.TeamId           `json:"team_id"`
+	CaptainId  database.UserId        `json:"captain_id"`
+	DraftOrder int                    `json:"draft_order"`
+	Selections []model.DraftSelection `json:"selections"`
+}
+
+// DraftResults is the response body for GetDraftResults: the draft's teams (in
+// draft order) with each team's rosters and per-player assigned ratings.
+type DraftResults struct {
+	Teams []DraftTeamResults `json:"teams"`
+}
+
+// GetDraftResults returns a read-only summary of a draft's final teams and
+// rosters, including each player's assigned rating. It is readable by anyone
+// who can view the draft (Draft is AccessibleToEveryone), mirroring the
+// model.Draft.GetDraftSelections / GetDraftSelectionsByCaptainId helpers.
+type GetDraftResults struct{}
+
+func (c GetDraftResults) Path() (api.HttpMethod, string) {
+	return api.HttpMethodGet, api.AppendPathId(BaseRoute) + "/results"
+}
+
+func (c GetDraftResults) RequestBody() (*EmptyBody, bool) {
+	return &EmptyBody{}, false
+}
+
+func (c GetDraftResults) Handler(req api.Request[*EmptyBody]) (any, int, error) {
+	draft, err := database.GetExistingRecordById(req.Context, req.DatabaseProvider, &model.Draft{}, req.PathId)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+
+	captains, err := draft.GetCaptains(req.Context, req.DatabaseProvider)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+
+	teams := make([]DraftTeamResults, 0, len(captains))
+	for _, captain := range captains {
+		selections, err := draft.GetDraftSelections(req.DatabaseProvider, captain.TeamId)
+		if err != nil {
+			return nil, http.StatusBadRequest, err
+		}
+		teams = append(teams, DraftTeamResults{
+			TeamId:     captain.TeamId,
+			CaptainId:  captain.CaptainId,
+			DraftOrder: captain.DraftOrder,
+			Selections: selections,
+		})
+	}
+
+	return gin.H{api.ResourceKey: DraftResults{Teams: teams}}, http.StatusOK, nil
+}
+
 // AssignDraftedPlayersToTeams finalizes a completed draft by assigning each
 // drafted player to their team with their draft rating (see
 // model.Draft.AssignDraftedPlayersToTeams).

--- a/route/draft/draft_test.go
+++ b/route/draft/draft_test.go
@@ -408,6 +408,92 @@ func TestDraftFullFlow(t *testing.T) {
 	}
 }
 
+func TestDraftResultsEndpoint(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	commissioner := newStoredUser(t, db)
+	format := newDefaultFormat(t, db)
+
+	captains := make([]*model.User, 3)
+	captainTokens := make(map[database.UserId]string)
+	for i := 0; i < 3; i++ {
+		c := newStoredUser(t, db)
+		captains[i] = c
+		captainTokens[c.ID] = newToken(t, c.ID)
+	}
+
+	draftID := createDraftViaHTTP(t, router, commissioner.ID, format.ID, "Results Draft")
+	captainIDs := make([]string, len(captains))
+	for i, c := range captains {
+		captainIDs[i] = c.ID.String()
+	}
+	w := doJSON(t, router, http.MethodPost, "/api/draft/"+draftID+"/initialize", map[string]any{
+		"captains": captainIDs,
+	}, newToken(t, commissioner.ID))
+	require.Equal(t, http.StatusOK, w.Code, "initialize: %s", w.Body.String())
+
+	// Assign rating cutoffs for every rating except the lowest.
+	draft, err := database.GetExistingRecordById(context.Background(), db, &model.Draft{}, mustParseRecordID(t, draftID))
+	require.NoError(t, err)
+	possibleRatings, err := format.GetPossibleRatings(context.Background(), db)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(possibleRatings), 2)
+	for i, r := range possibleRatings[:len(possibleRatings)-1] {
+		w = doJSON(t, router, http.MethodPost, "/api/draft/"+draftID+"/assign_rating_cutoff", map[string]any{
+			"rating": r.String(),
+			"cutoff": i + 1,
+		}, newToken(t, commissioner.ID))
+		require.Equal(t, http.StatusOK, w.Code, "assign rating cutoff: %s", w.Body.String())
+	}
+
+	// Drive the draft to completion so every team has selections.
+	completeDraftViaHTTP(t, router, db, draftID, captainTokens)
+	require.True(t, draft.IsDraftCompleted(context.Background(), db))
+
+	// The results endpoint returns each team (in draft order) with its roster
+	// and per-player assigned ratings. It is readable by a non-owner user.
+	outsider := newStoredUser(t, db)
+	w = doJSON(t, router, http.MethodGet, "/api/draft/"+draftID+"/results", nil, newToken(t, outsider.ID))
+	require.Equal(t, http.StatusOK, w.Code, "results: %s", w.Body.String())
+
+	var resp struct {
+		Resource struct {
+			Teams []struct {
+				TeamId     string `json:"team_id"`
+				CaptainId  string `json:"captain_id"`
+				DraftOrder int    `json:"draft_order"`
+				Selections []struct {
+					Round  int    `json:"round"`
+					Pick   int    `json:"pick"`
+					Rating string `json:"rating"`
+					User   struct {
+						ID string `json:"id"`
+					} `json:"user"`
+				} `json:"selections"`
+			} `json:"teams"`
+		} `json:"resource"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp.Resource.Teams, len(captains))
+
+	// Teams are returned in draft order and every selection has a rating.
+	selectionsTotal := 0
+	for i, team := range resp.Resource.Teams {
+		require.Equal(t, i, team.DraftOrder)
+		require.Equal(t, captains[i].ID.String(), team.CaptainId)
+		require.NotEmpty(t, team.TeamId)
+		for _, sel := range team.Selections {
+			require.Greater(t, sel.Round, 0)
+			require.Greater(t, sel.Pick, 0)
+			require.NotEmpty(t, sel.Rating)
+			require.NotEmpty(t, sel.User.ID)
+		}
+		selectionsTotal += len(team.Selections)
+	}
+	// Every drafted player (captains + extra players) is accounted for.
+	require.Equal(t, len(captains), selectionsTotal)
+}
+
 func TestDraftRatingCutoffCRUD(t *testing.T) {
 	db := database.NewUnitTestDBProvider()
 	router := newTestRouter(t, db)

--- a/route/draft/routes.go
+++ b/route/draft/routes.go
@@ -40,6 +40,8 @@ func RegisterRoutes(e *gin.RouterGroup, db database.Provider) {
 	selectFamily.Handle(e, SelectByCaptain{})
 	assignFamily := api.RouteFamily[*EmptyBody]{DatabaseProvider: db}
 	assignFamily.Handle(e, AssignDraftedPlayersToTeams{})
+	resultsFamily := api.RouteFamily[*EmptyBody]{DatabaseProvider: db}
+	resultsFamily.Handle(e, GetDraftResults{})
 	seasonFamily := api.RouteFamily[*CreateSeasonBody]{DatabaseProvider: db}
 	seasonFamily.Handle(e, CreateSeason{})
 	patternFamily := api.RouteFamily[*SetDraftOrderPatternBody]{DatabaseProvider: db}

--- a/ui/e2e/draft-finalize.spec.ts
+++ b/ui/e2e/draft-finalize.spec.ts
@@ -213,6 +213,26 @@ test('finalizing a completed draft assigns rosters and creates a Season', async 
 		expect(rosterUserIds.has(id)).toBeTruthy();
 	}
 
+	// --- Results page: read-only view of final teams, rosters, ratings, and
+	// the created Season ---
+	await page.goto(`/drafts/${draftId}/results`);
+	await waitForHydration(page);
+	// Wait for the page to finish loading (the Season link appears once the
+	// draft + results + seasons have all resolved).
+	await expect(page.getByRole('link', { name: seasonName })).toBeVisible();
+	await expect(page.getByRole('heading', { name: draftName })).toBeVisible();
+	// Completion state is shown and links back to the setup page.
+	await expect(page.getByText('Completed')).toBeVisible();
+	await expect(page.getByRole('link', { name: 'Draft setup' })).toBeVisible();
+	// Both teams and their drafted members are listed with assigned ratings.
+	await expect(page.getByText('Team 1')).toBeVisible();
+	await expect(page.getByText('Team 2')).toBeVisible();
+	// Captains appear both in the "Captain:" line and their roster entry, so
+	// scope to the roster list item to avoid a strict-mode match.
+	await expect(page.getByText(`${alexName} (captain)`)).toBeVisible();
+	await expect(page.getByText(`${blakeName} (captain)`)).toBeVisible();
+	await expect(page.getByText(`${people[2].first} ${people[2].last}`)).toBeVisible();
+
 	// Clean up the draft so the table doesn't accumulate rows across runs.
 	const cleanup = await page.request.delete(`${API}/draft/${draftId}`, {
 		headers: { 'X-INTRACLUB-TOKEN': token }

--- a/ui/src/lib/draft.ts
+++ b/ui/src/lib/draft.ts
@@ -21,6 +21,7 @@
 // (e.g. "Snake") rather than an opaque interface value. Record IDs are 16-char
 // hex strings; an empty string represents "not set" (InvalidRecordId).
 import { authFetch } from '$lib/auth';
+import type { User } from '$lib/user';
 
 export interface Draft {
 	id: string;
@@ -197,4 +198,35 @@ export async function createSeason(id: string, input: CreateSeasonInput): Promis
 			body: JSON.stringify(input)
 		})
 	);
+}
+
+// DraftSelection is one player's result in a completed draft: the round/pick
+// they were taken at, the drafted user, and their assigned rating.
+export interface DraftSelection {
+	round: number;
+	pick: number;
+	user: User;
+	rating: string;
+}
+
+// DraftTeamResults groups one team's DraftSelection rows with its captain and
+// draft order. It is one entry in the getDraftResults response.
+export interface DraftTeamResults {
+	team_id: string;
+	captain_id: string;
+	draft_order: number;
+	selections: DraftSelection[];
+}
+
+// DraftResults is the response of getDraftResults: the draft's teams (in draft
+// order) with each team's rosters and per-player assigned ratings.
+export interface DraftResults {
+	teams: DraftTeamResults[];
+}
+
+// getDraftResults fetches a read-only summary of a draft's final teams and
+// rosters, including each player's assigned rating
+// (GET /api/draft/:id/results).
+export async function getDraftResults(id: string): Promise<DraftResults> {
+	return unwrap(await authFetch(`${BASE}/${id}/results`));
 }

--- a/ui/src/routes/drafts/[id]/+page.svelte
+++ b/ui/src/routes/drafts/[id]/+page.svelte
@@ -283,6 +283,9 @@
 		<a href={`/drafts/${id()}/grades`} class="text-sm text-muted-foreground hover:text-foreground">
 			Pre-draft grades →
 		</a>
+		<a href={`/drafts/${id()}/results`} class="text-sm text-muted-foreground hover:text-foreground">
+			Results →
+		</a>
 		<a href="/drafts" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to drafts</a>
 	</div>
 </div>

--- a/ui/src/routes/drafts/[id]/draft/+page.svelte
+++ b/ui/src/routes/drafts/[id]/draft/+page.svelte
@@ -273,6 +273,12 @@
 		<a href={`/drafts/${id()}`} class="text-sm text-muted-foreground hover:text-foreground">
 			&larr; Draft setup
 		</a>
+		<a
+			href={`/drafts/${id()}/results`}
+			class="text-sm text-muted-foreground hover:text-foreground"
+		>
+			Results →
+		</a>
 	</div>
 </div>
 

--- a/ui/src/routes/drafts/[id]/results/+page.svelte
+++ b/ui/src/routes/drafts/[id]/results/+page.svelte
@@ -1,0 +1,168 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { page } from '$app/state';
+	import { getDraft, getDraftResults } from '$lib/draft';
+	import type { Draft, DraftResults } from '$lib/draft';
+	import { listUsers, fullName } from '$lib/user';
+	import type { User } from '$lib/user';
+	import { listRatings } from '$lib/rating';
+	import type { Rating } from '$lib/rating';
+	import { listSeasons } from '$lib/season';
+	import type { Season } from '$lib/season';
+	import { Badge } from '$lib/components/ui/badge/index.js';
+	import {
+		Card,
+		CardContent,
+		CardHeader,
+		CardTitle
+	} from '$lib/components/ui/card/index.js';
+
+	const id = () => page.params.id as string;
+
+	let draft = $state<Draft | null>(null);
+	let results = $state<DraftResults | null>(null);
+	let users = $state<User[]>([]);
+	let ratingsById = $state<Record<string, Rating>>({});
+	let season = $state<Season | null>(null);
+
+	let loading = $state(true);
+	let loadError = $state('');
+
+	async function load() {
+		loading = true;
+		loadError = '';
+		try {
+			const draftData = await getDraft(id());
+			const [resultsData, userList, ratingList, seasonList] = await Promise.all([
+				getDraftResults(id()),
+				listUsers(),
+				listRatings(),
+				listSeasons()
+			]);
+			draft = draftData;
+			results = resultsData;
+			users = userList;
+			ratingsById = Object.fromEntries(ratingList.map((r) => [r.id, r]));
+			season = seasonList.find((s) => s.draft_id === draftData.id) ?? null;
+		} catch (e) {
+			loadError = e instanceof Error ? e.message : 'Failed to load draft results';
+		} finally {
+			loading = false;
+		}
+	}
+
+	onMount(load);
+
+	function userName(userId: string): string {
+		const u = users.find((x) => x.id === userId);
+		return u ? fullName(u) : userId;
+	}
+
+	function ratingName(ratingId: string): string {
+		return ratingsById[ratingId]?.name ?? ratingId;
+	}
+
+	// The draft's final teams are returned by the backend in draft order.
+	const teams = $derived(results?.teams ?? []);
+
+	// A draft's completion state is read from the draft record's completed_at
+	// timestamp (zero value = not yet completed).
+	const ZERO_TIME = '0001-01-01T00:00:00Z';
+	const isCompleted = $derived(
+		draft !== null && draft.completed_at !== '' && draft.completed_at !== ZERO_TIME
+	);
+
+	function sortedMembers(members: { user_id: string; rating: string }[]) {
+		return [...members].sort((a, b) => userName(a.user_id).localeCompare(userName(b.user_id)));
+	}
+</script>
+
+<svelte:head>
+	<title>{draft ? `${draft.name} — Results` : 'Draft results'}</title>
+</svelte:head>
+
+<div class="flex items-center gap-4">
+	<h1 class="text-2xl font-semibold tracking-tight">{draft?.name ?? 'Draft results'}</h1>
+	<div class="ml-auto flex items-center gap-3">
+		<a href={`/drafts/${id()}`} class="text-sm text-muted-foreground hover:text-foreground">
+			&larr; Draft setup
+		</a>
+		<a
+			href={`/drafts/${id()}/draft`}
+			class="text-sm text-muted-foreground hover:text-foreground"
+		>
+			Live draft board
+		</a>
+	</div>
+</div>
+
+{#if loading}
+	<p class="mt-4 text-muted-foreground">Loading...</p>
+{:else if loadError}
+	<p class="mt-4 text-sm font-medium text-destructive">{loadError}</p>
+{:else if draft}
+	<!-- Completion state & created Season -->
+	<Card class="mt-6">
+		<CardHeader>
+			<CardTitle class="text-base">Draft status</CardTitle>
+		</CardHeader>
+		<CardContent>
+			<div class="flex flex-wrap items-center gap-4 text-sm">
+				<Badge variant={isCompleted ? 'secondary' : 'default'}>
+					{isCompleted ? 'Completed' : 'In progress'}
+				</Badge>
+				{#if season}
+					<span class="text-muted-foreground">
+						Season created:
+						<a
+							href={`/seasons/${season.id}`}
+							class="ml-1 font-medium text-foreground underline underline-offset-2 hover:text-primary"
+						>
+							{season.name}
+						</a>
+					</span>
+				{:else}
+					<span class="text-muted-foreground">No season has been created from this draft yet.</span>
+				{/if}
+			</div>
+		</CardContent>
+	</Card>
+
+	{#if teams.length === 0}
+		<p class="mt-6 text-sm text-muted-foreground">
+			This draft hasn't been initialized yet — go to the setup page to add captains.
+		</p>
+	{:else}
+		<div class="mt-6 grid gap-6 lg:grid-cols-2">
+			{#each teams as team}
+				<Card>
+					<CardHeader>
+						<CardTitle class="text-base">Team {team.draft_order + 1}</CardTitle>
+						<p class="text-xs text-muted-foreground">Captain: {userName(team.captain_id)}</p>
+					</CardHeader>
+					<CardContent>
+						{#if team.selections.length === 0}
+							<p class="text-sm text-muted-foreground">No players assigned.</p>
+						{:else}
+							<ul class="mt-2 space-y-2 text-sm">
+								{#each sortedMembers(team.selections.map((s) => ({ user_id: s.user.id, rating: s.rating }))) as member}
+									<li class="flex items-center justify-between gap-3">
+										<span class="font-medium">
+											{userName(member.user_id)}
+											{#if member.user_id === team.captain_id}
+												<span class="text-xs text-muted-foreground">(captain)</span>
+											{/if}
+										</span>
+										<span class="text-xs text-muted-foreground">
+											{ratingName(member.rating)}
+										</span>
+									</li>
+								{/each}
+							</ul>
+						{/if}
+					</CardContent>
+				</Card>
+			{/each}
+		</div>
+	{/if}
+{/if}


### PR DESCRIPTION
Implements ticket #129: a read-only draft results page at `/drafts/[id]/results` showing final teams and rosters with each player's assigned rating, plus completion state and the created Season.

## Backend
- New `GET /api/draft/:id/results` endpoint (`GetDraftResults`) returning each team (in draft order) with its captain and `DraftSelection` rows (round, pick, user, rating).
- Added JSON tags to `model.DraftSelection` so the wire format uses lowercase keys (`round`/`pick`/`user`/`rating`).
- Tests: `TestDraftResultsEndpoint` covers teams in draft order, per-selection round/pick/rating/user, and read access by a non-owner.

## Frontend
- `getDraftResults` API client + result types in `draft.ts`.
- `/drafts/[id]/results` page: status badge (Completed / In progress), link to the created Season, links back to draft setup & live board, and per-team rosters with ratings.
- Added `Results →` links to the draft setup and live board headers.
- Extended the `draft-finalize` e2e spec to exercise the results page.

## Verification
- `make tests` green, `npm run check` clean, full `make e2e` suite green (21 passed).