### PR TITLE
API: Organization CRUD + owner-managed membership endpoints (#145)

### DIFF
--- a/api/api_route.go
+++ b/api/api_route.go
@@ -84,6 +84,14 @@ func (a Request[T]) ParseQuery(v any) error {
 	return json.Unmarshal(b, v)
 }
 
+// HTTPRequest returns the underlying net/http.Request for this API request.
+// It is primarily used by routes that need to read path parameters beyond the
+// standard :id parameter (e.g. nested resource routes such as
+// /organization/:id/members/:userId).
+func (a Request[T]) HTTPRequest() *http.Request {
+	return a.request
+}
+
 // RouteFamily is a typed helper struct to implement a common interface for
 // API endpoints. Most API routes should use common helpers such as CrudCommon,
 // but this helper can be used for, e.g., special one-off routes or routes

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ import (
 	"intraclub/route"
 	"intraclub/route/draft"
 	"intraclub/route/format"
+	"intraclub/route/organization"
 	"intraclub/route/ruleset"
 	"intraclub/route/user"
 
@@ -76,6 +77,10 @@ func main() {
 
 	facilities := api.NewCrudCommon(model.NewFacility, false, db)
 	facilities.HandleRouteTypes(rg, api.CrudWrapperFunctionAll...)
+
+	organizations := api.NewCrudCommon(model.NewOrganization, false, db)
+	organizations.HandleRouteTypes(rg, api.CrudWrapperFunctionAll...)
+	organization.RegisterRoutes(rg, db)
 
 	rg.GET("/score_counting_types", model.GetScoreCountingTypes)
 	scoringStructures := api.NewCrudCommon(model.NewScoringStructure, false, db)

--- a/model/organization_member.go
+++ b/model/organization_member.go
@@ -111,6 +111,14 @@ func (m *OrganizationMember) SetDeletedAt(deletedAt *time.Time) {
 	m.DeletedAt = deletedAt
 }
 
+// NewOrganizationMember allocates a new *OrganizationMember record. Calling
+// this function (as opposed to doing e.g. `v := &OrganizationMember{}`) allows
+// us to easily navigate to all the points in the code which allocate a new
+// OrganizationMember.
+func NewOrganizationMember() *OrganizationMember {
+	return &OrganizationMember{}
+}
+
 func (m *OrganizationMember) NewRecord() database.CrudRecord {
 	return new(OrganizationMember)
 }

--- a/route/organization/membership.go
+++ b/route/organization/membership.go
@@ -1,0 +1,221 @@
+package organization
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+
+	"intraclub/api"
+	"intraclub/database"
+	"intraclub/model"
+
+	"github.com/gin-gonic/gin"
+)
+
+// BaseRoute is the base API route for Organization records. It matches the
+// model's Type() ("organization").
+var BaseRoute = "/organization"
+
+// loadEditableOrganization fetches the Organization referenced by the request's
+// path ID and verifies the requesting user (from the token) is authorized to
+// edit it (owner / sysadmin). This mirrors the access-control pattern used by
+// the Draft and Format custom routes.
+func loadEditableOrganization[T database.Validatable](req api.Request[T]) (*model.Organization, int, error) {
+	if req.Token == nil {
+		return nil, http.StatusUnauthorized, errors.New("token is required")
+	}
+
+	org, err := database.GetExistingRecordById(req.Context, req.DatabaseProvider, &model.Organization{}, req.PathId)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+
+	wac := database.NewWithAccessControl[*model.Organization](req.Context, req.DatabaseProvider, req.Token.UserId)
+	if !wac.CanUserEdit(org) {
+		return nil, http.StatusForbidden, errors.New("not authorized to modify this organization")
+	}
+
+	return org, http.StatusOK, nil
+}
+
+// EmptyBody is used by routes that do not accept a request body.
+type EmptyBody struct{}
+
+func (b *EmptyBody) StaticallyValid() error {
+	return nil
+}
+
+// AddMemberBody is the request body for AddMember.
+type AddMemberBody struct {
+	// UserId is the registered User to add to the organization's membership.
+	UserId database.UserId `json:"user_id"`
+}
+
+// StaticallyValid ensures a user was provided.
+func (b *AddMemberBody) StaticallyValid() error {
+	if b.UserId == database.InvalidUserId {
+		return errors.New("user_id must not be empty")
+	}
+	return nil
+}
+
+// ListMembers returns the current membership roster (a flat list of registered
+// User records) for the organization referenced by the path ID. Any
+// authenticated user may list members, since organizations are AccessibleTo
+// everyone.
+type ListMembers struct{}
+
+func (c ListMembers) Path() (api.HttpMethod, string) {
+	return api.HttpMethodGet, api.AppendPathId(BaseRoute) + "/members"
+}
+
+func (c ListMembers) RequestBody() (*EmptyBody, bool) {
+	return &EmptyBody{}, false
+}
+
+func (c ListMembers) Handler(req api.Request[*EmptyBody]) (any, int, error) {
+	if req.Token == nil {
+		return nil, http.StatusUnauthorized, errors.New("token is required")
+	}
+
+	// verify the organization exists before listing its members
+	if _, err := database.GetExistingRecordById(req.Context, req.DatabaseProvider, &model.Organization{}, req.PathId); err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+
+	members, err := listMembers(req)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+
+	return gin.H{api.ResourceKey: members}, http.StatusOK, nil
+}
+
+// AddMember adds a registered User to the organization's membership roster.
+// Only the organization owner (or a sysadmin) may add members. Adding the same
+// user twice, or a non-existent user, is rejected.
+type AddMember struct{}
+
+func (c AddMember) Path() (api.HttpMethod, string) {
+	return api.HttpMethodPost, api.AppendPathId(BaseRoute) + "/members"
+}
+
+func (c AddMember) RequestBody() (*AddMemberBody, bool) {
+	return &AddMemberBody{}, true
+}
+
+func (c AddMember) Handler(req api.Request[*AddMemberBody]) (any, int, error) {
+	org, status, err := loadEditableOrganization(req)
+	if err != nil {
+		return nil, status, err
+	}
+
+	member := model.NewOrganizationMember()
+	member.OrganizationId = org.ID
+	member.UserId = req.Body.UserId
+
+	created, err := database.CreateOne(req.Context, req.DatabaseProvider, member)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+
+	return gin.H{api.ResourceKey: created}, http.StatusOK, nil
+}
+
+// RemoveMember removes a User from the organization's membership roster. Only
+// the organization owner (or a sysadmin) may remove members.
+type RemoveMember struct{}
+
+func (c RemoveMember) Path() (api.HttpMethod, string) {
+	return api.HttpMethodDelete, api.AppendPathId(BaseRoute) + "/members/:userId"
+}
+
+func (c RemoveMember) RequestBody() (*EmptyBody, bool) {
+	return &EmptyBody{}, false
+}
+
+func (c RemoveMember) Handler(req api.Request[*EmptyBody]) (any, int, error) {
+	org, status, err := loadEditableOrganization(req)
+	if err != nil {
+		return nil, status, err
+	}
+
+	userId, err := userIdFromPath(req)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+
+	membership, err := findMembership(req, org.ID, userId)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	if membership == nil {
+		return nil, http.StatusNotFound, errors.New("user is not a member of this organization")
+	}
+
+	deleted, exists, err := database.DeleteOneById(req.Context, req.DatabaseProvider, membership, membership.GetId())
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	if !exists {
+		return nil, http.StatusNotFound, errors.New("user is not a member of this organization")
+	}
+
+	return gin.H{api.ResourceKey: deleted}, http.StatusOK, nil
+}
+
+// listMembers fetches the current membership roster of the organization and
+// resolves each membership to its registered User record.
+func listMembers[T database.Validatable](req api.Request[T]) ([]*model.User, error) {
+	memberships, err := database.GetAllWhere[*model.OrganizationMember](req.Context, req.DatabaseProvider,
+		func(_ context.Context, m *model.OrganizationMember) bool { return m.OrganizationId == model.OrganizationId(req.PathId) })
+	if err != nil {
+		return nil, err
+	}
+
+	users := make([]*model.User, 0, len(memberships))
+	for _, m := range memberships {
+		user, exists, err := database.GetOneById(req.Context, req.DatabaseProvider, &model.User{}, m.UserId.RecordId())
+		if err != nil {
+			return nil, err
+		}
+		if !exists {
+			continue
+		}
+		users = append(users, user)
+	}
+	return users, nil
+}
+
+// findMembership looks up the OrganizationMember join record linking the given
+// organization and user, returning nil if it does not exist.
+func findMembership[T database.Validatable](req api.Request[T], orgID model.OrganizationId, userId database.UserId) (*model.OrganizationMember, error) {
+	memberships, err := database.GetAllWhere[*model.OrganizationMember](req.Context, req.DatabaseProvider,
+		func(_ context.Context, m *model.OrganizationMember) bool {
+			return m.OrganizationId == orgID && m.UserId == userId
+		})
+	if err != nil {
+		return nil, err
+	}
+	if len(memberships) == 0 {
+		return nil, nil
+	}
+	return memberships[0], nil
+}
+
+// userIdFromPath parses the :userId path parameter (the final segment of the
+// request path) into a database.UserId.
+func userIdFromPath[T database.Validatable](req api.Request[T]) (database.UserId, error) {
+	path := req.HTTPRequest().URL.Path
+	segments := strings.Split(strings.Trim(path, "/"), "/")
+	if len(segments) == 0 {
+		return database.InvalidUserId, errors.New("invalid :userId path parameter")
+	}
+	raw := segments[len(segments)-1]
+	rid, err := database.RecordIdFromString(raw)
+	if err != nil {
+		return database.InvalidUserId, errors.New("invalid :userId path parameter")
+	}
+	return database.UserId(rid), nil
+}

--- a/route/organization/membership_test.go
+++ b/route/organization/membership_test.go
@@ -1,0 +1,269 @@
+package organization
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/rand/v2"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"intraclub/api"
+	"intraclub/database"
+	"intraclub/model"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// test setup helpers (mirror route/draft/draft_test.go)
+// ---------------------------------------------------------------------------
+
+func newStoredUser(t *testing.T, db database.Provider) *model.User {
+	t.Helper()
+	user := model.NewUser()
+	user.Email = model.EmailAddress(fmt.Sprintf("user%d@email.com", rand.Uint64()))
+	user.FirstName = fmt.Sprintf("Test %d", rand.Uint64())
+	user.LastName = "User"
+	user.PhoneNumber = model.PhoneNumber(fmt.Sprintf("%d", 100_000_0000+rand.Uint32N(999_999_999)))
+	v, err := database.CreateOne(context.Background(), db, user)
+	require.NoError(t, err)
+	return v
+}
+
+// newTestRouter builds a gin engine with the organization CRUD + membership
+// surface registered (as in main.go) and the auth globals wired up so real
+// tokens validate.
+func newTestRouter(t *testing.T, db database.Provider) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	api.UserType = &model.User{}
+	database.SysAdminCheck = model.IsUserSystemAdministrator
+
+	router := gin.New()
+	group := router.Group("/api")
+
+	orgs := api.NewCrudCommon(model.NewOrganization, false, db)
+	orgs.HandleRouteTypes(group, api.CrudWrapperFunctionAll...)
+	RegisterRoutes(group, db)
+
+	return router
+}
+
+// testKeyOnce generates a single JWT keypair shared by every token minted in a
+// test process, so tokens issued by different helpers all verify.
+var (
+	testKeyOnce sync.Once
+	testPubKey  *ecdsa.PublicKey
+	testPrivKey *ecdsa.PrivateKey
+)
+
+// newToken returns a signed JWT for the given user ID without touching key
+// files on disk.
+func newToken(t *testing.T, userId database.UserId) string {
+	t.Helper()
+	testKeyOnce.Do(func() {
+		pub, priv, err := api.GenerateKeyPair()
+		require.NoError(t, err)
+		testPubKey = pub
+		testPrivKey = priv
+	})
+	api.JwtPublicKey = testPubKey
+	api.JwtPrivateKey = testPrivKey
+	token, err := api.GenerateToken(userId.RecordId())
+	require.NoError(t, err)
+	return token
+}
+
+// doJSON performs an authenticated HTTP request against the router.
+func doJSON(t *testing.T, router *gin.Engine, method, path string, body any, token string) *httptest.ResponseRecorder {
+	t.Helper()
+	var reader io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		require.NoError(t, err)
+		reader = bytes.NewReader(b)
+	}
+	req, err := http.NewRequest(method, path, reader)
+	require.NoError(t, err)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if token != "" {
+		req.Header.Set(api.AuthTokenHeaderValue, token)
+	}
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+// createOrgViaHTTP creates an organization through the CRUD route as the given
+// owner, returning its ID string.
+func createOrgViaHTTP(t *testing.T, router *gin.Engine, owner database.UserId, name string) string {
+	t.Helper()
+	w := doJSON(t, router, http.MethodPost, "/api/organization", map[string]any{
+		"name": name,
+	}, newToken(t, owner))
+	require.Equal(t, http.StatusOK, w.Code, "create org: %s", w.Body.String())
+
+	var resp struct {
+		Resource *model.Organization `json:"resource"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.NotNil(t, resp.Resource)
+	require.Equal(t, owner, resp.Resource.GetOwner())
+	return resp.Resource.ID.String()
+}
+
+// ---------------------------------------------------------------------------
+// Organization CRUD
+// ---------------------------------------------------------------------------
+
+func TestOrganizationCRUD(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	owner := newStoredUser(t, db)
+
+	orgID := createOrgViaHTTP(t, router, owner.ID, "Martin's Landing Men")
+
+	// GET one
+	w := doJSON(t, router, http.MethodGet, "/api/organization/"+orgID, nil, newToken(t, owner.ID))
+	require.Equal(t, http.StatusOK, w.Code)
+	var one struct {
+		Resource *model.Organization `json:"resource"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &one))
+	require.Equal(t, orgID, one.Resource.ID.String())
+	require.Equal(t, owner.ID, one.Resource.GetOwner())
+
+	// GET many
+	w = doJSON(t, router, http.MethodGet, "/api/organization", nil, newToken(t, owner.ID))
+	require.Equal(t, http.StatusOK, w.Code)
+	var many struct {
+		Resource []*model.Organization `json:"resource"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &many))
+	require.Len(t, many.Resource, 1)
+
+	// PUT update
+	w = doJSON(t, router, http.MethodPut, "/api/organization/"+orgID, map[string]any{
+		"id":   orgID,
+		"name": "Renamed Org",
+	}, newToken(t, owner.ID))
+	require.Equal(t, http.StatusOK, w.Code, "update org: %s", w.Body.String())
+
+	// DELETE
+	w = doJSON(t, router, http.MethodDelete, "/api/organization/"+orgID, nil, newToken(t, owner.ID))
+	require.Equal(t, http.StatusOK, w.Code)
+
+	w = doJSON(t, router, http.MethodGet, "/api/organization/"+orgID, nil, newToken(t, owner.ID))
+	require.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// ---------------------------------------------------------------------------
+// Membership endpoints
+// ---------------------------------------------------------------------------
+
+func TestMembershipAddListRemove(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	owner := newStoredUser(t, db)
+	orgID := createOrgViaHTTP(t, router, owner.ID, "Members Org")
+	memberA := newStoredUser(t, db)
+	memberB := newStoredUser(t, db)
+
+	// add memberA
+	w := doJSON(t, router, http.MethodPost, "/api/organization/"+orgID+"/members",
+		map[string]any{"user_id": memberA.ID.String()}, newToken(t, owner.ID))
+	require.Equal(t, http.StatusOK, w.Code, "add member: %s", w.Body.String())
+	var added struct {
+		Resource *model.OrganizationMember `json:"resource"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &added))
+	require.NotNil(t, added.Resource)
+	require.Equal(t, memberA.ID, added.Resource.UserId)
+
+	// add memberB
+	w = doJSON(t, router, http.MethodPost, "/api/organization/"+orgID+"/members",
+		map[string]any{"user_id": memberB.ID.String()}, newToken(t, owner.ID))
+	require.Equal(t, http.StatusOK, w.Code, "add member B: %s", w.Body.String())
+
+	// list members (any authenticated user)
+	w = doJSON(t, router, http.MethodGet, "/api/organization/"+orgID+"/members", nil, newToken(t, memberA.ID))
+	require.Equal(t, http.StatusOK, w.Code)
+	var listed struct {
+		Resource []*model.User `json:"resource"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &listed))
+	require.Len(t, listed.Resource, 2)
+
+	// remove memberA
+	w = doJSON(t, router, http.MethodDelete, "/api/organization/"+orgID+"/members/"+memberA.ID.String(), nil, newToken(t, owner.ID))
+	require.Equal(t, http.StatusOK, w.Code, "remove member: %s", w.Body.String())
+
+	w = doJSON(t, router, http.MethodGet, "/api/organization/"+orgID+"/members", nil, newToken(t, owner.ID))
+	require.Equal(t, http.StatusOK, w.Code)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &listed))
+	require.Len(t, listed.Resource, 1)
+	require.Equal(t, memberB.ID, listed.Resource[0].ID)
+}
+
+func TestMembershipAuthz(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	owner := newStoredUser(t, db)
+	orgID := createOrgViaHTTP(t, router, owner.ID, "Authz Org")
+	nonOwner := newStoredUser(t, db)
+	member := newStoredUser(t, db)
+
+	// non-owner cannot add
+	w := doJSON(t, router, http.MethodPost, "/api/organization/"+orgID+"/members",
+		map[string]any{"user_id": member.ID.String()}, newToken(t, nonOwner.ID))
+	require.Equal(t, http.StatusForbidden, w.Code)
+
+	// non-owner cannot remove (even though member was never added, authz check
+	// happens before membership lookup)
+	w = doJSON(t, router, http.MethodDelete, "/api/organization/"+orgID+"/members/"+member.ID.String(), nil, newToken(t, nonOwner.ID))
+	require.Equal(t, http.StatusForbidden, w.Code)
+
+	// unauthenticated cannot list
+	w = doJSON(t, router, http.MethodGet, "/api/organization/"+orgID+"/members", nil, "")
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestMembershipRejectsDuplicateAndUnknown(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	owner := newStoredUser(t, db)
+	orgID := createOrgViaHTTP(t, router, owner.ID, "Dup Org")
+	member := newStoredUser(t, db)
+
+	// unknown user rejected
+	unknownID := database.NewRecordId()
+	w := doJSON(t, router, http.MethodPost, "/api/organization/"+orgID+"/members",
+		map[string]any{"user_id": unknownID.String()}, newToken(t, owner.ID))
+	require.Equal(t, http.StatusBadRequest, w.Code, "unknown user: %s", w.Body.String())
+
+	// add member once
+	w = doJSON(t, router, http.MethodPost, "/api/organization/"+orgID+"/members",
+		map[string]any{"user_id": member.ID.String()}, newToken(t, owner.ID))
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// duplicate add rejected
+	w = doJSON(t, router, http.MethodPost, "/api/organization/"+orgID+"/members",
+		map[string]any{"user_id": member.ID.String()}, newToken(t, owner.ID))
+	require.Equal(t, http.StatusBadRequest, w.Code, "duplicate: %s", w.Body.String())
+
+	// removing a non-member returns 404
+	w = doJSON(t, router, http.MethodDelete, "/api/organization/"+orgID+"/members/"+member.ID.String(), nil, newToken(t, owner.ID))
+	require.Equal(t, http.StatusOK, w.Code)
+
+	w = doJSON(t, router, http.MethodDelete, "/api/organization/"+orgID+"/members/"+member.ID.String(), nil, newToken(t, owner.ID))
+	require.Equal(t, http.StatusNotFound, w.Code)
+}

--- a/route/organization/routes.go
+++ b/route/organization/routes.go
@@ -1,0 +1,27 @@
+package organization
+
+import (
+	"intraclub/api"
+	"intraclub/database"
+
+	"github.com/gin-gonic/gin"
+)
+
+// RegisterRoutes wires up the owner-managed Organization membership REST
+// surface. The Organization CRUD routes themselves are registered directly in
+// main.go via api.NewCrudCommon(model.NewOrganization, false, db) (mirroring
+// the facilities wiring); this function adds the custom membership endpoints.
+//
+// Each route is registered on its own RouteFamily because the routes use
+// different request-body types (ListMembers/RemoveMember take no body while
+// AddMember takes an AddMemberBody).
+func RegisterRoutes(e *gin.RouterGroup, db database.Provider) {
+	listFamily := api.RouteFamily[*EmptyBody]{DatabaseProvider: db}
+	listFamily.Handle(e, ListMembers{})
+
+	addFamily := api.RouteFamily[*AddMemberBody]{DatabaseProvider: db}
+	addFamily.Handle(e, AddMember{})
+
+	removeFamily := api.RouteFamily[*EmptyBody]{DatabaseProvider: db}
+	removeFamily.Handle(e, RemoveMember{})
+}


### PR DESCRIPTION
Closes #145

Implements Organization CRUD and owner-managed membership endpoints.

## Organization CRUD
- `GET /api/organization` -> `{ resource: Organization[] }`
- `GET /api/organization/:id` -> `{ resource: Organization }`
- `POST /api/organization` -> `{ resource: Organization }` (owner = token user)
- `PUT /api/organization/:id` -> `{ resource: Organization }`
- `DELETE /api/organization/:id` -> `{ resource: Organization }`

## Membership endpoints
- `GET /api/organization/:id/members` -> `{ resource: User[] }` (any authenticated user)
- `POST /api/organization/:id/members` body `{ user_id }` (owner/sysadmin)
- `DELETE /api/organization/:id/members/:userId` (owner/sysadmin)

Duplicate-add and non-existent user are rejected via `database.CreateOne` validation.

## Tests
- `route/organization/membership_test.go`: org CRUD, membership add/list/remove, authz (non-owner denied, unauthenticated denied), duplicate-add and unknown-user rejection.

Verified: `make tests` green + curl acceptance against `./main --dev-token`.