### PR TITLE
Prefix page titles with 'Intraclub |' for context

### DIFF
--- a/ui/src/routes/auth/callback/+page.svelte
+++ b/ui/src/routes/auth/callback/+page.svelte
@@ -48,7 +48,7 @@
 </script>
 
 <svelte:head>
-	<title>Logging in...</title>
+	<title>Intraclub | Logging in...</title>
 </svelte:head>
 
 {#if status === 'exchanging'}

--- a/ui/src/routes/drafts/+page.svelte
+++ b/ui/src/routes/drafts/+page.svelte
@@ -47,7 +47,7 @@
 </script>
 
 <svelte:head>
-	<title>Drafts</title>
+	<title>Intraclub | Drafts</title>
 </svelte:head>
 
 <div class="flex items-center justify-between gap-4">

--- a/ui/src/routes/drafts/[id]/+page.svelte
+++ b/ui/src/routes/drafts/[id]/+page.svelte
@@ -271,7 +271,7 @@
 </script>
 
 <svelte:head>
-	<title>{draft ? draft.name : 'Draft'}</title>
+	<title>Intraclub | {draft ? draft.name : 'Draft'}</title>
 </svelte:head>
 
 <div class="flex items-center gap-4">

--- a/ui/src/routes/drafts/[id]/draft/+page.svelte
+++ b/ui/src/routes/drafts/[id]/draft/+page.svelte
@@ -264,7 +264,7 @@
 </script>
 
 <svelte:head>
-	<title>{draft ? `${draft.name} — Live draft` : 'Live draft'}</title>
+	<title>Intraclub | {draft ? `${draft.name} — Live draft` : 'Live draft'}</title>
 </svelte:head>
 
 <div class="flex items-center gap-4">

--- a/ui/src/routes/drafts/[id]/grades/+page.svelte
+++ b/ui/src/routes/drafts/[id]/grades/+page.svelte
@@ -202,7 +202,7 @@
 </script>
 
 <svelte:head>
-	<title>{draft ? `${draft.name} — Grades` : 'Pre-draft grades'}</title>
+	<title>Intraclub | {draft ? `${draft.name} — Grades` : 'Pre-draft grades'}</title>
 </svelte:head>
 
 <div class="flex items-center gap-4">

--- a/ui/src/routes/drafts/[id]/results/+page.svelte
+++ b/ui/src/routes/drafts/[id]/results/+page.svelte
@@ -78,7 +78,7 @@
 </script>
 
 <svelte:head>
-	<title>{draft ? `${draft.name} — Results` : 'Draft results'}</title>
+	<title>Intraclub | {draft ? `${draft.name} — Results` : 'Draft results'}</title>
 </svelte:head>
 
 <div class="flex items-center gap-4">

--- a/ui/src/routes/drafts/new/+page.svelte
+++ b/ui/src/routes/drafts/new/+page.svelte
@@ -71,7 +71,7 @@
 </script>
 
 <svelte:head>
-	<title>New draft</title>
+	<title>Intraclub | New draft</title>
 </svelte:head>
 
 <div class="flex items-center gap-4">

--- a/ui/src/routes/facilities/+page.svelte
+++ b/ui/src/routes/facilities/+page.svelte
@@ -28,7 +28,7 @@
 </script>
 
 <svelte:head>
-	<title>Facilities</title>
+	<title>Intraclub | Facilities</title>
 </svelte:head>
 
 <div class="flex items-center justify-between gap-4">

--- a/ui/src/routes/facilities/[id]/+page.svelte
+++ b/ui/src/routes/facilities/[id]/+page.svelte
@@ -81,7 +81,7 @@
 </script>
 
 <svelte:head>
-	<title>{facility ? facility.name : 'Facility'}</title>
+	<title>Intraclub | {facility ? facility.name : 'Facility'}</title>
 </svelte:head>
 
 {#if loadError}

--- a/ui/src/routes/facilities/new/+page.svelte
+++ b/ui/src/routes/facilities/new/+page.svelte
@@ -34,7 +34,7 @@
 </script>
 
 <svelte:head>
-	<title>New facility</title>
+	<title>Intraclub | New facility</title>
 </svelte:head>
 
 <div class="flex items-center gap-4">

--- a/ui/src/routes/formats/+page.svelte
+++ b/ui/src/routes/formats/+page.svelte
@@ -28,7 +28,7 @@
 </script>
 
 <svelte:head>
-	<title>Formats</title>
+	<title>Intraclub | Formats</title>
 </svelte:head>
 
 <div class="flex items-center justify-between gap-4">

--- a/ui/src/routes/formats/[id]/+page.svelte
+++ b/ui/src/routes/formats/[id]/+page.svelte
@@ -135,7 +135,7 @@
 </script>
 
 <svelte:head>
-	<title>{format ? format.name : 'Format'}</title>
+	<title>Intraclub | {format ? format.name : 'Format'}</title>
 </svelte:head>
 
 {#if loadError}

--- a/ui/src/routes/formats/new/+page.svelte
+++ b/ui/src/routes/formats/new/+page.svelte
@@ -26,7 +26,7 @@
 </script>
 
 <svelte:head>
-	<title>New format</title>
+	<title>Intraclub | New format</title>
 </svelte:head>
 
 <div class="flex items-center gap-4">

--- a/ui/src/routes/login/+page.svelte
+++ b/ui/src/routes/login/+page.svelte
@@ -3,7 +3,7 @@
 </script>
 
 <svelte:head>
-	<title>Log in</title>
+	<title>Intraclub | Log in</title>
 </svelte:head>
 
 <h1>Log in</h1>

--- a/ui/src/routes/photos/+page.svelte
+++ b/ui/src/routes/photos/+page.svelte
@@ -32,7 +32,7 @@
 </script>
 
 <svelte:head>
-	<title>Photos</title>
+	<title>Intraclub | Photos</title>
 </svelte:head>
 
 <div class="flex items-center justify-between gap-4">

--- a/ui/src/routes/photos/[id]/+page.svelte
+++ b/ui/src/routes/photos/[id]/+page.svelte
@@ -108,7 +108,7 @@
 </script>
 
 <svelte:head>
-	<title>Photo</title>
+	<title>Intraclub | Photo</title>
 </svelte:head>
 
 {#if loadError}

--- a/ui/src/routes/photos/new/+page.svelte
+++ b/ui/src/routes/photos/new/+page.svelte
@@ -53,7 +53,7 @@
 </script>
 
 <svelte:head>
-	<title>New photo</title>
+	<title>Intraclub | New photo</title>
 </svelte:head>
 
 <div class="flex items-center gap-4">

--- a/ui/src/routes/playoff-structures/+page.svelte
+++ b/ui/src/routes/playoff-structures/+page.svelte
@@ -28,7 +28,7 @@
 </script>
 
 <svelte:head>
-	<title>Playoff Structures</title>
+	<title>Intraclub | Playoff Structures</title>
 </svelte:head>
 
 <div class="flex items-center justify-between gap-4">

--- a/ui/src/routes/playoff-structures/[id]/+page.svelte
+++ b/ui/src/routes/playoff-structures/[id]/+page.svelte
@@ -81,7 +81,7 @@
 </script>
 
 <svelte:head>
-	<title>Playoff Structure</title>
+	<title>Intraclub | Playoff Structure</title>
 </svelte:head>
 
 {#if loadError}

--- a/ui/src/routes/playoff-structures/new/+page.svelte
+++ b/ui/src/routes/playoff-structures/new/+page.svelte
@@ -30,7 +30,7 @@
 </script>
 
 <svelte:head>
-	<title>New playoff structure</title>
+	<title>Intraclub | New playoff structure</title>
 </svelte:head>
 
 <div class="flex items-center gap-4">

--- a/ui/src/routes/ratings/+page.svelte
+++ b/ui/src/routes/ratings/+page.svelte
@@ -28,7 +28,7 @@
 </script>
 
 <svelte:head>
-	<title>Ratings</title>
+	<title>Intraclub | Ratings</title>
 </svelte:head>
 
 <div class="flex items-center justify-between gap-4">

--- a/ui/src/routes/ratings/[id]/+page.svelte
+++ b/ui/src/routes/ratings/[id]/+page.svelte
@@ -73,7 +73,7 @@
 </script>
 
 <svelte:head>
-	<title>{rating ? rating.name : 'Rating'}</title>
+	<title>Intraclub | {rating ? rating.name : 'Rating'}</title>
 </svelte:head>
 
 {#if loadError}

--- a/ui/src/routes/ratings/new/+page.svelte
+++ b/ui/src/routes/ratings/new/+page.svelte
@@ -28,7 +28,7 @@
 </script>
 
 <svelte:head>
-	<title>New rating</title>
+	<title>Intraclub | New rating</title>
 </svelte:head>
 
 <div class="flex items-center gap-4">

--- a/ui/src/routes/rulesets/+page.svelte
+++ b/ui/src/routes/rulesets/+page.svelte
@@ -28,7 +28,7 @@
 </script>
 
 <svelte:head>
-	<title>Rulesets</title>
+	<title>Intraclub | Rulesets</title>
 </svelte:head>
 
 <div class="flex items-center justify-between gap-4">

--- a/ui/src/routes/rulesets/[id]/+page.svelte
+++ b/ui/src/routes/rulesets/[id]/+page.svelte
@@ -75,7 +75,7 @@
 </script>
 
 <svelte:head>
-	<title>{ruleset ? ruleset.name : 'Ruleset'}</title>
+	<title>Intraclub | {ruleset ? ruleset.name : 'Ruleset'}</title>
 </svelte:head>
 
 {#if loadError}

--- a/ui/src/routes/rulesets/new/+page.svelte
+++ b/ui/src/routes/rulesets/new/+page.svelte
@@ -26,7 +26,7 @@
 </script>
 
 <svelte:head>
-	<title>New ruleset</title>
+	<title>Intraclub | New ruleset</title>
 </svelte:head>
 
 <div class="flex items-center gap-4">

--- a/ui/src/routes/scoring-structures/+page.svelte
+++ b/ui/src/routes/scoring-structures/+page.svelte
@@ -36,7 +36,7 @@
 </script>
 
 <svelte:head>
-	<title>Scoring Structures</title>
+	<title>Intraclub | Scoring Structures</title>
 </svelte:head>
 
 <div class="flex items-center justify-between gap-4">

--- a/ui/src/routes/scoring-structures/[id]/+page.svelte
+++ b/ui/src/routes/scoring-structures/[id]/+page.svelte
@@ -105,7 +105,7 @@
 </script>
 
 <svelte:head>
-	<title>{structure ? structure.name : 'Scoring Structure'}</title>
+	<title>Intraclub | {structure ? structure.name : 'Scoring Structure'}</title>
 </svelte:head>
 
 {#if loadError}

--- a/ui/src/routes/scoring-structures/new/+page.svelte
+++ b/ui/src/routes/scoring-structures/new/+page.svelte
@@ -51,7 +51,7 @@
 </script>
 
 <svelte:head>
-	<title>New scoring structure</title>
+	<title>Intraclub | New scoring structure</title>
 </svelte:head>
 
 <div class="flex items-center gap-4">

--- a/ui/src/routes/seasons/[id]/+page.svelte
+++ b/ui/src/routes/seasons/[id]/+page.svelte
@@ -106,7 +106,7 @@
 </script>
 
 <svelte:head>
-	<title>{season ? season.name : 'Season'}</title>
+	<title>Intraclub | {season ? season.name : 'Season'}</title>
 </svelte:head>
 
 <div class="flex items-center gap-4">

--- a/ui/src/routes/users/import/+page.svelte
+++ b/ui/src/routes/users/import/+page.svelte
@@ -27,7 +27,7 @@
 </script>
 
 <svelte:head>
-	<title>Import users</title>
+	<title>Intraclub | Import users</title>
 </svelte:head>
 
 <div class="flex items-center gap-4">


### PR DESCRIPTION
Each page now sets its title as `Intraclub | <page>` (e.g. `Intraclub | Drafts`) instead of just `<page>`, giving the browser tab context about the app.

Verified: `npm run check` (0 errors/warnings) and the full `make e2e` suite (21 passed).