### PR TITLE
DB: Organization + OrganizationMember tables and CrudRecord models

### DIFF
--- a/database/migrations/0050_create_organizations.sql
+++ b/database/migrations/0050_create_organizations.sql
@@ -1,0 +1,18 @@
+-- 0050_create_organizations.sql
+-- The organization table, matching the Organization record shape
+-- (model/organization.go).
+-- Table name equals record.Type() ("organization").
+--   id         -> OrganizationId hex TEXT primary key
+--   user_id    -> owner UserId hex TEXT
+--   name       -> TEXT
+--   created_at -> RFC3339 TEXT
+--   updated_at -> RFC3339 TEXT
+--   deleted_at -> RFC3339 TEXT, nullable (*time.Time)
+CREATE TABLE organization (
+    id         TEXT PRIMARY KEY,   -- OrganizationId hex string
+    user_id    TEXT NOT NULL,      -- owner UserId hex string
+    name       TEXT NOT NULL,      -- unique organization name
+    created_at TEXT NOT NULL,      -- RFC3339
+    updated_at TEXT NOT NULL,      -- RFC3339
+    deleted_at TEXT                -- RFC3339, nullable
+);

--- a/database/migrations/0051_create_organization_members.sql
+++ b/database/migrations/0051_create_organization_members.sql
@@ -1,0 +1,18 @@
+-- 0051_create_organization_members.sql
+-- The organization_member join table, matching the OrganizationMember
+-- record shape (model/organization_member.go).
+-- Table name equals record.Type() ("organization_member").
+--   id              -> RecordId hex TEXT primary key
+--   organization_id -> OrganizationId hex TEXT
+--   user_id         -> UserId hex TEXT
+--   created_at      -> RFC3339 TEXT
+--   updated_at      -> RFC3339 TEXT
+--   deleted_at      -> RFC3339 TEXT, nullable (*time.Time)
+CREATE TABLE organization_member (
+    id              TEXT PRIMARY KEY,   -- RecordId hex string
+    organization_id TEXT NOT NULL,      -- OrganizationId hex string
+    user_id         TEXT NOT NULL,      -- UserId hex string
+    created_at      TEXT NOT NULL,      -- RFC3339
+    updated_at      TEXT NOT NULL,      -- RFC3339
+    deleted_at      TEXT                -- RFC3339, nullable
+);

--- a/database/sqlite_organization_roundtrip_test.go
+++ b/database/sqlite_organization_roundtrip_test.go
@@ -1,0 +1,164 @@
+package database_test
+
+import (
+	"context"
+	"testing"
+
+	"intraclub/database"
+	"intraclub/model"
+)
+
+// TestOrganizationRoundTrip verifies field-by-field losslessness for the
+// Organization model across Create -> GetOne/GetAll -> Update -> Delete on the
+// SQLite provider, confirming the `organization` table exists post-migration.
+func TestOrganizationRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	p := newSqliteProvider(t)
+
+	owner, err := database.CreateOne(ctx, p, &model.User{
+		FirstName:   "Dana",
+		LastName:    "Lee",
+		PhoneNumber: "7705552222",
+		Email:       "dana@example.com",
+	})
+	if err != nil {
+		t.Fatalf("CreateOne(user): %v", err)
+	}
+
+	created, err := database.CreateOne(ctx, p, &model.Organization{
+		UserId: owner.ID,
+		Name:   "Martin's Landing Men",
+	})
+	if err != nil {
+		t.Fatalf("CreateOne(organization): %v", err)
+	}
+	org := created
+	if org.GetId() == database.InvalidRecordId {
+		t.Fatal("CreateOne(organization) did not assign an OrganizationId")
+	}
+	if org.GetOwner() != owner.ID {
+		t.Fatalf("organization owner = %v, want %v", org.GetOwner(), owner.ID)
+	}
+
+	// GetOne round-trips every field.
+	got, exists, err := database.GetOneById(ctx, p, &model.Organization{}, org.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(organization): %v", err)
+	}
+	if !exists {
+		t.Fatal("GetOneById(organization): record not found")
+	}
+	if got.Name != org.Name || got.UserId != org.UserId {
+		t.Fatalf("organization round-trip mismatch:\n  got  %+v\n  want %+v", got, org)
+	}
+
+	// GetAll returns the record with matching fields.
+	all, err := database.GetAll[*model.Organization](ctx, p)
+	if err != nil {
+		t.Fatalf("GetAll(organization): %v", err)
+	}
+	if len(all) != 1 || all[0].ID != org.ID {
+		t.Fatalf("GetAll(organization): got %d records, want 1 matching the created org", len(all))
+	}
+
+	// Update persists changes.
+	org.Name = "Martin's Landing Ladies"
+	if err := database.UpdateOne(ctx, p, org); err != nil {
+		t.Fatalf("UpdateOne(organization): %v", err)
+	}
+	got2, _, err := database.GetOneById(ctx, p, &model.Organization{}, org.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(organization) after update: %v", err)
+	}
+	if got2.Name != "Martin's Landing Ladies" {
+		t.Fatalf("organization update not persisted, got %+v", got2)
+	}
+
+	// Delete removes the record.
+	if _, _, err := database.DeleteOneById(ctx, p, &model.Organization{}, org.GetId()); err != nil {
+		t.Fatalf("DeleteOneById(organization): %v", err)
+	}
+	_, exists, err = database.GetOneById(ctx, p, &model.Organization{}, org.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(organization) after delete: %v", err)
+	}
+	if exists {
+		t.Fatal("organization should have been deleted")
+	}
+}
+
+// TestOrganizationMemberRoundTrip verifies that the `organization_member`
+// join table exists post-migration and round-trips through the SQLite provider.
+func TestOrganizationMemberRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	p := newSqliteProvider(t)
+
+	owner, err := database.CreateOne(ctx, p, &model.User{
+		FirstName:   "Erin",
+		LastName:    "Ng",
+		PhoneNumber: "6785553333",
+		Email:       "erin@example.com",
+	})
+	if err != nil {
+		t.Fatalf("CreateOne(owner): %v", err)
+	}
+	member, err := database.CreateOne(ctx, p, &model.User{
+		FirstName:   "Frank",
+		LastName:    "Wu",
+		PhoneNumber: "6785554444",
+		Email:       "frank@example.com",
+	})
+	if err != nil {
+		t.Fatalf("CreateOne(member): %v", err)
+	}
+	org, err := database.CreateOne(ctx, p, &model.Organization{
+		UserId: owner.ID,
+		Name:   "Riverside Racquets",
+	})
+	if err != nil {
+		t.Fatalf("CreateOne(organization): %v", err)
+	}
+
+	created, err := database.CreateOne(ctx, p, &model.OrganizationMember{
+		OrganizationId: org.ID,
+		UserId:         member.ID,
+	})
+	if err != nil {
+		t.Fatalf("CreateOne(organization_member): %v", err)
+	}
+	m := created
+	if m.GetId() == database.InvalidRecordId {
+		t.Fatal("CreateOne(organization_member) did not assign an ID")
+	}
+
+	got, exists, err := database.GetOneById(ctx, p, &model.OrganizationMember{}, m.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(organization_member): %v", err)
+	}
+	if !exists {
+		t.Fatal("GetOneById(organization_member): record not found")
+	}
+	if got.OrganizationId != m.OrganizationId || got.UserId != m.UserId {
+		t.Fatalf("organization_member round-trip mismatch:\n  got  %+v\n  want %+v", got, m)
+	}
+
+	// Duplicate membership must be rejected through the provider.
+	if _, err := database.CreateOne(ctx, p, &model.OrganizationMember{
+		OrganizationId: org.ID,
+		UserId:         member.ID,
+	}); err == nil {
+		t.Fatal("expected error on duplicate organization membership")
+	}
+
+	// Delete removes the record.
+	if _, _, err := database.DeleteOneById(ctx, p, &model.OrganizationMember{}, m.GetId()); err != nil {
+		t.Fatalf("DeleteOneById(organization_member): %v", err)
+	}
+	_, exists, err = database.GetOneById(ctx, p, &model.OrganizationMember{}, m.GetId())
+	if err != nil {
+		t.Fatalf("GetOneById(organization_member) after delete: %v", err)
+	}
+	if exists {
+		t.Fatal("organization_member should have been deleted")
+	}
+}

--- a/model/organization.go
+++ b/model/organization.go
@@ -1,0 +1,148 @@
+package model
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"intraclub/database"
+)
+
+// OrganizationId is a wrapper around the common.RecordId type
+// which refers specifically to the primary key for the Organization
+// struct. Other records referring to this type (as opposed to
+// common.RecordId) allows better code navigation, enabling us
+// to automatically determine which structs depend on Organization.
+type OrganizationId database.RecordId
+
+func (id OrganizationId) RecordId() database.RecordId {
+	return database.RecordId(id)
+}
+
+func (id OrganizationId) String() string {
+	return id.RecordId().String()
+}
+
+func (id OrganizationId) MarshalJSON() ([]byte, error) {
+	return id.RecordId().MarshalJSON()
+}
+
+func (id *OrganizationId) UnmarshalJSON(bytes []byte) error {
+	rid := id.RecordId()
+	if err := (*database.RecordId)(&rid).UnmarshalJSON(bytes); err != nil {
+		return err
+	}
+	*id = OrganizationId(rid)
+	return nil
+}
+
+// Organization is an evergreen, flat roster of registered users grouped
+// together season-over-season (e.g. "Martin's Landing Men"). It is owned
+// by the creating UserId, but is publicly accessible to all users so that
+// memberships can be read by anyone.
+//
+// An Organization must have a non-empty Name, which is unique across all
+// organizations (to prevent duplicate records). The membership list is a
+// flat list of User records via the organization_member join table.
+type Organization struct {
+	ID        OrganizationId `json:"id"`       // Unique ID for this Organization
+	UserId    database.UserId `json:"user_id"` // ID of the User who owns the record
+	Name      string          `json:"name"`    // Unique name for the Organization
+	CreatedAt time.Time       `json:"created_at"`
+	UpdatedAt time.Time       `json:"updated_at"`
+	DeletedAt *time.Time      `json:"deleted_at"`
+}
+
+func (o *Organization) GetOwner() database.UserId {
+	return o.UserId
+}
+
+func (o *Organization) UniquenessEquivalent(other *Organization) error {
+	if o.Name == other.Name {
+		return errors.New("duplicate record for organization name")
+	}
+	return nil
+}
+
+// NewOrganization allocates a new *Organization record. Calling this function
+// (as opposed to doing e.g. `v := &Organization{}`) allows us to easily
+// navigate to all the points in the code which allocate a new Organization.
+func NewOrganization() *Organization {
+	return &Organization{}
+}
+
+// SetOwner assigns the owner of this common.CrudRecord
+func (o *Organization) SetOwner(userId database.UserId) {
+	o.UserId = userId
+}
+
+// EditableBy returns a list of common.UserId values who are allowed
+// to edit (or possibly delete) this common.CrudRecord
+func (o *Organization) EditableBy(ctx context.Context, db database.Provider) []database.UserId {
+	// This record can only be edited by the owner (mirrors Facility).
+	return database.SysAdminAndUsers(o.UserId)
+}
+
+// AccessibleTo returns a list of common.UserId values who are allowed
+// to view this record (in this instance, all users, regardless of their
+// authentication status)
+func (o *Organization) AccessibleTo(ctx context.Context, db database.Provider) []database.UserId {
+	return database.AccessibleToEveryone
+}
+
+// Type is the database table name for this record
+func (o *Organization) Type() string {
+	return "organization"
+}
+
+// GetId returns a unique ID for this record
+func (o *Organization) GetId() database.RecordId {
+	return o.ID.RecordId()
+}
+
+// SetId sets a unique ID for this record
+func (o *Organization) SetId(id database.RecordId) {
+	o.ID = OrganizationId(id)
+}
+
+// StaticallyValid validates this record against the record-specific
+// business logic rules without requiring the caller to provide a
+// common.DatabaseProvider for database validation
+func (o *Organization) StaticallyValid() error {
+	o.Name = strings.TrimSpace(o.Name)
+
+	if o.Name == "" {
+		return errors.New("organization name is empty")
+	}
+	return nil
+}
+
+// DynamicallyValid validates this record against the record-specific
+// business logic rules using a common.DatabaseProvider to validate e.g.
+// individual ID values for existence, ownership constraints, etc.
+func (o *Organization) DynamicallyValid(ctx context.Context, db database.Provider) error {
+	return nil
+}
+
+// Timestamps returns the create, update and delete timestamps for this
+// Organization record.
+func (o *Organization) Timestamps() (time.Time, time.Time, *time.Time) {
+	return o.CreatedAt, o.UpdatedAt, o.DeletedAt
+}
+
+func (o *Organization) SetCreatedAt(createdAt time.Time) {
+	o.CreatedAt = createdAt
+}
+
+func (o *Organization) SetUpdatedAt(updatedAt time.Time) {
+	o.UpdatedAt = updatedAt
+}
+
+func (o *Organization) SetDeletedAt(deletedAt *time.Time) {
+	o.DeletedAt = deletedAt
+}
+
+func (o *Organization) NewRecord() database.CrudRecord {
+	return new(Organization)
+}

--- a/model/organization_member.go
+++ b/model/organization_member.go
@@ -1,0 +1,116 @@
+package model
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"intraclub/database"
+)
+
+// OrganizationMember is a join table record that links a User to an
+// Organization's evergreen membership roster. Membership is flat (no roles),
+// and a single (Organization, User) pair may appear at most once.
+type OrganizationMember struct {
+	ID             database.RecordId `json:"id"`
+	OrganizationId OrganizationId    `json:"organization_id"`
+	UserId         database.UserId   `json:"user_id"`
+	CreatedAt      time.Time         `json:"created_at"`
+	UpdatedAt      time.Time         `json:"updated_at"`
+	DeletedAt      *time.Time        `json:"deleted_at"`
+}
+
+// GetOwner returns InvalidUserId as OrganizationMember has no specific owner.
+func (m *OrganizationMember) GetOwner() database.UserId {
+	return database.InvalidUserId
+}
+
+// SetOwner is a no-op as OrganizationMember has no specific owner.
+func (m *OrganizationMember) SetOwner(userId database.UserId) {}
+
+// AccessibleTo returns everyone as OrganizationMember records are public.
+func (m *OrganizationMember) AccessibleTo(ctx context.Context, db database.Provider) []database.UserId {
+	return database.AccessibleToEveryone
+}
+
+func (m *OrganizationMember) EditableBy(ctx context.Context, db database.Provider) []database.UserId {
+	// Memberships may be edited by the organization's owner (or sysadmin).
+	// Resolve the owning user from the referenced organization.
+	org, exists, err := database.GetOneById(ctx, db, &Organization{}, m.OrganizationId.RecordId())
+	if err != nil || !exists {
+		return []database.UserId{database.SysAdminUserId}
+	}
+	return database.SysAdminAndUsers(org.UserId)
+}
+
+// Type returns the record type identifier for OrganizationMember.
+func (m *OrganizationMember) Type() string {
+	return "organization_member"
+}
+
+// GetId returns the unique identifier for this OrganizationMember record.
+func (m *OrganizationMember) GetId() database.RecordId {
+	return m.ID
+}
+
+// SetId sets the unique identifier for this OrganizationMember record.
+func (m *OrganizationMember) SetId(id database.RecordId) {
+	m.ID = id
+}
+
+// UniquenessEquivalent guards against a duplicate (organization, user)
+// membership pair.
+func (m *OrganizationMember) UniquenessEquivalent(other *OrganizationMember) error {
+	if m.OrganizationId == other.OrganizationId && m.UserId == other.UserId {
+		return fmt.Errorf("duplicate organization membership for organization %s user %s",
+			m.OrganizationId, m.UserId)
+	}
+	return nil
+}
+
+// StaticallyValid validates the record's field-level constraints without
+// requiring a database provider.
+func (m *OrganizationMember) StaticallyValid() error {
+	if m.OrganizationId == 0 {
+		return errors.New("organization member organization is empty")
+	}
+	if m.UserId == 0 {
+		return errors.New("organization member user is empty")
+	}
+	return nil
+}
+
+// DynamicallyValid verifies that both the referenced Organization and User
+// records exist.
+func (m *OrganizationMember) DynamicallyValid(ctx context.Context, db database.Provider) error {
+	if err := database.ExistsById(ctx, db, &Organization{}, m.OrganizationId.RecordId()); err != nil {
+		return err
+	}
+	if err := database.ExistsById(ctx, db, &User{}, m.UserId.RecordId()); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Timestamps returns the create, update and delete timestamps for this
+// OrganizationMember record.
+func (m *OrganizationMember) Timestamps() (time.Time, time.Time, *time.Time) {
+	return m.CreatedAt, m.UpdatedAt, m.DeletedAt
+}
+
+func (m *OrganizationMember) SetCreatedAt(createdAt time.Time) {
+	m.CreatedAt = createdAt
+}
+
+func (m *OrganizationMember) SetUpdatedAt(updatedAt time.Time) {
+	m.UpdatedAt = updatedAt
+}
+
+func (m *OrganizationMember) SetDeletedAt(deletedAt *time.Time) {
+	m.DeletedAt = deletedAt
+}
+
+func (m *OrganizationMember) NewRecord() database.CrudRecord {
+	return new(OrganizationMember)
+}

--- a/model/organization_member_test.go
+++ b/model/organization_member_test.go
@@ -1,0 +1,90 @@
+package model
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"intraclub/database"
+)
+
+func newStoredOrganizationMember(t *testing.T, db database.Provider, org *Organization, user *User) *OrganizationMember {
+	m := &OrganizationMember{
+		OrganizationId: org.ID,
+		UserId:         user.ID,
+	}
+	v, err := database.CreateOne(context.Background(), db, m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return v
+}
+
+func TestOrganizationMemberCrud(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	user := newStoredUser(t, db)
+	org := newStoredOrganization(t, db, user.ID)
+
+	member := newStoredOrganizationMember(t, db, org, user)
+	if member.GetId() == database.InvalidRecordId {
+		t.Fatal("CreateOne(organization_member) did not assign an ID")
+	}
+	if member.OrganizationId != org.ID || member.UserId != user.ID {
+		t.Fatalf("member mismatch: %+v", member)
+	}
+
+	// round-trip via GetOne
+	got, exists, err := database.GetOneById(context.Background(), db, &OrganizationMember{}, member.GetId())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exists {
+		t.Fatal("organization_member not found")
+	}
+	if got.OrganizationId != member.OrganizationId || got.UserId != member.UserId {
+		t.Fatalf("organization_member round-trip mismatch:\n  got  %+v\n  want %+v", got, member)
+	}
+}
+
+func TestOrganizationMemberDuplicateGuard(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	user := newStoredUser(t, db)
+	org := newStoredOrganization(t, db, user.ID)
+
+	newStoredOrganizationMember(t, db, org, user)
+
+	// Attempt to add the same (organization, user) pair again.
+	dup := &OrganizationMember{
+		OrganizationId: org.ID,
+		UserId:         user.ID,
+	}
+	_, err := database.CreateOne(context.Background(), db, dup)
+	if err == nil {
+		t.Fatal("expected error on duplicate organization membership")
+	}
+	fmt.Println(err)
+}
+
+func TestOrganizationMemberRequiresExistingRecords(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	user := newStoredUser(t, db)
+	org := newStoredOrganization(t, db, user.ID)
+
+	// Referencing a non-existent user should fail dynamic validation.
+	bad := &OrganizationMember{
+		OrganizationId: org.ID,
+		UserId:         database.InvalidUserId,
+	}
+	if err := bad.DynamicallyValid(context.Background(), db); err == nil {
+		t.Fatal("expected error when referenced user does not exist")
+	}
+
+	// Referencing a non-existent organization should fail dynamic validation.
+	bad2 := &OrganizationMember{
+		OrganizationId: OrganizationId(database.InvalidRecordId),
+		UserId:         user.ID,
+	}
+	if err := bad2.DynamicallyValid(context.Background(), db); err == nil {
+		t.Fatal("expected error when referenced organization does not exist")
+	}
+}

--- a/model/organization_test.go
+++ b/model/organization_test.go
@@ -1,0 +1,111 @@
+package model
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"intraclub/database"
+)
+
+func newStoredOrganization(t *testing.T, db database.Provider, owner database.UserId) *Organization {
+	org := NewOrganization()
+	org.UserId = owner
+	org.Name = fmt.Sprintf("Test organization %s", database.NewRecordId())
+	v, err := database.CreateOne(context.Background(), db, org)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return v
+}
+
+func copyOrganization(org *Organization) *Organization {
+	o := NewOrganization()
+	o.ID = org.ID
+	o.UserId = org.UserId
+	o.Name = org.Name
+	return o
+}
+
+func TestOrganizationCrud(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	user := newStoredUser(t, db)
+	org := newStoredOrganization(t, db, user.ID)
+	if org.GetId() == database.InvalidRecordId {
+		t.Fatal("CreateOne(organization) did not assign an ID")
+	}
+	if org.GetOwner() != user.ID {
+		t.Fatalf("organization owner = %v, want %v", org.GetOwner(), user.ID)
+	}
+
+	// do CRUD via the WithAccessControl construct
+	wac := database.WithAccessControl[*Organization]{Database: db, AccessControlUser: user.ID}
+
+	// copy organization to a new record and update in the database
+	o2 := copyOrganization(org)
+	o2.Name = "New name"
+	err := wac.UpdateOneById(context.Background(), o2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// verify that organization was updated
+	v, exists, err := wac.GetOneById(context.Background(), org, org.GetId())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exists {
+		t.Fatal("organization does not exist")
+	}
+	if v.Name != o2.Name {
+		t.Fatal("organization name does not match")
+	}
+
+	// delete organization
+	_, exists, err = wac.DeleteOneById(context.Background(), org, org.GetId())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exists {
+		t.Fatal("organization does not exist")
+	}
+}
+
+func TestOrganizationEditableByOwnerAndSysAdmin(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	user := newStoredUser(t, db)
+	sysAdmin := newSysAdmin(t, db)
+	org := newStoredOrganization(t, db, user.ID)
+
+	ownerWac := database.WithAccessControl[*Organization]{Database: db, AccessControlUser: user.ID}
+	if !ownerWac.CanUserEdit(org) {
+		t.Fatal("owner should be able to edit organization")
+	}
+
+	sysWac := database.WithAccessControl[*Organization]{Database: db, AccessControlUser: sysAdmin.ID}
+	if !sysWac.CanUserEdit(org) {
+		t.Fatal("sys admin should be able to edit organization")
+	}
+}
+
+func TestOrganizationNameAlreadyExists(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	user := newStoredUser(t, db)
+	org := newStoredOrganization(t, db, user.ID)
+
+	copied := copyOrganization(org)
+	copied.ID = OrganizationId(database.InvalidRecordId) // force a name conflict with old record
+	_, err := database.CreateOne(context.Background(), db, copied)
+	if err == nil {
+		t.Fatal("expected error on duplicate name")
+	}
+}
+
+func TestOrganizationEmptyNameInvalid(t *testing.T) {
+	org := NewOrganization()
+	org.UserId = database.InvalidUserId
+	org.Name = "   "
+	if err := org.StaticallyValid(); err == nil {
+		t.Fatal("expected error for blank organization name")
+	}
+}


### PR DESCRIPTION
Implements #144.

## Summary
Adds persistence for Organizations (evergreen flat rosters of registered users) and their members.

## Changes
- Migrations (auto-applied via embedded migrations):
  - `0050_create_organizations.sql` -> `organization` table (matches `Type() == "organization"`)
  - `0051_create_organization_members.sql` -> `organization_member` table (matches `Type() == "organization_member"`)
- `model/organization.go`: `OrganizationId` wrapper + `Organization` CrudRecord (owner via `UserId`, unique `Name`, timestamps incl. nullable `deleted_at`). Mirrors `facility.go`.
- `model/organization_member.go`: `OrganizationMember` join record (mirrors `season_team.go`/team_assignment), `DynamicallyValid` checks both `Organization` and `User` exist, duplicate (org, user) membership guard, `EditableBy` = sysadmin + org owner.
- Tests: `model/organization_test.go`, `model/organization_member_test.go`, and SQLite round-trip suite in `database/sqlite_organization_roundtrip_test.go`.

## Acceptance
- [x] `make tests` green (go test ./... + go vet)
- [x] `organization` and `organization_member` tables exist after migration and round-trip through the SQLite provider