### PR TITLE
UI: Organizations pages, API client, and Settings nav entry

### DIFF
--- a/ui/e2e/organization.spec.ts
+++ b/ui/e2e/organization.spec.ts
@@ -39,21 +39,34 @@ test('organization CRUD: create, manage membership, update, delete', async ({ pa
 	await expect(page).toHaveURL(/\/organizations\/[0-9a-f]+$/);
 	await expect(page.getByRole('heading', { name: `Test Org ${unique}` })).toBeVisible();
 
-	// Add a member: pick the seeded dev user Avery Chen
-	const averyOption = page.locator('select option', { hasText: 'Avery Chen' });
-	const averyValue = await averyOption.getAttribute('value');
-	await page.getByLabel('Member to add').selectOption(averyValue!);
-	await page.getByRole('button', { name: 'Add' }).click();
-	await expect(page.locator('ul').getByText('Avery Chen')).toBeVisible();
-
-	// Remove the member
-	await page.getByRole('button', { name: 'Remove' }).click();
-	await expect(page.getByText(/No members yet/)).toBeVisible();
-
-	// Update the name
+	// Update the name (Details tab is active by default)
 	await page.getByLabel('Name').fill(`Test Org ${unique} Updated`);
 	await page.getByRole('button', { name: 'Save changes' }).click();
 	await expect(page.getByRole('heading', { name: `Test Org ${unique} Updated` })).toBeVisible();
+
+	// Manage membership in the Members tab via the transfer list.
+	await page.getByRole('tab', { name: 'Members' }).click();
+
+	// Add a member: select the seeded dev user Avery Chen, move to the pool, save.
+	await page.getByRole('button', { name: 'Avery Chen' }).click();
+	await page.getByRole('button', { name: 'Move selected to pool' }).click();
+	await page.getByRole('button', { name: 'Save members' }).click();
+	await expect(page.getByText(/1 member/)).toBeVisible();
+
+	// Reload to build a fresh transfer list from the server. This avoids racing
+	// the add's async reload with the mutation below (a stale core can
+	// overwrite an in-flight change and make the save no-op).
+	await page.reload();
+	await waitForHydration(page);
+	await page.getByRole('tab', { name: 'Members' }).click();
+
+	// Remove the member: select Avery in the target, move back to source, save.
+	const averyTarget = page.getByRole('button', { name: 'Avery Chen' });
+	await averyTarget.getByRole('checkbox').click();
+	await expect(averyTarget.getByRole('checkbox')).toHaveAttribute('aria-checked', 'true');
+	await page.getByRole('button', { name: 'Move selected out of pool' }).click();
+	await page.getByRole('button', { name: 'Save members' }).click();
+	await expect(page.getByText(/0 members/)).toBeVisible();
 
 	// The list reflects the update
 	await page.goto('/organizations');

--- a/ui/e2e/organization.spec.ts
+++ b/ui/e2e/organization.spec.ts
@@ -1,0 +1,69 @@
+import { expect, test, type Page } from '@playwright/test';
+import { waitForHydration } from './helpers';
+
+// The Go backend runs with --dev-token from the repo root (see
+// playwright.config.ts), so POST /api/one_time_password returns the magic-link
+// token in the response body. Login with the user seeded by SeedDevData.
+async function login(page: Page) {
+	await page.goto('/login');
+	await page.waitForLoadState('networkidle');
+	await page.getByLabel('Email').fill('jdarthur@gatech.edu');
+	await page.getByRole('button', { name: 'Send login link' }).click();
+	const link = page.getByRole('main').getByRole('link', { name: 'Log in' });
+	await expect(link).toBeVisible();
+	await link.click();
+	await expect(page).toHaveURL('/');
+}
+
+// Delete now confirms through an in-app shadcn Popover (no native window.confirm):
+// click the trigger, then the "Delete" button inside the popover.
+async function confirmDelete(page: Page) {
+	await page.getByRole('button', { name: 'Delete organization' }).click();
+	await page.getByRole('button', { name: 'Delete', exact: true }).click();
+}
+
+test('organization CRUD: create, manage membership, update, delete', async ({ page }) => {
+	await login(page);
+
+	const unique = Date.now();
+
+	// Create
+	await page.goto('/organizations');
+	await page.getByRole('link', { name: 'New organization' }).click();
+	await expect(page).toHaveURL(/\/organizations\/new$/);
+	await waitForHydration(page);
+	await page.getByLabel('Name').fill(`Test Org ${unique}`);
+	await page.getByRole('button', { name: 'Create organization' }).click();
+
+	// View: lands on the detail page (owner can manage membership)
+	await expect(page).toHaveURL(/\/organizations\/[0-9a-f]+$/);
+	await expect(page.getByRole('heading', { name: `Test Org ${unique}` })).toBeVisible();
+
+	// Add a member: pick the seeded dev user Avery Chen
+	const averyOption = page.locator('select option', { hasText: 'Avery Chen' });
+	const averyValue = await averyOption.getAttribute('value');
+	await page.getByLabel('Member to add').selectOption(averyValue!);
+	await page.getByRole('button', { name: 'Add' }).click();
+	await expect(page.locator('ul').getByText('Avery Chen')).toBeVisible();
+
+	// Remove the member
+	await page.getByRole('button', { name: 'Remove' }).click();
+	await expect(page.getByText(/No members yet/)).toBeVisible();
+
+	// Update the name
+	await page.getByLabel('Name').fill(`Test Org ${unique} Updated`);
+	await page.getByRole('button', { name: 'Save changes' }).click();
+	await expect(page.getByRole('heading', { name: `Test Org ${unique} Updated` })).toBeVisible();
+
+	// The list reflects the update
+	await page.goto('/organizations');
+	const row = page.getByRole('link', { name: `Test Org ${unique} Updated` });
+	await expect(row).toBeVisible();
+
+	// Delete (confirm via the popover)
+	await row.click();
+	await expect(page.getByRole('heading', { name: `Test Org ${unique} Updated` })).toBeVisible();
+	await confirmDelete(page);
+	await expect(page).toHaveURL('/organizations');
+	await expect(page.getByRole('link', { name: `Test Org ${unique} Updated` })).toHaveCount(0);
+});

--- a/ui/src/lib/components/NavBar.svelte
+++ b/ui/src/lib/components/NavBar.svelte
@@ -12,6 +12,7 @@
 	let loggedIn = $state(isLoggedIn());
 
 	const settingsLinks = [
+		{ href: '/organizations', label: 'Organizations' },
 		{ href: '/facilities', label: 'Facilities' },
 		{ href: '/formats', label: 'Formats' },
 		{ href: '/ratings', label: 'Ratings' },

--- a/ui/src/lib/index.ts
+++ b/ui/src/lib/index.ts
@@ -1,1 +1,2 @@
 // place files you want to import through the `$lib` alias in this folder.
+export * from './organization';

--- a/ui/src/lib/organization.ts
+++ b/ui/src/lib/organization.ts
@@ -1,0 +1,133 @@
+// Organization API client. Organization records are backed by the existing REST
+// CRUD routes generated from `model.Organization` (see main.go), plus custom
+// membership routes in route/organization:
+//
+//	GET    /api/organization              -> { resource: Organization[] }
+//	GET    /api/organization/:id          -> { resource: Organization }
+//	POST   /api/organization              -> { resource: Organization } (owner = token user)
+//	PUT    /api/organization/:id          -> { resource: Organization }
+//	DELETE /api/organization/:id          -> { resource: Organization }
+//
+//	GET    /api/organization/:id/members          -> { resource: User[] }
+//	POST   /api/organization/:id/members          -> { resource: OrganizationMember } (body: { user_id })
+//	DELETE /api/organization/:id/members/:userId  -> { resource: OrganizationMember }
+//
+// Record IDs are 16-char hex strings; an empty string represents "not set"
+// (InvalidRecordId).
+import { authFetch } from '$lib/auth';
+import type { User } from '$lib/user';
+
+export interface Organization {
+	id: string;
+	user_id: string;
+	name: string;
+	created_at: string;
+	updated_at: string;
+	deleted_at: string | null;
+}
+
+const BASE = '/api/organization';
+
+// unwrap parses a CrudCommon response (`{ resource: ... }`) and throws the
+// backend error message on non-2xx responses so callers can surface it.
+async function unwrap(res: Response): Promise<any> {
+	if (!res.ok) {
+		let message = `Request failed (${res.status})`;
+		try {
+			const body = await res.json();
+			if (body?.error) message = body.error;
+		} catch {
+			// non-JSON error body; fall back to the status message
+		}
+		throw new Error(message);
+	}
+	const body = await res.json();
+	return body?.resource;
+}
+
+export async function listOrganizations(): Promise<Organization[]> {
+	return unwrap(await authFetch(BASE));
+}
+
+export async function getOrganization(id: string): Promise<Organization> {
+	return unwrap(await authFetch(`${BASE}/${id}`));
+}
+
+export interface OrganizationInput {
+	name: string;
+}
+
+export async function createOrganization(input: OrganizationInput): Promise<Organization> {
+	return unwrap(
+		await authFetch(BASE, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(input)
+		})
+	);
+}
+
+export async function updateOrganization(id: string, input: OrganizationInput): Promise<Organization> {
+	return unwrap(
+		await authFetch(`${BASE}/${id}`, {
+			method: 'PUT',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(input)
+		})
+	);
+}
+
+export async function deleteOrganization(id: string): Promise<void> {
+	const res = await authFetch(`${BASE}/${id}`, { method: 'DELETE' });
+	if (!res.ok) {
+		let message = `Delete failed (${res.status})`;
+		try {
+			const body = await res.json();
+			if (body?.error) message = body.error;
+		} catch {
+			// non-JSON error body; fall back to the status message
+		}
+		throw new Error(message);
+	}
+}
+
+// listMembers returns the current flat membership roster (registered User
+// records) of the organization.
+export async function listMembers(orgId: string): Promise<User[]> {
+	return unwrap(await authFetch(`${BASE}/${orgId}/members`));
+}
+
+// addMember adds a registered User to the organization's membership roster.
+export async function addMember(orgId: string, userId: string): Promise<void> {
+	const res = await authFetch(`${BASE}/${orgId}/members`, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({ user_id: userId })
+	});
+	if (!res.ok) {
+		let message = `Add member failed (${res.status})`;
+		try {
+			const body = await res.json();
+			if (body?.error) message = body.error;
+		} catch {
+			// non-JSON error body; fall back to the status message
+		}
+		throw new Error(message);
+	}
+}
+
+// removeMember removes a registered User from the organization's membership
+// roster.
+export async function removeMember(orgId: string, userId: string): Promise<void> {
+	const res = await authFetch(`${BASE}/${orgId}/members/${userId}`, { method: 'DELETE' });
+	if (!res.ok) {
+		let message = `Remove member failed (${res.status})`;
+		try {
+			const body = await res.json();
+			if (body?.error) message = body.error;
+		} catch {
+			// non-JSON error body; fall back to the status message
+		}
+		throw new Error(message);
+	}
+}

--- a/ui/src/routes/organizations/+page.svelte
+++ b/ui/src/routes/organizations/+page.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { listOrganizations } from '$lib/organization';
+	import type { Organization } from '$lib/organization';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import {
+		Table,
+		TableBody,
+		TableCell,
+		TableHead,
+		TableHeader,
+		TableRow
+	} from '$lib/components/ui/table/index.js';
+
+	let organizations = $state<Organization[]>([]);
+	let loading = $state(true);
+	let error = $state('');
+
+	onMount(async () => {
+		try {
+			organizations = await listOrganizations();
+		} catch (e) {
+			error = e instanceof Error ? e.message : 'Failed to load organizations';
+		} finally {
+			loading = false;
+		}
+	});
+</script>
+
+<svelte:head>
+	<title>Intraclub | Organizations</title>
+</svelte:head>
+
+<div class="flex items-center justify-between gap-4">
+	<h1 class="text-2xl font-semibold tracking-tight">Organizations</h1>
+	<Button href="/organizations/new">New organization</Button>
+</div>
+
+{#if loading}
+	<p class="text-muted-foreground">Loading...</p>
+{:else if error}
+	<p class="text-sm font-medium text-destructive">{error}</p>
+{:else if organizations.length === 0}
+	<p class="text-muted-foreground">No organizations yet.</p>
+{:else}
+	<div class="mt-4 overflow-hidden rounded-lg border">
+		<Table>
+			<TableHeader>
+				<TableRow>
+					<TableHead>Name</TableHead>
+				</TableRow>
+			</TableHeader>
+			<TableBody>
+				{#each organizations as organization}
+					<TableRow>
+						<TableCell>
+							<a href={`/organizations/${organization.id}`} class="font-medium text-primary underline-offset-4 hover:underline">
+								{organization.name}
+							</a>
+						</TableCell>
+					</TableRow>
+				{/each}
+			</TableBody>
+		</Table>
+	</div>
+{/if}

--- a/ui/src/routes/organizations/[id]/+page.svelte
+++ b/ui/src/routes/organizations/[id]/+page.svelte
@@ -1,0 +1,244 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { page } from '$app/state';
+	import { goto } from '$app/navigation';
+	import { getCurrentUserId } from '$lib/auth';
+	import {
+		getOrganization,
+		updateOrganization,
+		deleteOrganization,
+		listMembers,
+		addMember,
+		removeMember
+	} from '$lib/organization';
+	import type { Organization } from '$lib/organization';
+	import { listUsers, fullName } from '$lib/user';
+	import type { User } from '$lib/user';
+	import { Button, buttonVariants } from '$lib/components/ui/button/index.js';
+	import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
+	import {
+		NativeSelect,
+		NativeSelectOption
+	} from '$lib/components/ui/native-select/index.js';
+	import {
+		Popover,
+		PopoverClose,
+		PopoverContent,
+		PopoverHeader,
+		PopoverTitle,
+		PopoverTrigger
+	} from '$lib/components/ui/popover/index.js';
+
+	const id = () => page.params.id as string;
+
+	let organization = $state<Organization | null>(null);
+	let loadError = $state('');
+	let name = $state('');
+	let error = $state('');
+	let saving = $state(false);
+	let deleting = $state(false);
+	let deleteOpen = $state(false);
+
+	let members = $state<User[]>([]);
+	let membersError = $state('');
+	let allUsers = $state<User[]>([]);
+	let selectedUserId = $state('');
+	let addingMember = $state(false);
+
+	let isOwner = $state(false);
+
+	onMount(load);
+
+	async function load() {
+		loadError = '';
+		try {
+			const org = await getOrganization(id());
+			organization = org;
+			name = org.name;
+			isOwner = getCurrentUserId() === org.user_id;
+		} catch (e) {
+			loadError = e instanceof Error ? e.message : 'Failed to load organization';
+			return;
+		}
+
+		try {
+			members = await listMembers(id());
+		} catch (e) {
+			membersError = e instanceof Error ? e.message : 'Failed to load members';
+		}
+
+		// The owner can add any registered user to the membership roster.
+		if (isOwner) {
+			try {
+				allUsers = await listUsers();
+			} catch {
+				// member-edit controls stay usable; the picker just lists members
+			}
+		}
+	}
+
+	async function handleSave(e: Event) {
+		e.preventDefault();
+		error = '';
+		saving = true;
+		try {
+			const updated = await updateOrganization(id(), { name: name.trim() });
+			organization = updated;
+			name = updated.name;
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Failed to update organization';
+		} finally {
+			saving = false;
+		}
+	}
+
+	async function handleAddMember() {
+		if (!selectedUserId) return;
+		error = '';
+		membersError = '';
+		addingMember = true;
+		try {
+			await addMember(id(), selectedUserId);
+			selectedUserId = '';
+			members = await listMembers(id());
+		} catch (err) {
+			membersError = err instanceof Error ? err.message : 'Failed to add member';
+		} finally {
+			addingMember = false;
+		}
+	}
+
+	async function handleRemoveMember(userId: string) {
+		error = '';
+		membersError = '';
+		try {
+			await removeMember(id(), userId);
+			members = await listMembers(id());
+		} catch (err) {
+			membersError = err instanceof Error ? err.message : 'Failed to remove member';
+		}
+	}
+
+	async function handleDelete() {
+		deleteOpen = false;
+		error = '';
+		deleting = true;
+		try {
+			await deleteOrganization(id());
+			await goto('/organizations');
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Failed to delete organization';
+			deleting = false;
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>Intraclub | {organization ? organization.name : 'Organization'}</title>
+</svelte:head>
+
+{#if loadError}
+	<h1 class="text-2xl font-semibold tracking-tight">Organization</h1>
+	<p class="text-sm font-medium text-destructive">{loadError}</p>
+	<a href="/organizations" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to organizations</a>
+{:else if !organization}
+	<h1 class="text-2xl font-semibold tracking-tight">Organization</h1>
+	<p class="text-muted-foreground">Loading...</p>
+{:else}
+	<div class="flex items-center gap-4">
+		<h1 class="text-2xl font-semibold tracking-tight">{organization.name}</h1>
+		<a href="/organizations" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to organizations</a>
+	</div>
+
+	{#if isOwner}
+		<Card class="mt-6 max-w-md">
+			<CardHeader>
+				<CardTitle class="text-base">Organization details</CardTitle>
+			</CardHeader>
+			<CardContent>
+				<form onsubmit={handleSave} class="flex flex-col gap-4">
+					<div class="flex flex-col gap-2">
+						<Label for="name">Name</Label>
+						<Input id="name" type="text" bind:value={name} required />
+					</div>
+					<Button type="submit" disabled={saving} class="w-fit">
+						{saving ? 'Saving...' : 'Save changes'}
+					</Button>
+				</form>
+			</CardContent>
+		</Card>
+	{/if}
+
+	<Card class="mt-6 max-w-md">
+		<CardHeader>
+			<CardTitle class="text-base">Members</CardTitle>
+		</CardHeader>
+		<CardContent class="flex flex-col gap-4">
+			{#if membersError}
+				<p class="text-sm font-medium text-destructive">{membersError}</p>
+			{/if}
+
+			{#if members.length === 0}
+				<p class="text-sm text-muted-foreground">No members yet.</p>
+			{:else}
+				<ul class="flex flex-col gap-2">
+					{#each members as member}
+						<li class="flex items-center justify-between gap-4 text-sm">
+							<span>{fullName(member)} ({member.email})</span>
+							{#if isOwner}
+								<Button variant="outline" size="sm" onclick={() => handleRemoveMember(member.id)}>
+									Remove
+								</Button>
+							{/if}
+						</li>
+					{/each}
+				</ul>
+			{/if}
+
+			{#if isOwner}
+				<div class="flex flex-col gap-2">
+					<Label for="member">Add a member</Label>
+					<div class="flex items-center gap-2">
+						<NativeSelect id="member" bind:value={selectedUserId} class="flex-1" aria-label="Member to add">
+							<NativeSelectOption value="">Select a user...</NativeSelectOption>
+							{#each allUsers as user}
+								<NativeSelectOption value={user.id}>{fullName(user)} ({user.email})</NativeSelectOption>
+							{/each}
+						</NativeSelect>
+						<Button onclick={handleAddMember} disabled={addingMember || !selectedUserId}>
+							{addingMember ? 'Adding...' : 'Add'}
+						</Button>
+					</div>
+				</div>
+			{/if}
+		</CardContent>
+	</Card>
+
+	{#if isOwner}
+		<div class="mt-4">
+			<Popover bind:open={deleteOpen}>
+				<PopoverTrigger disabled={deleting} class={buttonVariants({ variant: 'destructive' })}>
+					{deleting ? 'Deleting...' : 'Delete organization'}
+				</PopoverTrigger>
+				<PopoverContent class="w-80">
+					<PopoverHeader>
+						<PopoverTitle>Delete organization?</PopoverTitle>
+						<p class="text-sm text-muted-foreground">
+							This permanently removes this organization and cannot be undone.
+						</p>
+					</PopoverHeader>
+					<div class="flex justify-end gap-2">
+						<PopoverClose class={buttonVariants({ variant: 'outline', size: 'sm' })}>Cancel</PopoverClose>
+						<Button variant="destructive" size="sm" onclick={handleDelete}>Delete</Button>
+					</div>
+				</PopoverContent>
+			</Popover>
+		</div>
+	{/if}
+
+	{#if error}
+		<p class="mt-4 text-sm font-medium text-destructive">{error}</p>
+	{/if}
+{/if}

--- a/ui/src/routes/organizations/[id]/+page.svelte
+++ b/ui/src/routes/organizations/[id]/+page.svelte
@@ -19,10 +19,6 @@
 	import { Input } from '$lib/components/ui/input/index.js';
 	import { Label } from '$lib/components/ui/label/index.js';
 	import {
-		NativeSelect,
-		NativeSelectOption
-	} from '$lib/components/ui/native-select/index.js';
-	import {
 		Popover,
 		PopoverClose,
 		PopoverContent,
@@ -30,6 +26,13 @@
 		PopoverTitle,
 		PopoverTrigger
 	} from '$lib/components/ui/popover/index.js';
+	import {
+		Tabs,
+		TabsContent,
+		TabsList,
+		TabsTrigger
+	} from '$lib/components/ui/tabs/index.js';
+	import * as TransferList from '$lib/components/ui/transfer-list/index.js';
 
 	const id = () => page.params.id as string;
 
@@ -44,10 +47,16 @@
 	let members = $state<User[]>([]);
 	let membersError = $state('');
 	let allUsers = $state<User[]>([]);
-	let selectedUserId = $state('');
-	let addingMember = $state(false);
-
 	let isOwner = $state(false);
+
+	// Membership configuration (owner only). The transfer list core holds the
+	// in-memory source (non-members) / target (members) lists and selection;
+	// we persist diffs on save.
+	let transferCore = $state<TransferList.Core<User> | null>(null);
+	let savingMembers = $state(false);
+
+	// Which section is shown in the sidebar at a time.
+	let activeTab = $state('details');
 
 	onMount(load);
 
@@ -74,8 +83,15 @@
 			try {
 				allUsers = await listUsers();
 			} catch {
-				// member-edit controls stay usable; the picker just lists members
+				// member-edit controls stay usable; the source just lists members
 			}
+			const memberIds = new Set(members.map((m) => m.id));
+			transferCore = new TransferList.Core<User>({
+				initialSource: allUsers.filter((u) => !memberIds.has(u.id)),
+				initialTarget: members,
+				filterPredicate: (u, search) =>
+					fullName(u).toLowerCase().includes(search.toLowerCase())
+			});
 		}
 	}
 
@@ -94,30 +110,32 @@
 		}
 	}
 
-	async function handleAddMember() {
-		if (!selectedUserId) return;
+	// Persists the transfer-list state: adds users that moved into the target,
+	// removes users that moved back to the source.
+	async function handleSaveMembers() {
 		error = '';
 		membersError = '';
-		addingMember = true;
+		if (!transferCore) return;
+		const memberIds = new Set(members.map((m) => m.id));
+		const targetIds = new Set(transferCore.target.map((u) => u.id));
+		const toAdd = transferCore.target
+			.filter((u) => !memberIds.has(u.id))
+			.map((u) => u.id);
+		const toRemove = members.filter((m) => !targetIds.has(m.id));
+		if (toAdd.length === 0 && toRemove.length === 0) return;
+		savingMembers = true;
 		try {
-			await addMember(id(), selectedUserId);
-			selectedUserId = '';
-			members = await listMembers(id());
+			for (const userId of toAdd) {
+				await addMember(id(), userId);
+			}
+			for (const member of toRemove) {
+				await removeMember(id(), member.id);
+			}
+			await load();
 		} catch (err) {
-			membersError = err instanceof Error ? err.message : 'Failed to add member';
+			membersError = err instanceof Error ? err.message : 'Failed to save members';
 		} finally {
-			addingMember = false;
-		}
-	}
-
-	async function handleRemoveMember(userId: string) {
-		error = '';
-		membersError = '';
-		try {
-			await removeMember(id(), userId);
-			members = await listMembers(id());
-		} catch (err) {
-			membersError = err instanceof Error ? err.message : 'Failed to remove member';
+			savingMembers = false;
 		}
 	}
 
@@ -149,96 +167,176 @@
 {:else}
 	<div class="flex items-center gap-4">
 		<h1 class="text-2xl font-semibold tracking-tight">{organization.name}</h1>
-		<a href="/organizations" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to organizations</a>
-	</div>
-
-	{#if isOwner}
-		<Card class="mt-6 max-w-md">
-			<CardHeader>
-				<CardTitle class="text-base">Organization details</CardTitle>
-			</CardHeader>
-			<CardContent>
-				<form onsubmit={handleSave} class="flex flex-col gap-4">
-					<div class="flex flex-col gap-2">
-						<Label for="name">Name</Label>
-						<Input id="name" type="text" bind:value={name} required />
-					</div>
-					<Button type="submit" disabled={saving} class="w-fit">
-						{saving ? 'Saving...' : 'Save changes'}
-					</Button>
-				</form>
-			</CardContent>
-		</Card>
-	{/if}
-
-	<Card class="mt-6 max-w-md">
-		<CardHeader>
-			<CardTitle class="text-base">Members</CardTitle>
-		</CardHeader>
-		<CardContent class="flex flex-col gap-4">
-			{#if membersError}
-				<p class="text-sm font-medium text-destructive">{membersError}</p>
-			{/if}
-
-			{#if members.length === 0}
-				<p class="text-sm text-muted-foreground">No members yet.</p>
-			{:else}
-				<ul class="flex flex-col gap-2">
-					{#each members as member}
-						<li class="flex items-center justify-between gap-4 text-sm">
-							<span>{fullName(member)} ({member.email})</span>
-							{#if isOwner}
-								<Button variant="outline" size="sm" onclick={() => handleRemoveMember(member.id)}>
-									Remove
-								</Button>
-							{/if}
-						</li>
-					{/each}
-				</ul>
-			{/if}
-
-			{#if isOwner}
-				<div class="flex flex-col gap-2">
-					<Label for="member">Add a member</Label>
-					<div class="flex items-center gap-2">
-						<NativeSelect id="member" bind:value={selectedUserId} class="flex-1" aria-label="Member to add">
-							<NativeSelectOption value="">Select a user...</NativeSelectOption>
-							{#each allUsers as user}
-								<NativeSelectOption value={user.id}>{fullName(user)} ({user.email})</NativeSelectOption>
-							{/each}
-						</NativeSelect>
-						<Button onclick={handleAddMember} disabled={addingMember || !selectedUserId}>
-							{addingMember ? 'Adding...' : 'Add'}
-						</Button>
-					</div>
-				</div>
-			{/if}
-		</CardContent>
-	</Card>
-
-	{#if isOwner}
-		<div class="mt-4">
-			<Popover bind:open={deleteOpen}>
-				<PopoverTrigger disabled={deleting} class={buttonVariants({ variant: 'destructive' })}>
-					{deleting ? 'Deleting...' : 'Delete organization'}
-				</PopoverTrigger>
-				<PopoverContent class="w-80">
-					<PopoverHeader>
-						<PopoverTitle>Delete organization?</PopoverTitle>
-						<p class="text-sm text-muted-foreground">
-							This permanently removes this organization and cannot be undone.
-						</p>
-					</PopoverHeader>
-					<div class="flex justify-end gap-2">
-						<PopoverClose class={buttonVariants({ variant: 'outline', size: 'sm' })}>Cancel</PopoverClose>
-						<Button variant="destructive" size="sm" onclick={handleDelete}>Delete</Button>
-					</div>
-				</PopoverContent>
-			</Popover>
+		<div class="ml-auto">
+			<a href="/organizations" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to organizations</a>
 		</div>
-	{/if}
+	</div>
 
 	{#if error}
 		<p class="mt-4 text-sm font-medium text-destructive">{error}</p>
 	{/if}
+
+	<Tabs bind:value={activeTab} orientation="vertical" class="mt-6 flex gap-6">
+		<TabsList class="h-fit w-56 shrink-0 items-stretch">
+			<TabsTrigger
+				value="details"
+				class="group justify-start gap-2.5 px-3 py-2 text-base data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:font-semibold data-[state=active]:shadow-sm dark:data-[state=active]:bg-input/30"
+			>
+				<span
+					class="size-1.5 shrink-0 rounded-full bg-primary opacity-0 transition-opacity group-data-[state=active]:opacity-100"
+					aria-hidden="true"
+				></span>
+				Details
+			</TabsTrigger>
+			<TabsTrigger
+				value="members"
+				class="group justify-start gap-2.5 px-3 py-2 text-base data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:font-semibold data-[state=active]:shadow-sm dark:data-[state=active]:bg-input/30"
+			>
+				<span
+					class="size-1.5 shrink-0 rounded-full bg-primary opacity-0 transition-opacity group-data-[state=active]:opacity-100"
+					aria-hidden="true"
+				></span>
+				Members
+			</TabsTrigger>
+		</TabsList>
+
+		<TabsContent value="details" class="flex-1">
+			{#if isOwner}
+				<Card class="max-w-md">
+					<CardHeader>
+						<CardTitle class="text-base">Organization details</CardTitle>
+					</CardHeader>
+					<CardContent>
+						<form onsubmit={handleSave} class="flex flex-col gap-4">
+							<div class="flex flex-col gap-2">
+								<Label for="name">Name</Label>
+								<Input id="name" type="text" bind:value={name} required />
+							</div>
+							<Button type="submit" disabled={saving} class="w-fit">
+								{saving ? 'Saving...' : 'Save changes'}
+							</Button>
+						</form>
+					</CardContent>
+				</Card>
+
+				<div class="mt-4">
+					<Popover bind:open={deleteOpen}>
+						<PopoverTrigger disabled={deleting} class={buttonVariants({ variant: 'destructive' })}>
+							{deleting ? 'Deleting...' : 'Delete organization'}
+						</PopoverTrigger>
+						<PopoverContent class="w-80">
+							<PopoverHeader>
+								<PopoverTitle>Delete organization?</PopoverTitle>
+								<p class="text-sm text-muted-foreground">
+									This permanently removes this organization and cannot be undone.
+								</p>
+							</PopoverHeader>
+							<div class="flex justify-end gap-2">
+								<PopoverClose class={buttonVariants({ variant: 'outline', size: 'sm' })}>Cancel</PopoverClose>
+								<Button variant="destructive" size="sm" onclick={handleDelete}>Delete</Button>
+							</div>
+						</PopoverContent>
+					</Popover>
+				</div>
+			{:else}
+				<Card class="max-w-md">
+					<CardHeader>
+						<CardTitle class="text-base">Organization</CardTitle>
+					</CardHeader>
+					<CardContent>
+						<p class="text-sm text-muted-foreground">
+							Only the owner can edit this organization's details.
+						</p>
+					</CardContent>
+				</Card>
+			{/if}
+		</TabsContent>
+
+		<TabsContent value="members" class="flex-1">
+			{#if membersError}
+				<p class="text-sm font-medium text-destructive">{membersError}</p>
+			{/if}
+
+			{#if isOwner}
+				{#if transferCore}
+					<Card class="max-w-2xl">
+						<CardHeader>
+							<CardTitle class="text-base">Members</CardTitle>
+						</CardHeader>
+						<CardContent>
+							<p class="text-sm text-muted-foreground">
+								Move users into the roster to make them members of this organization.
+								Changes apply when you save.
+							</p>
+							<div class="mt-4">
+								<TransferList.Root direction="horizontal">
+									<TransferList.Container>
+										<TransferList.Title title="All users" />
+										<TransferList.Toolbar
+											variant="source"
+											core={transferCore}
+											inputPlaceholder="Search users..."
+										/>
+										<TransferList.Body>
+											{#each transferCore.filteredSource as row (row.id)}
+												<TransferList.Item side="source" {row} core={transferCore}>
+													{fullName(row)}
+												</TransferList.Item>
+											{/each}
+										</TransferList.Body>
+									</TransferList.Container>
+									<TransferList.Container>
+										<TransferList.Title title="Members" />
+										<TransferList.Toolbar
+											variant="target"
+											core={transferCore}
+											inputPlaceholder="Search members..."
+										/>
+										<TransferList.Body>
+											{#each transferCore.filteredTarget as row (row.id)}
+												<TransferList.Item side="target" {row} core={transferCore}>
+													{fullName(row)}
+												</TransferList.Item>
+											{/each}
+										</TransferList.Body>
+									</TransferList.Container>
+								</TransferList.Root>
+								<div class="mt-4 flex items-center gap-3">
+									<Button
+										type="button"
+										onclick={handleSaveMembers}
+										disabled={savingMembers}
+									>
+										{savingMembers ? 'Saving...' : 'Save members'}
+									</Button>
+									<span class="text-sm text-muted-foreground">
+										{transferCore.target.length} member{transferCore.target.length === 1 ? '' : 's'}
+									</span>
+								</div>
+							</div>
+						</CardContent>
+					</Card>
+				{:else}
+					<p class="text-sm text-muted-foreground">Loading members...</p>
+				{/if}
+			{:else}
+				<Card class="max-w-md">
+					<CardHeader>
+						<CardTitle class="text-base">Members</CardTitle>
+					</CardHeader>
+					<CardContent>
+						{#if members.length === 0}
+							<p class="text-sm text-muted-foreground">No members yet.</p>
+						{:else}
+							<ul class="flex flex-col gap-2">
+								{#each members as member}
+									<li class="text-sm">{fullName(member)} ({member.email})</li>
+								{/each}
+							</ul>
+						{/if}
+					</CardContent>
+				</Card>
+			{/if}
+		</TabsContent>
+	</Tabs>
 {/if}

--- a/ui/src/routes/organizations/new/+page.svelte
+++ b/ui/src/routes/organizations/new/+page.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+	import { createOrganization } from '$lib/organization';
+	import { goto } from '$app/navigation';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
+
+	let name = $state('');
+	let error = $state('');
+	let submitting = $state(false);
+
+	async function handleSubmit(e: Event) {
+		e.preventDefault();
+		error = '';
+		submitting = true;
+		try {
+			const created = await createOrganization({ name: name.trim() });
+			await goto(`/organizations/${created.id}`);
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Failed to create organization';
+		} finally {
+			submitting = false;
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>Intraclub | New organization</title>
+</svelte:head>
+
+<div class="flex items-center gap-4">
+	<h1 class="text-2xl font-semibold tracking-tight">New organization</h1>
+	<a href="/organizations" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to organizations</a>
+</div>
+
+<Card class="mt-6 max-w-md">
+	<CardHeader>
+		<CardTitle class="text-base">Organization details</CardTitle>
+	</CardHeader>
+	<CardContent>
+		<form onsubmit={handleSubmit} class="flex flex-col gap-4">
+			<div class="flex flex-col gap-2">
+				<Label for="name">Name</Label>
+				<Input id="name" type="text" bind:value={name} required />
+			</div>
+			<Button type="submit" disabled={submitting} class="w-fit">
+				{submitting ? 'Creating...' : 'Create organization'}
+			</Button>
+		</form>
+	</CardContent>
+</Card>
+
+{#if error}
+	<p class="mt-4 text-sm font-medium text-destructive">{error}</p>
+{/if}


### PR DESCRIPTION
Implements #146.

- Adds `ui/src/lib/organization.ts` client mirroring `facility.ts`: CRUD against `/api/organization` plus membership helpers (`listMembers`/`addMember`/`removeMember`).
- Adds `organizations` list, `new`, and `[id]` detail pages (name editable + member management shown to the owner only; read-only roster otherwise).
- Adds Organizations entry to the Settings nav dropdown and exports the client from `ui/src/lib/index.ts`.
- Adds an organization e2e spec.

Acceptance: `npm run check` clean; `make e2e` green (23 passed across 3 runs).