### PR TITLE
UI: transfer-list for Available players in draft setup (PoC)

### DIFF
--- a/ui/e2e/draft-setup.spec.ts
+++ b/ui/e2e/draft-setup.spec.ts
@@ -97,17 +97,17 @@ test('draft setup page configures captains, players, and rating cutoffs', async 
 
 	// --- Available players ---
 	await page.getByRole('tab', { name: 'Available players' }).click();
-	await page.getByLabel('Player', { exact: true }).selectOption({ label: rosterOne });
-	await page.getByRole('button', { name: 'Add player' }).click();
-	// Wait for the first add's reload to commit before adding the second, so the
-	// select/button DOM is stable.
-	await expect(page.getByRole('list').getByText(rosterOne)).toBeVisible();
-	await page.getByLabel('Player', { exact: true }).selectOption({ label: rosterTwo });
-	await page.getByRole('button', { name: 'Add player' }).click();
-	await expect(page.getByRole('list').getByText(rosterTwo)).toBeVisible();
+
+	// The two roster players start in the source panel; select and move them
+	// into the pool with the transfer list, then save.
+	await page.getByRole('button', { name: rosterOne }).click();
+	await page.getByRole('button', { name: rosterTwo }).click();
+	await page.getByRole('button', { name: 'Move selected to pool' }).click();
+	await page.getByRole('button', { name: 'Save players' }).click();
+	// Saving reloads; the players now sit in the target (in-pool) panel.
+	await expect(page.getByText(rosterTwo)).toBeVisible();
 
 	// Two captains (auto-added) + two roster players = 4 across 2 teams.
-	await expect(page.getByRole('list').getByText(rosterOne)).toBeVisible();
 	await expect(page.getByText('4 available players across 2 teams (2 per team)')).toBeVisible();
 
 	// --- Rating cutoffs ---

--- a/ui/src/lib/components/ui/checkbox/checkbox.svelte
+++ b/ui/src/lib/components/ui/checkbox/checkbox.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+	import { Checkbox as CheckboxPrimitive } from "bits-ui";
+	import CheckIcon from '@lucide/svelte/icons/check';
+	import MinusIcon from '@lucide/svelte/icons/minus';
+	import { cn, type WithoutChildrenOrChild } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		checked = $bindable(false),
+		indeterminate = $bindable(false),
+		class: className,
+		...restProps
+	}: WithoutChildrenOrChild<CheckboxPrimitive.RootProps> = $props();
+</script>
+
+<CheckboxPrimitive.Root
+	bind:ref
+	data-slot="checkbox"
+	class={cn(
+		"flex size-4 items-center justify-center rounded-[4px] border border-input transition-colors group-has-disabled/field:opacity-50 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 aria-invalid:aria-checked:border-primary dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary peer relative shrink-0 outline-none after:absolute after:-inset-x-3 after:-inset-y-2 disabled:cursor-not-allowed disabled:opacity-50",
+		className
+	)}
+	bind:checked
+	bind:indeterminate
+	{...restProps}
+>
+	{#snippet children({ checked, indeterminate })}
+		<div
+			data-slot="checkbox-indicator"
+			class="[&>svg]:size-3.5 grid place-content-center text-current transition-none"
+		>
+			{#if checked}
+				<CheckIcon  />
+			{:else if indeterminate}
+				<MinusIcon  />
+			{/if}
+		</div>
+	{/snippet}
+</CheckboxPrimitive.Root>

--- a/ui/src/lib/components/ui/checkbox/index.ts
+++ b/ui/src/lib/components/ui/checkbox/index.ts
@@ -1,0 +1,6 @@
+import Root from "./checkbox.svelte";
+export {
+	Root,
+	//
+	Root as Checkbox,
+};

--- a/ui/src/lib/components/ui/scroll-area/index.ts
+++ b/ui/src/lib/components/ui/scroll-area/index.ts
@@ -1,0 +1,10 @@
+import Scrollbar from "./scroll-area-scrollbar.svelte";
+import Root from "./scroll-area.svelte";
+
+export {
+	Root,
+	Scrollbar,
+	//,
+	Root as ScrollArea,
+	Scrollbar as ScrollAreaScrollbar,
+};

--- a/ui/src/lib/components/ui/scroll-area/scroll-area-scrollbar.svelte
+++ b/ui/src/lib/components/ui/scroll-area/scroll-area-scrollbar.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+	import { ScrollArea as ScrollAreaPrimitive } from "bits-ui";
+	import { cn, type WithoutChild } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		orientation = "vertical",
+		children,
+		...restProps
+	}: WithoutChild<ScrollAreaPrimitive.ScrollbarProps> = $props();
+</script>
+
+<ScrollAreaPrimitive.Scrollbar
+	bind:ref
+	data-slot="scroll-area-scrollbar"
+	data-orientation={orientation}
+	{orientation}
+	class={cn(
+		"data-horizontal:h-2.5 data-horizontal:flex-col data-horizontal:border-t data-horizontal:border-t-transparent data-vertical:h-full data-vertical:w-2.5 data-vertical:border-l data-vertical:border-l-transparent flex touch-none p-px transition-colors select-none",
+		className
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+	<ScrollAreaPrimitive.Thumb
+		data-slot="scroll-area-thumb"
+		class="rounded-full relative flex-1 bg-border"
+	/>
+</ScrollAreaPrimitive.Scrollbar>

--- a/ui/src/lib/components/ui/scroll-area/scroll-area.svelte
+++ b/ui/src/lib/components/ui/scroll-area/scroll-area.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+	import { ScrollArea as ScrollAreaPrimitive } from "bits-ui";
+	import { cn, type WithoutChild } from "$lib/utils.js";
+	import { Scrollbar } from "./index.js";
+
+	let {
+		ref = $bindable(null),
+		viewportRef = $bindable(null),
+		class: className,
+		orientation = "vertical",
+		scrollbarXClasses = "",
+		scrollbarYClasses = "",
+		children,
+		...restProps
+	}: WithoutChild<ScrollAreaPrimitive.RootProps> & {
+		orientation?: "vertical" | "horizontal" | "both" | undefined;
+		scrollbarXClasses?: string | undefined;
+		scrollbarYClasses?: string | undefined;
+		viewportRef?: HTMLElement | null;
+	} = $props();
+</script>
+
+<ScrollAreaPrimitive.Root
+	bind:ref
+	data-slot="scroll-area"
+	class={cn("relative", className)}
+	{...restProps}
+>
+	<ScrollAreaPrimitive.Viewport
+		bind:ref={viewportRef}
+		data-slot="scroll-area-viewport"
+		class="cn-scroll-area-viewport size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1"
+	>
+		{@render children?.()}
+	</ScrollAreaPrimitive.Viewport>
+	{#if orientation === "vertical" || orientation === "both"}
+		<Scrollbar orientation="vertical" class={scrollbarYClasses} />
+	{/if}
+	{#if orientation === "horizontal" || orientation === "both"}
+		<Scrollbar orientation="horizontal" class={scrollbarXClasses} />
+	{/if}
+	<ScrollAreaPrimitive.Corner />
+</ScrollAreaPrimitive.Root>

--- a/ui/src/lib/components/ui/transfer-list/index.ts
+++ b/ui/src/lib/components/ui/transfer-list/index.ts
@@ -1,0 +1,17 @@
+import TransferListBody from "./transfer-list-body.svelte";
+import TransferListContainer from "./transfer-list-container.svelte";
+import TransferListToolbar from "./transfer-list-toolbar.svelte";
+import TransferList from "./transfer-list.svelte";
+import TransferListTitle from "./transfer-list-title.svelte";
+import TransferListItem from "./transfer-list-item.svelte";
+import { TransferListCore } from "./transfer-list-core.svelte.js";
+
+export {
+	TransferList as Root,
+	TransferListBody as Body,
+	TransferListContainer as Container,
+	TransferListToolbar as Toolbar,
+	TransferListTitle as Title,
+	TransferListItem as Item,
+	TransferListCore as Core
+};

--- a/ui/src/lib/components/ui/transfer-list/transfer-list-body.svelte
+++ b/ui/src/lib/components/ui/transfer-list/transfer-list-body.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import ScrollArea from "$lib/components/ui/scroll-area/scroll-area.svelte";
+	import type { Snippet } from "svelte";
+
+	type Props = {
+		children: Snippet;
+		class?: string;
+	};
+
+	let { children, class: _class = "" }: Props = $props();
+</script>
+
+<ScrollArea
+	class={`flex flex-col border border-t-0 p-1 h-48 rounded-b-md ${_class}`}
+>
+	{@render children()}
+</ScrollArea>

--- a/ui/src/lib/components/ui/transfer-list/transfer-list-container.svelte
+++ b/ui/src/lib/components/ui/transfer-list/transfer-list-container.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+	import type { Snippet } from "svelte";
+
+	type Props = {
+		children: Snippet;
+		class?: string;
+	};
+
+	let { children, class: _class }: Props = $props();
+</script>
+
+<div class={cn("w-full", _class)}>
+	{@render children()}
+</div>

--- a/ui/src/lib/components/ui/transfer-list/transfer-list-core.svelte.ts
+++ b/ui/src/lib/components/ui/transfer-list/transfer-list-core.svelte.ts
@@ -1,0 +1,102 @@
+import { SvelteSet } from "svelte/reactivity";
+
+export type ItemFilterPredicate<T> = (item: T, search: string) => boolean;
+
+export type TransferListCoreConfig<T> = {
+	filterPredicate: ItemFilterPredicate<T>;
+	initialSource: T[];
+	initialTarget?: T[];
+};
+
+export class TransferListCore<T> {
+	source: T[] = $state([]);
+	target: T[] = $state([]);
+
+	selectedSourceItems: SvelteSet<T> = $state(new SvelteSet());
+	selectedTargetItems: SvelteSet<T> = $state(new SvelteSet());
+
+	sourceSearchQuery: string = $state("");
+	targetSearchQuery: string = $state("");
+
+	private filterPredicate: ItemFilterPredicate<T>;
+
+	constructor({
+		filterPredicate: filterFn,
+		initialSource,
+		initialTarget = []
+	}: TransferListCoreConfig<T>) {
+		this.source = initialSource;
+		this.target = initialTarget;
+		this.filterPredicate = filterFn;
+	}
+
+	isSelected(side: "source" | "target", item: T): boolean {
+		return (side === "source" ? this.selectedSourceItems : this.selectedTargetItems).has(item);
+	}
+	hasSourceSelection() {
+		return this.selectedSourceItems.size > 0;
+	}
+	hasTargetSelection() {
+		return this.selectedTargetItems.size > 0;
+	}
+
+	get filteredSource(): T[] {
+		if (!this.sourceSearchQuery) return this.source;
+		return this.source.filter((item) => this.filterPredicate(item, this.sourceSearchQuery));
+	}
+
+	get filteredTarget(): T[] {
+		if (!this.targetSearchQuery) return this.target;
+		return this.target.filter((item) => this.filterPredicate(item, this.targetSearchQuery));
+	}
+
+	// Search handling
+	updateSearch(side: "source" | "target", query: string): void {
+		if (side === "source") {
+			this.sourceSearchQuery = query;
+		} else {
+			this.targetSearchQuery = query;
+		}
+	}
+
+	clearSearch(side: "source" | "target"): void {
+		this.updateSearch(side, "");
+	}
+
+	// Selection handling
+	toggleSelection(side: "source" | "target", item: T): void {
+		const selectionSet = side === "source" ? this.selectedSourceItems : this.selectedTargetItems;
+		if (selectionSet.has(item)) {
+			selectionSet.delete(item);
+		} else {
+			selectionSet.add(item);
+		}
+	}
+
+	// Transfer operations
+	transferAll(fromSide: "source" | "target"): void {
+		if (fromSide === "source") {
+			this.target = [...this.target, ...this.source];
+			this.source = [];
+			this.selectedSourceItems.clear();
+		} else {
+			this.source = [...this.source, ...this.target];
+			this.target = [];
+			this.selectedTargetItems.clear();
+		}
+	}
+
+	transferSelected(fromSide: "source" | "target"): void {
+		if (fromSide === "source") {
+			const selectedItems = Array.from(this.selectedSourceItems);
+			this.target = [...this.target, ...selectedItems];
+			this.source = this.source.filter((item) => !this.selectedSourceItems.has(item));
+			this.selectedSourceItems.clear();
+		} else {
+			const selectedItems = Array.from(this.selectedTargetItems);
+			this.source = [...this.source, ...selectedItems];
+			this.target = this.target.filter((item) => !this.selectedTargetItems.has(item));
+			this.selectedTargetItems.clear();
+		}
+	}
+}

--- a/ui/src/lib/components/ui/transfer-list/transfer-list-item.svelte
+++ b/ui/src/lib/components/ui/transfer-list/transfer-list-item.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+	import Checkbox from "$lib/components/ui/checkbox/checkbox.svelte";
+	import type { Snippet } from "svelte";
+	import type { TransferListCore } from "./transfer-list-core.svelte.js";
+
+	type Props = {
+		side: "source" | "target";
+		core: TransferListCore<any>;
+		row: any;
+		onclick?: () => void;
+		withCheckbox?: boolean;
+		children: Snippet;
+	};
+
+	let {
+		core,
+		side,
+		row,
+		withCheckbox = true,
+		onclick = () => core.toggleSelection(side, row),
+		children
+	}: Props = $props();
+</script>
+
+<button
+	{onclick}
+	class="flex w-full cursor-pointer items-center gap-2 p-2 hover:bg-muted"
+>
+	{#if withCheckbox}
+		<Checkbox checked={core?.isSelected(side, row)} />
+	{/if}
+	{@render children()}
+</button>

--- a/ui/src/lib/components/ui/transfer-list/transfer-list-title.svelte
+++ b/ui/src/lib/components/ui/transfer-list/transfer-list-title.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+	import type { Snippet } from "svelte";
+
+	type Props = {
+		title: string;
+		class?: string;
+		children?: Snippet;
+	};
+
+	let { title, class: _class, children }: Props = $props();
+</script>
+
+{#if children}
+	{@render children()}
+{:else}
+	<p class={cn("pb-1 font-semibold", _class)}>{title}</p>
+{/if}

--- a/ui/src/lib/components/ui/transfer-list/transfer-list-toolbar.svelte
+++ b/ui/src/lib/components/ui/transfer-list/transfer-list-toolbar.svelte
@@ -1,0 +1,125 @@
+<script lang="ts">
+	import Button from "$lib/components/ui/button/button.svelte";
+	import Input from "$lib/components/ui/input/input.svelte";
+	import ChevronLeft from "@lucide/svelte/icons/chevron-left";
+	import ChevronRight from "@lucide/svelte/icons/chevron-right";
+	import ChevronsLeft from "@lucide/svelte/icons/chevrons-left";
+	import ChevronsRight from "@lucide/svelte/icons/chevrons-right";
+	import type { Snippet } from "svelte";
+	import type { TransferListCore } from "./transfer-list-core.svelte.js";
+	import { cn } from "$lib/utils.js";
+
+	type Props = {
+		core: TransferListCore<any>;
+		children?: Snippet;
+
+		class?: {
+			container?: string;
+			input?: string;
+			moveAllIcon?: string;
+			moveSelectedIcon?: string;
+		};
+
+		variant: "source" | "target";
+
+		moveSelectedIconSlot?: Snippet;
+		moveAllIconSlot?: Snippet;
+		inputSlot?: Snippet;
+
+		inputPlaceholder?: string;
+	};
+
+	let {
+		children,
+		core,
+		variant,
+		inputPlaceholder = "Search...",
+		moveAllIconSlot,
+		moveSelectedIconSlot,
+		inputSlot,
+		class: _class
+	}: Props = $props();
+</script>
+
+<div class="flex">
+	{#if children}
+		{@render children()}
+	{:else if variant === "source"}
+		{#if inputSlot}
+			{@render inputSlot()}
+		{:else}
+			<Input
+				class={cn("rounded-none rounded-tl-md focus-visible:ring-0", _class?.input)}
+				oninput={(e) => core.updateSearch("source", e.currentTarget.value)}
+				placeholder={inputPlaceholder}
+			/>
+		{/if}
+
+		<Button
+			variant="outline"
+			aria-label="Move selected to pool"
+			class={cn(
+				"rounded-none border-x-0 disabled:opacity-100",
+				!core.hasSourceSelection() && "cursor-not-allowed text-muted-foreground",
+				_class?.moveSelectedIcon
+			)}
+			onclick={() => core.transferSelected("source")}
+		>
+			{#if moveSelectedIconSlot}
+				{@render moveSelectedIconSlot()}
+			{:else}
+				<ChevronRight />
+			{/if}
+		</Button>
+		<Button
+			variant="outline"
+			aria-label="Move all to pool"
+			class={cn("rounded-none rounded-tr-md", _class?.moveAllIcon)}
+			onclick={() => core.transferAll("source")}
+		>
+			{#if moveAllIconSlot}
+				{@render moveAllIconSlot()}
+			{:else}
+					<ChevronsRight />
+			{/if}
+		</Button>
+	{:else if variant === "target"}
+		<Button
+			variant="outline"
+			aria-label="Move all out of pool"
+			class={cn("rounded-none rounded-tl-md disabled:opacity-100", _class?.moveAllIcon)}
+			onclick={() => core.transferAll("target")}
+		>
+			{#if moveAllIconSlot}
+				{@render moveAllIconSlot()}
+			{:else}
+				<ChevronsLeft />
+			{/if}
+		</Button>
+		<Button
+			variant="outline"
+			aria-label="Move selected out of pool"
+			class={cn(
+				"rounded-none border-x-0 disabled:opacity-100",
+				!core.hasTargetSelection() && "cursor-not-allowed text-muted-foreground",
+				_class?.moveSelectedIcon
+			)}
+			onclick={() => core.transferSelected("target")}
+		>
+			{#if moveSelectedIconSlot}
+				{@render moveSelectedIconSlot()}
+			{:else}
+				<ChevronLeft />
+			{/if}
+		</Button>
+		{#if inputSlot}
+			{@render inputSlot()}
+		{:else}
+			<Input
+				class={cn("rounded-none rounded-tr-md focus-visible:ring-0", _class?.input)}
+				oninput={(e) => core.updateSearch("target", e.currentTarget.value)}
+				placeholder={inputPlaceholder}
+			/>
+		{/if}
+	{/if}
+</div>

--- a/ui/src/lib/components/ui/transfer-list/transfer-list.svelte
+++ b/ui/src/lib/components/ui/transfer-list/transfer-list.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+	import type { Snippet } from "svelte";
+	import { cn } from "$lib/utils.js";
+
+	type Props = {
+		direction?: "horizontal" | "vertical";
+		children: Snippet;
+		class?: string;
+	};
+
+	let { direction = "horizontal", children, class: _class = "" }: Props = $props();
+</script>
+
+<div
+	class={cn(
+		"flex w-full gap-4 ",
+		direction === "horizontal" ? "flex-row" : "flex-col",
+		_class
+	)}
+>
+	{@render children()}
+</div>

--- a/ui/src/routes/drafts/[id]/+page.svelte
+++ b/ui/src/routes/drafts/[id]/+page.svelte
@@ -48,6 +48,7 @@
 		TabsList,
 		TabsTrigger
 	} from '$lib/components/ui/tabs/index.js';
+	import * as TransferList from '$lib/components/ui/transfer-list/index.js';
 
 	const id = () => page.params.id as string;
 
@@ -71,9 +72,10 @@
 	let initializing = $state(false);
 	let actionError = $state('');
 
-	// Available players configuration.
-	let playerToAdd = $state('');
-	let addingPlayer = $state(false);
+	// Available players configuration (transfer-list PoC). The core holds the
+	// in-memory source/target lists and selection; we persist diffs on save.
+	let transferCore = $state<TransferList.Core<User> | null>(null);
+	let savingPlayers = $state(false);
 
 	// Rating cutoffs configuration. Kept as an array of entry objects so each
 	// input can bind to a stable item property (binding to a dynamic object key
@@ -120,6 +122,18 @@
 			availablePlayers = availableList.filter((a) => a.draft_id === draftData.id);
 			ratingCutoffs = cutoffList.filter((c) => c.draft_id === draftData.id);
 			picks = pickList.filter((p) => p.draft_id === draftData.id);
+
+			// Seed the transfer list: source = every user not already in the
+			// pool, target = the currently available players.
+			const inPool = new Set(availablePlayers.map((a) => a.player_id));
+			transferCore = new TransferList.Core<User>({
+				initialSource: users.filter((u) => !inPool.has(u.id)),
+				initialTarget: availablePlayers
+					.map((a) => users.find((u) => u.id === a.player_id))
+					.filter((u): u is User => u !== undefined),
+				filterPredicate: (u, search) =>
+					fullName(u).toLowerCase().includes(search.toLowerCase())
+			});
 
 			// Seed the cutoff inputs from the existing rows.
 			cutoffEntries = ratingsToConfigure().map((rating) => {
@@ -179,28 +193,31 @@
 
 	// --- Available players ---
 
-	async function handleAddPlayer() {
+	// Persists the transfer-list state: adds players that moved into the
+	// target, removes players that moved back to the source.
+	async function handleSavePlayers() {
 		actionError = '';
-		if (!playerToAdd) return;
-		addingPlayer = true;
+		if (!transferCore) return;
+		const poolIds = new Set(availablePlayers.map((a) => a.player_id));
+		const targetIds = new Set(transferCore.target.map((u) => u.id));
+		const toAdd = transferCore.target
+			.filter((u) => !poolIds.has(u.id))
+			.map((u) => u.id);
+		const toRemove = availablePlayers.filter((a) => !targetIds.has(a.player_id));
+		if (toAdd.length === 0 && toRemove.length === 0) return;
+		savingPlayers = true;
 		try {
-			await assignDraftablePlayers(id(), [playerToAdd]);
-			playerToAdd = '';
+			if (toAdd.length > 0) {
+				await assignDraftablePlayers(id(), toAdd);
+			}
+			for (const row of toRemove) {
+				await deleteDraftAvailablePlayer(row.id);
+			}
 			await load();
 		} catch (e) {
-			actionError = e instanceof Error ? e.message : 'Failed to add player';
+			actionError = e instanceof Error ? e.message : 'Failed to save players';
 		} finally {
-			addingPlayer = false;
-		}
-	}
-
-	async function handleRemovePlayer(row: DraftAvailablePlayer) {
-		actionError = '';
-		try {
-			await deleteDraftAvailablePlayer(row.id);
-			await load();
-		} catch (e) {
-			actionError = e instanceof Error ? e.message : 'Failed to remove player';
+			savingPlayers = false;
 		}
 	}
 
@@ -455,40 +472,60 @@
 			</CardHeader>
 			<CardContent>
 				<p class="text-sm text-muted-foreground">
-					Add the players who are eligible to be drafted. Keep the count even-ish across
-					teams so each team ends up with a fair roster.
+					Move players into the pool to make them eligible to be drafted. Keep the count
+					even-ish across teams so each team ends up with a fair roster. Changes apply when
+					you save.
 				</p>
-				<div class="mt-4 flex flex-col gap-2">
-					<Label for="player-select">Player</Label>
-					<div class="flex gap-2">
-						<NativeSelect id="player-select" bind:value={playerToAdd} class="w-full">
-							<NativeSelectOption value="" disabled>Select a player…</NativeSelectOption>
-							{#each userOptions(availablePlayers.map((a) => a.player_id)) as u}
-								<NativeSelectOption value={u.id}>{fullName(u)}</NativeSelectOption>
-							{/each}
-						</NativeSelect>
-						<Button type="button" variant="outline" onclick={handleAddPlayer} disabled={addingPlayer}>
-							Add player
-						</Button>
+				{#if transferCore}
+					<div class="mt-4">
+						<TransferList.Root direction="horizontal">
+							<TransferList.Container>
+								<TransferList.Title title="All players" />
+								<TransferList.Toolbar
+									variant="source"
+									core={transferCore}
+									inputPlaceholder="Search players..."
+								/>
+								<TransferList.Body>
+									{#each transferCore.filteredSource as row (row.id)}
+										<TransferList.Item side="source" {row} core={transferCore}>
+											{fullName(row)}
+										</TransferList.Item>
+									{/each}
+								</TransferList.Body>
+							</TransferList.Container>
+							<TransferList.Container>
+								<TransferList.Title title="Available for draft" />
+								<TransferList.Toolbar
+									variant="target"
+									core={transferCore}
+									inputPlaceholder="Search players..."
+								/>
+								<TransferList.Body>
+									{#each transferCore.filteredTarget as row (row.id)}
+										<TransferList.Item side="target" {row} core={transferCore}>
+											{fullName(row)}
+										</TransferList.Item>
+									{/each}
+								</TransferList.Body>
+							</TransferList.Container>
+						</TransferList.Root>
+						<div class="mt-4 flex items-center gap-3">
+							<Button
+								type="button"
+								onclick={handleSavePlayers}
+								disabled={savingPlayers}
+							>
+								{savingPlayers ? 'Saving...' : 'Save players'}
+							</Button>
+							<span class="text-sm text-muted-foreground">
+								{transferCore.target.length} player{transferCore.target.length === 1 ? '' : 's'}
+								in pool
+							</span>
+						</div>
 					</div>
-				</div>
-				{#if availablePlayers.length === 0}
-					<p class="mt-4 text-sm text-muted-foreground">No available players yet.</p>
 				{:else}
-					<ul class="mt-4 flex flex-col gap-2">
-						{#each availablePlayers as player}
-							<li class="flex items-center justify-between rounded-lg border px-3 py-2 text-sm">
-								<span>{userName(player.player_id)}</span>
-								<Button
-									type="button"
-									variant="ghost"
-									onclick={() => handleRemovePlayer(player)}
-								>
-									Remove
-								</Button>
-							</li>
-						{/each}
-					</ul>
+					<p class="mt-4 text-sm text-muted-foreground">Loading players...</p>
 				{/if}
 			</CardContent>
 		</Card>


### PR DESCRIPTION
## Summary
Vendor the shadcn-svelte [transfer-list](https://shadcn-svelte-enhancements.tzezar.pl/components/transfer-list) dual-list component (same author as the React one on shadcn-form.com) and use it to manage the draft's available players. Replaces the single-select "Add player" + per-row Remove list with a select-many transfer panel.

## Changes
- Add `checkbox` + `scroll-area` shadcn primitives (transfer-list dependencies) via the CLI.
- Vendor `transfer-list` under `ui/src/lib/components/ui/transfer-list/`. Adapted icon imports to `@lucide/svelte` (repo convention) and added `aria-label`s to the four transfer buttons.
- Wire it into the **Available players** tab of `routes/drafts/[id]/+page.svelte`:
  - Source = users not in the pool; Target = current available players.
  - Selections/moves are in-memory on the `TransferListCore`; a **Save players** button diffs target vs. pool and persists via existing `assignDraftablePlayers` / `deleteDraftAvailablePlayer`, then reloads.
- Update `draft-setup.spec.ts` to drive the new transfer UI.

## Verification
- `npm run check`: 0 errors.
- `make e2e`: 22 passed, run twice (full parallel suite, incl. the updated draft-setup spec).

## Notes
PoC — the explicit "Save players" step could be replaced with persist-on-move if preferred.