### PR TITLE
Add read-only Users CRUD pages and seed 10 dev users

### DIFF
--- a/model/dev_data.go
+++ b/model/dev_data.go
@@ -22,17 +22,38 @@ func getDevContext() context.Context {
 }
 
 func seedDevUsers(db database.Provider) *User {
-	user1 := NewUser()
-	user1.FirstName = "JD"
-	user1.LastName = "Arthur"
-	user1.Email = "jdarthur@gatech.edu"
-
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	v, err := database.CreateOne(ctx, db, user1)
-	if err != nil {
-		panic(err)
+	devUsers := []struct {
+		FirstName string
+		LastName  string
+		Email     string
+	}{
+		{"JD", "Arthur", "jdarthur@gatech.edu"},
+		{"Avery", "Chen", "avery.chen@example.com"},
+		{"Bailey", "Nguyen", "bailey.nguyen@example.com"},
+		{"Cameron", "Patel", "cameron.patel@example.com"},
+		{"Dana", "Kim", "dana.kim@example.com"},
+		{"Elliot", "Garcia", "elliot.garcia@example.com"},
+		{"Frankie", "Rossi", "frankie.rossi@example.com"},
+		{"Grayson", "Walsh", "grayson.walsh@example.com"},
+		{"Harper", "Okafor", "harper.okafor@example.com"},
+		{"Imani", "Silva", "imani.silva@example.com"},
+	}
+
+	var v *User
+	for _, u := range devUsers {
+		user := NewUser()
+		user.FirstName = u.FirstName
+		user.LastName = u.LastName
+		user.Email = EmailAddress(u.Email)
+
+		created, err := database.CreateOne(ctx, db, user)
+		if err != nil {
+			panic(err)
+		}
+		v = created
 	}
 	return v
 }

--- a/ui/e2e/user.spec.ts
+++ b/ui/e2e/user.spec.ts
@@ -1,0 +1,35 @@
+import { expect, test, type Page } from '@playwright/test';
+import { waitForHydration } from './helpers';
+
+// The Go backend runs with --dev-token from the repo root (see
+// playwright.config.ts), so POST /api/one_time_password returns the magic-link
+// token in the response body. Login with the user seeded by SeedDevData.
+async function login(page: Page) {
+	await page.goto('/login');
+	await page.waitForLoadState('networkidle');
+	await page.getByLabel('Email').fill('jdarthur@gatech.edu');
+	await page.getByRole('button', { name: 'Send login link' }).click();
+	const link = page.getByRole('main').getByRole('link', { name: 'Log in' });
+	await expect(link).toBeVisible();
+	await link.click();
+	await expect(page).toHaveURL('/');
+}
+
+test('users: list shows seeded users and detail page is read-only', async ({ page }) => {
+	await login(page);
+
+	// List page shows the seeded dev users.
+	await page.goto('/users');
+	await waitForHydration(page);
+	await expect(page.getByRole('heading', { name: 'Users' })).toBeVisible();
+	await expect(page.getByRole('link', { name: 'JD Arthur' })).toBeVisible();
+	await expect(page.getByRole('link', { name: 'Avery Chen' })).toBeVisible();
+	await expect(page.getByRole('cell', { name: 'jdarthur@gatech.edu' })).toBeVisible();
+
+	// Detail page renders the user's fields without edit/delete actions.
+	await page.getByRole('link', { name: 'JD Arthur' }).click();
+	await expect(page).toHaveURL(/\/users\/[0-9a-f]{16}$/);
+	await expect(page.getByRole('heading', { name: 'JD Arthur' })).toBeVisible();
+	await expect(page.getByText('jdarthur@gatech.edu')).toBeVisible();
+	await expect(page.getByRole('button', { name: /Save|Delete/ })).toHaveCount(0);
+});

--- a/ui/src/lib/components/NavBar.svelte
+++ b/ui/src/lib/components/NavBar.svelte
@@ -48,7 +48,7 @@
 			</Popover>
 			<a href="/drafts" class="rounded-md px-2 py-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground">Drafts</a>
 			<a href="/photos" class="rounded-md px-2 py-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground">Photos</a>
-			<a href="/users/import" class="rounded-md px-2 py-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground">Users</a>
+			<a href="/users" class="rounded-md px-2 py-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground">Users</a>
 		</nav>
 		<div class="ml-auto flex items-center">
 			{#if loggedIn}

--- a/ui/src/routes/users/+page.svelte
+++ b/ui/src/routes/users/+page.svelte
@@ -1,0 +1,72 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { listUsers } from '$lib/user';
+	import type { User } from '$lib/user';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import {
+		Table,
+		TableBody,
+		TableCell,
+		TableHead,
+		TableHeader,
+		TableRow
+	} from '$lib/components/ui/table/index.js';
+
+	let users = $state<User[]>([]);
+	let loading = $state(true);
+	let error = $state('');
+
+	onMount(async () => {
+		try {
+			users = await listUsers();
+		} catch (e) {
+			error = e instanceof Error ? e.message : 'Failed to load users';
+		} finally {
+			loading = false;
+		}
+	});
+</script>
+
+<svelte:head>
+	<title>Intraclub | Users</title>
+</svelte:head>
+
+<div class="flex items-center justify-between gap-4">
+	<h1 class="text-2xl font-semibold tracking-tight">Users</h1>
+	<Button href="/users/import">Import users</Button>
+</div>
+
+{#if loading}
+	<p class="text-muted-foreground">Loading...</p>
+{:else if error}
+	<p class="text-sm font-medium text-destructive">{error}</p>
+{:else if users.length === 0}
+	<p class="text-muted-foreground">No users yet.</p>
+{:else}
+	<div class="mt-4 overflow-hidden rounded-lg border">
+		<Table>
+			<TableHeader>
+				<TableRow>
+					<TableHead>Name</TableHead>
+					<TableHead>Email</TableHead>
+					<TableHead>Phone</TableHead>
+					<TableHead>Verified</TableHead>
+				</TableRow>
+			</TableHeader>
+			<TableBody>
+				{#each users as user}
+					<TableRow>
+						<TableCell>
+							<a href={`/users/${user.id}`} class="font-medium text-primary underline-offset-4 hover:underline">
+								{user.first_name} {user.last_name}
+							</a>
+						</TableCell>
+						<TableCell>{user.email}</TableCell>
+						<TableCell>{user.phone_number || '—'}</TableCell>
+						<TableCell>{user.verified ? 'Yes' : 'No'}</TableCell>
+					</TableRow>
+				{/each}
+			</TableBody>
+		</Table>
+	</div>
+{/if}

--- a/ui/src/routes/users/[id]/+page.svelte
+++ b/ui/src/routes/users/[id]/+page.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { page } from '$app/state';
+	import { getUser } from '$lib/user';
+	import type { User } from '$lib/user';
+	import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card/index.js';
+
+	const id = () => page.params.id as string;
+
+	let user = $state<User | null>(null);
+	let loadError = $state('');
+
+	onMount(load);
+
+	async function load() {
+		loadError = '';
+		try {
+			user = await getUser(id());
+		} catch (e) {
+			loadError = e instanceof Error ? e.message : 'Failed to load user';
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>Intraclub | {user ? `${user.first_name} ${user.last_name}` : 'User'}</title>
+</svelte:head>
+
+{#if loadError}
+	<h1 class="text-2xl font-semibold tracking-tight">User</h1>
+	<p class="text-sm font-medium text-destructive">{loadError}</p>
+	<a href="/users" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to users</a>
+{:else if !user}
+	<h1 class="text-2xl font-semibold tracking-tight">User</h1>
+	<p class="text-muted-foreground">Loading...</p>
+{:else}
+	<div class="flex items-center gap-4">
+		<h1 class="text-2xl font-semibold tracking-tight">{user.first_name} {user.last_name}</h1>
+		<a href="/users" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to users</a>
+	</div>
+
+	<Card class="mt-6 max-w-md">
+		<CardHeader>
+			<CardTitle class="text-base">User details</CardTitle>
+		</CardHeader>
+		<CardContent>
+			<dl class="grid gap-4 text-sm">
+				<div class="flex justify-between gap-4">
+					<dt class="text-muted-foreground">Name</dt>
+					<dd>{user.first_name} {user.last_name}</dd>
+				</div>
+				<div class="flex justify-between gap-4">
+					<dt class="text-muted-foreground">Email</dt>
+					<dd>{user.email}</dd>
+				</div>
+				<div class="flex justify-between gap-4">
+					<dt class="text-muted-foreground">Phone</dt>
+					<dd>{user.phone_number || '—'}</dd>
+				</div>
+				<div class="flex justify-between gap-4">
+					<dt class="text-muted-foreground">Verified</dt>
+					<dd>{user.verified ? 'Yes' : 'No'}</dd>
+				</div>
+			</dl>
+		</CardContent>
+	</Card>
+{/if}


### PR DESCRIPTION
## Summary
Adds a family of CRUD pages for the `Users` type so users can actually be viewed (previously only the CSV import page existed). As discussed, update/delete are intentionally excluded since users shouldn't be able to modify other users.

## Changes
- **Seed data**: dev-mode seeding now creates 10 unique users instead of 1 (`model/dev_data.go`).
- **`/users` list page**: table of all users (Name, Email, Phone, Verified) with links to detail pages and an "Import users" button.
- **`/users/[id]` detail page**: read-only view of a user's fields — no edit/delete actions.
- **Nav**: the "Users" navbar link now points to `/users` instead of `/users/import`.
- **e2e**: added `ui/e2e/user.spec.ts` covering the list and read-only detail page.

## Verification
- `npm run check` (svelte-check): 0 errors, 0 warnings
- `make e2e`: full Playwright suite passed (22/22)
- `go build ./...`, `go vet`, `go test ./...` pass