### PR TITLE
UI: add sidebar tabs to the single-Draft setup page

### DIFF
--- a/ui/e2e/draft-setup.spec.ts
+++ b/ui/e2e/draft-setup.spec.ts
@@ -77,6 +77,13 @@ test('draft setup page configures captains, players, and rating cutoffs', async 
 	await expect(page.getByRole('heading', { name: draftName })).toBeVisible();
 	await waitForHydration(page);
 
+	// The active tab is visually indicated (bold) so it's clear at a glance
+	// which section is shown. Captains is the default tab.
+	await expect(page.getByRole('tab', { name: 'Captains & teams' })).toHaveCSS(
+		'font-weight',
+		'600'
+	);
+
 	await page.getByLabel('Captain', { exact: true }).selectOption({ label: captainOne });
 	await page.getByRole('button', { name: 'Add captain' }).click();
 	await page.getByLabel('Captain', { exact: true }).selectOption({ label: captainTwo });

--- a/ui/e2e/draft-setup.spec.ts
+++ b/ui/e2e/draft-setup.spec.ts
@@ -77,9 +77,9 @@ test('draft setup page configures captains, players, and rating cutoffs', async 
 	await expect(page.getByRole('heading', { name: draftName })).toBeVisible();
 	await waitForHydration(page);
 
-	await page.getByLabel('Captain').selectOption({ label: captainOne });
+	await page.getByLabel('Captain', { exact: true }).selectOption({ label: captainOne });
 	await page.getByRole('button', { name: 'Add captain' }).click();
-	await page.getByLabel('Captain').selectOption({ label: captainTwo });
+	await page.getByLabel('Captain', { exact: true }).selectOption({ label: captainTwo });
 	await page.getByRole('button', { name: 'Add captain' }).click();
 	await page.getByRole('button', { name: 'Initialize draft' }).click();
 
@@ -89,12 +89,13 @@ test('draft setup page configures captains, players, and rating cutoffs', async 
 	await expect(page.getByRole('table').getByText(captainOne)).toBeVisible();
 
 	// --- Available players ---
-	await page.getByLabel('Player').selectOption({ label: rosterOne });
+	await page.getByRole('tab', { name: 'Available players' }).click();
+	await page.getByLabel('Player', { exact: true }).selectOption({ label: rosterOne });
 	await page.getByRole('button', { name: 'Add player' }).click();
 	// Wait for the first add's reload to commit before adding the second, so the
 	// select/button DOM is stable.
 	await expect(page.getByRole('list').getByText(rosterOne)).toBeVisible();
-	await page.getByLabel('Player').selectOption({ label: rosterTwo });
+	await page.getByLabel('Player', { exact: true }).selectOption({ label: rosterTwo });
 	await page.getByRole('button', { name: 'Add player' }).click();
 	await expect(page.getByRole('list').getByText(rosterTwo)).toBeVisible();
 
@@ -103,6 +104,7 @@ test('draft setup page configures captains, players, and rating cutoffs', async 
 	await expect(page.getByText('4 available players across 2 teams (2 per team)')).toBeVisible();
 
 	// --- Rating cutoffs ---
+	await page.getByRole('tab', { name: 'Rating cutoffs' }).click();
 	await page.getByLabel("Men's 1").fill('2');
 	await page.getByLabel("Men's 2").fill('4');
 	await page.getByRole('button', { name: 'Save cutoffs' }).click();
@@ -112,6 +114,7 @@ test('draft setup page configures captains, players, and rating cutoffs', async 
 	await expect(page.getByText('Ready to grade & pick')).toBeVisible();
 	await page.reload();
 	await waitForHydration(page);
+	await page.getByRole('tab', { name: 'Rating cutoffs' }).click();
 	await expect(page.getByLabel("Men's 1")).toHaveValue('2');
 	await expect(page.getByLabel("Men's 2")).toHaveValue('4');
 	await expect(page.getByText('Ready to grade & pick')).toBeVisible();

--- a/ui/src/lib/components/ui/tabs/index.ts
+++ b/ui/src/lib/components/ui/tabs/index.ts
@@ -1,0 +1,18 @@
+import Content from "./tabs-content.svelte";
+import Trigger from "./tabs-trigger.svelte";
+import Root from "./tabs.svelte";
+import List, { tabsListVariants, type TabsListVariant } from "./tabs-list.svelte";
+
+export {
+	Root,
+	Content,
+	List,
+	Trigger,
+	tabsListVariants,
+	type TabsListVariant,
+	//
+	Root as Tabs,
+	Content as TabsContent,
+	List as TabsList,
+	Trigger as TabsTrigger,
+};

--- a/ui/src/lib/components/ui/tabs/tabs-content.svelte
+++ b/ui/src/lib/components/ui/tabs/tabs-content.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { Tabs as TabsPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: TabsPrimitive.ContentProps = $props();
+</script>
+
+<TabsPrimitive.Content
+	bind:ref
+	data-slot="tabs-content"
+	class={cn("text-sm flex-1 outline-none", className)}
+	{...restProps}
+/>

--- a/ui/src/lib/components/ui/tabs/tabs-list.svelte
+++ b/ui/src/lib/components/ui/tabs/tabs-list.svelte
@@ -1,0 +1,40 @@
+<script lang="ts" module>
+	import { tv, type VariantProps } from "tailwind-variants";
+
+	export const tabsListVariants = tv({
+		base: "rounded-lg p-[3px] group-data-horizontal/tabs:h-8 data-[variant=line]:rounded-none group/tabs-list inline-flex w-fit items-center justify-center text-muted-foreground group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col",
+		variants: {
+			variant: {
+				default: "cn-tabs-list-variant-default bg-muted",
+				line: "cn-tabs-list-variant-line gap-1 bg-transparent",
+			},
+		},
+		defaultVariants: {
+			variant: "default",
+		},
+	});
+
+	export type TabsListVariant = VariantProps<typeof tabsListVariants>["variant"];
+</script>
+
+<script lang="ts">
+	import { Tabs as TabsPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		variant = "default",
+		class: className,
+		...restProps
+	}: TabsPrimitive.ListProps & {
+		variant?: TabsListVariant;
+	} = $props();
+</script>
+
+<TabsPrimitive.List
+	bind:ref
+	data-slot="tabs-list"
+	data-variant={variant}
+	class={cn(tabsListVariants({ variant }), className)}
+	{...restProps}
+/>

--- a/ui/src/lib/components/ui/tabs/tabs-trigger.svelte
+++ b/ui/src/lib/components/ui/tabs/tabs-trigger.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import { Tabs as TabsPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: TabsPrimitive.TriggerProps = $props();
+</script>
+
+<TabsPrimitive.Trigger
+	bind:ref
+	data-slot="tabs-trigger"
+	class={cn(
+		"gap-1.5 rounded-md border border-transparent px-1.5 py-0.5 text-sm font-medium has-data-[icon=inline-end]:pr-1 has-data-[icon=inline-start]:pl-1 group-data-[variant=default]/tabs-list:data-active:shadow-sm group-data-[variant=line]/tabs-list:data-active:shadow-none [&_svg:not([class*='size-'])]:size-4 relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center whitespace-nowrap text-foreground/60 transition-all group-data-[orientation=vertical]/tabs:w-full group-data-[orientation=vertical]/tabs:justify-start hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 dark:text-muted-foreground dark:hover:text-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		"group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-active:bg-transparent dark:group-data-[variant=line]/tabs-list:data-active:border-transparent dark:group-data-[variant=line]/tabs-list:data-active:bg-transparent",
+		"data-active:bg-background data-active:text-foreground dark:data-active:border-input dark:data-active:bg-input/30 dark:data-active:text-foreground",
+		"after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-[orientation=horizontal]/tabs:after:inset-x-0 group-data-[orientation=horizontal]/tabs:after:bottom-[-5px] group-data-[orientation=horizontal]/tabs:after:h-0.5 group-data-[orientation=vertical]/tabs:after:inset-y-0 group-data-[orientation=vertical]/tabs:after:-right-1 group-data-[orientation=vertical]/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-active:after:opacity-100",
+		className
+	)}
+	{...restProps}
+/>

--- a/ui/src/lib/components/ui/tabs/tabs.svelte
+++ b/ui/src/lib/components/ui/tabs/tabs.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import { Tabs as TabsPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		value = $bindable(""),
+		class: className,
+		...restProps
+	}: TabsPrimitive.RootProps = $props();
+</script>
+
+<TabsPrimitive.Root
+	bind:ref
+	bind:value
+	data-slot="tabs"
+	class={cn("gap-2 group/tabs flex data-[orientation=horizontal]:flex-col", className)}
+	{...restProps}
+/>

--- a/ui/src/routes/drafts/[id]/+page.svelte
+++ b/ui/src/routes/drafts/[id]/+page.svelte
@@ -42,6 +42,12 @@
 		NativeSelect,
 		NativeSelectOption
 	} from '$lib/components/ui/native-select/index.js';
+	import {
+		Tabs,
+		TabsContent,
+		TabsList,
+		TabsTrigger
+	} from '$lib/components/ui/tabs/index.js';
 
 	const id = () => page.params.id as string;
 
@@ -74,6 +80,9 @@
 	// does not propagate in Svelte 5).
 	let cutoffEntries = $state<{ ratingId: string; value: string }[]>([]);
 	let savingCutoffs = $state(false);
+
+	// Which setup section is shown in the sidebar at a time.
+	let activeTab = $state('captains');
 
 	async function load() {
 		loading = true;
@@ -330,7 +339,20 @@
 		<p class="mt-4 text-sm font-medium text-destructive">{actionError}</p>
 	{/if}
 
-	<div class="mt-6 grid gap-6 lg:grid-cols-2">
+	<Tabs bind:value={activeTab} orientation="vertical" class="mt-6 flex gap-6">
+		<TabsList class="h-fit w-56 shrink-0 items-stretch">
+			<TabsTrigger value="captains" class="justify-start px-3 py-2 text-base">
+				Captains &amp; teams
+			</TabsTrigger>
+			<TabsTrigger value="players" class="justify-start px-3 py-2 text-base">
+				Available players
+			</TabsTrigger>
+			<TabsTrigger value="cutoffs" class="justify-start px-3 py-2 text-base">
+				Rating cutoffs
+			</TabsTrigger>
+		</TabsList>
+
+		<TabsContent value="captains" class="flex-1">
 		<!-- Captains / teams -->
 		<Card>
 			<CardHeader>
@@ -402,7 +424,9 @@
 				{/if}
 			</CardContent>
 		</Card>
+		</TabsContent>
 
+		<TabsContent value="players" class="flex-1">
 		<!-- Available players -->
 		<Card>
 			<CardHeader>
@@ -447,7 +471,9 @@
 				{/if}
 			</CardContent>
 		</Card>
+		</TabsContent>
 
+		<TabsContent value="cutoffs" class="flex-1">
 		<!-- Rating cutoffs -->
 		<Card>
 			<CardHeader>
@@ -498,5 +524,6 @@
 				{/if}
 			</CardContent>
 		</Card>
-	</div>
+		</TabsContent>
+	</Tabs>
 {/if}

--- a/ui/src/routes/drafts/[id]/+page.svelte
+++ b/ui/src/routes/drafts/[id]/+page.svelte
@@ -341,13 +341,34 @@
 
 	<Tabs bind:value={activeTab} orientation="vertical" class="mt-6 flex gap-6">
 		<TabsList class="h-fit w-56 shrink-0 items-stretch">
-			<TabsTrigger value="captains" class="justify-start px-3 py-2 text-base">
+			<TabsTrigger
+				value="captains"
+				class="group justify-start gap-2.5 px-3 py-2 text-base data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:font-semibold data-[state=active]:shadow-sm dark:data-[state=active]:bg-input/30"
+			>
+				<span
+					class="size-1.5 shrink-0 rounded-full bg-primary opacity-0 transition-opacity group-data-[state=active]:opacity-100"
+					aria-hidden="true"
+				></span>
 				Captains &amp; teams
 			</TabsTrigger>
-			<TabsTrigger value="players" class="justify-start px-3 py-2 text-base">
+			<TabsTrigger
+				value="players"
+				class="group justify-start gap-2.5 px-3 py-2 text-base data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:font-semibold data-[state=active]:shadow-sm dark:data-[state=active]:bg-input/30"
+			>
+				<span
+					class="size-1.5 shrink-0 rounded-full bg-primary opacity-0 transition-opacity group-data-[state=active]:opacity-100"
+					aria-hidden="true"
+				></span>
 				Available players
 			</TabsTrigger>
-			<TabsTrigger value="cutoffs" class="justify-start px-3 py-2 text-base">
+			<TabsTrigger
+				value="cutoffs"
+				class="group justify-start gap-2.5 px-3 py-2 text-base data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:font-semibold data-[state=active]:shadow-sm dark:data-[state=active]:bg-input/30"
+			>
+				<span
+					class="size-1.5 shrink-0 rounded-full bg-primary opacity-0 transition-opacity group-data-[state=active]:opacity-100"
+					aria-hidden="true"
+				></span>
 				Rating cutoffs
 			</TabsTrigger>
 		</TabsList>


### PR DESCRIPTION
## What
Restructures the single-Draft setup page so the three configuration sections — **Captains & teams**, **Available players**, and **Rating cutoffs** — are shown as separate tabs in a left sidebar, with only one visible at a time, instead of all three stacked on the same viewport.

## Changes
- Adds the shadcn-svelte `tabs` component (`ui/src/lib/components/ui/tabs/`).
- Wraps the three setup cards in a vertical `Tabs` layout with a sidebar `TabsList` (vertical) on the left. The existing **Setup status** summary card stays at the top, outside the tabs.
- Updates the `draft-setup` e2e test to switch tabs between sections (and uses exact label matches, since tabpanel accessible names now contain `Captain`/`Player`).

## Verification
- `npm run check`: 0 errors, 0 warnings
- `npm run test` (vitest): 8 passed
- `make e2e`: 22 passed