### PR TITLE
UI: Organization filter for the Draft 'Available players' pool

### DIFF
--- a/ui/e2e/draft-setup.spec.ts
+++ b/ui/e2e/draft-setup.spec.ts
@@ -132,3 +132,92 @@ test('draft setup page configures captains, players, and rating cutoffs', async 
 	});
 	expect(cleanup.ok()).toBeTruthy();
 });
+
+test('available players pool filters by organization with a hard boundary', async ({
+	page
+}) => {
+	await login(page);
+	const token = await page.evaluate(() => localStorage.getItem('intraclub_jwt') ?? '');
+	expect(token).toBeTruthy();
+
+	const unique = Date.now();
+
+	// Two fresh users: one will be an org member, the other an outsider.
+	const people = [
+		{ first: `Mia${unique}`, last: 'Member' },
+		{ first: `Noah${unique}`, last: 'Outsider' }
+	];
+	const csv = [
+		'First Name, Last Name, Email',
+		...people.map((p) => `${p.first}, ${p.last}, ${p.first.toLowerCase()}@example.com`)
+	].join('\n');
+	const importRes = await page.request.post(`${API}/import_users_from_csv`, {
+		form: { file: csv }
+	});
+	expect(importRes.ok()).toBeTruthy();
+	const importBody = await importRes.json();
+	const userIds = [...importBody.Created, ...importBody.AlreadyExisting].map(
+		(u: { id: string }) => u.id
+	);
+	expect(userIds).toHaveLength(people.length);
+
+	// Create an organization and add only the first user as a member.
+	const orgName = `Filter Org ${unique}`;
+	const orgRes = await page.request.post(`${API}/organization`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { name: orgName }
+	});
+	expect(orgRes.ok()).toBeTruthy();
+	const orgId = (await orgRes.json()).resource.id as string;
+	const addRes = await page.request.post(`${API}/organization/${orgId}/members`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { user_id: userIds[0] }
+	});
+	expect(addRes.ok()).toBeTruthy();
+
+	// Create a draft for the seed format.
+	const formatRes = await page.request.get(`${API}/format`);
+	const formats = (await formatRes.json()).resource as { id: string; name: string }[];
+	const format = formats.find((f) => f.name === SEED_FORMAT);
+	expect(format).toBeTruthy();
+	const draftRes = await page.request.post(`${API}/draft`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { name: `Filter Draft ${unique}`, format: format!.id }
+	});
+	expect(draftRes.ok()).toBeTruthy();
+	const draftId = (await draftRes.json()).resource.id as string;
+
+	const memberName = `${people[0].first} ${people[0].last}`;
+	const outsiderName = `${people[1].first} ${people[1].last}`;
+
+	await page.goto(`/drafts/${draftId}`);
+	await expect(page.getByRole('heading', { name: `Filter Draft ${unique}` })).toBeVisible();
+	await waitForHydration(page);
+	await page.getByRole('tab', { name: 'Available players' }).click();
+
+	// No filter selected: both users appear in the source panel.
+	await expect(page.getByRole('button', { name: memberName })).toBeVisible();
+	await expect(page.getByRole('button', { name: outsiderName })).toBeVisible();
+
+	// Toggle the org chip: only members of the org remain in the source, and
+	// the source title reflects the filtered pool.
+	await page.getByRole('button', { name: orgName }).click();
+	await expect(page.getByRole('button', { name: memberName })).toBeVisible();
+	await expect(page.getByRole('button', { name: outsiderName })).toHaveCount(0);
+	await expect(page.getByText('All players (filtered) — 1 member')).toBeVisible();
+
+	// Move the member into the pool, then save.
+	await page.getByRole('button', { name: memberName }).click();
+	await page.getByRole('button', { name: 'Move selected to pool' }).click();
+	await expect(page.getByText('1 player in pool')).toBeVisible();
+
+	// Deselect the filter: the outsider is restored to the source.
+	await page.getByRole('button', { name: 'All users' }).click();
+	await expect(page.getByRole('button', { name: outsiderName })).toBeVisible();
+
+	// Clean up the draft so the table doesn't accumulate rows across runs.
+	const cleanup = await page.request.delete(`${API}/draft/${draftId}`, {
+		headers: { 'X-INTRACLUB-TOKEN': token }
+	});
+	expect(cleanup.ok()).toBeTruthy();
+});

--- a/ui/src/routes/drafts/[id]/+page.svelte
+++ b/ui/src/routes/drafts/[id]/+page.svelte
@@ -29,6 +29,8 @@
 	import type { DraftRatingCutoff } from '$lib/draftRatingCutoff';
 	import { listDraftPicks } from '$lib/draftPick';
 	import type { DraftPick } from '$lib/draftPick';
+	import { listOrganizations, listMembers } from '$lib/organization';
+	import type { Organization } from '$lib/organization';
 	import { Badge } from '$lib/components/ui/badge/index.js';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import {
@@ -57,6 +59,12 @@
 	let possibleRatings = $state<Rating[]>([]);
 	let ratingsById = $state<Record<string, Rating>>({});
 	let users = $state<User[]>([]);
+
+	// Organizations and their membership roster, used to filter the "Available
+	// players" source pool (transient UI filter only — nothing persisted).
+	let organizations = $state<Organization[]>([]);
+	let userIdsByOrg = $state<Map<string, Set<string>>>(new Map());
+	let selectedOrgIds = $state<string[]>([]);
 
 	let captains = $state<DraftCaptain[]>([]);
 	let availablePlayers = $state<DraftAvailablePlayer[]>([]);
@@ -99,7 +107,8 @@
 				captainList,
 				availableList,
 				cutoffList,
-				pickList
+				pickList,
+				organizationList
 			] = await Promise.all([
 				listFormats(),
 				listUsers(),
@@ -107,12 +116,29 @@
 				listDraftCaptains(),
 				listDraftAvailablePlayers(),
 				listDraftRatingCutoffs(),
-				listDraftPicks()
+				listDraftPicks(),
+				listOrganizations()
 			]);
 
 			draft = draftData;
 			users = userList;
 			ratingsById = Object.fromEntries(ratingList.map((r) => [r.id, r]));
+
+			// Build the org -> member userIds map (N+1 per org is acceptable for
+			// the small number of organizations).
+			organizations = organizationList;
+			userIdsByOrg = new Map(
+				await Promise.all(
+					organizationList.map(async (org) => {
+						const members = await listMembers(org.id);
+						return [org.id, new Set(members.map((m) => m.id))] as [
+							string,
+							Set<string>
+						];
+					})
+				)
+			);
+			selectedOrgIds = [];
 
 			const fmt = formatList.find((f) => f.id === draftData.format) ?? null;
 			format = fmt;
@@ -192,6 +218,52 @@
 	}
 
 	// --- Available players ---
+
+	// Union of member userIds across the currently selected organizations.
+	// Empty selection -> empty set (means "no filter", handled by callers).
+	function memberIdsOfSelectedOrgs(): Set<string> {
+		const ids = new Set<string>();
+		for (const orgId of selectedOrgIds) {
+			for (const uid of userIdsByOrg.get(orgId) ?? []) {
+				ids.add(uid);
+			}
+		}
+		return ids;
+	}
+
+	function isOrgSelected(orgId: string): boolean {
+		return selectedOrgIds.includes(orgId);
+	}
+
+	function toggleOrg(orgId: string) {
+		selectedOrgIds = isOrgSelected(orgId)
+			? selectedOrgIds.filter((id) => id !== orgId)
+			: [...selectedOrgIds, orgId];
+		recomputeSource();
+	}
+
+	// Recomputes the transfer core's source list from the org filter. This is
+	// what enforces the hard pool boundary: with orgs selected, ONLY members of
+	// those orgs can ever appear in the source (and therefore be moved).
+	// `target` (already-available players) is left untouched so in-progress
+	// additions aren't clobbered by a filter change.
+	function recomputeSource() {
+		if (!transferCore) return;
+		const inPool = new Set(availablePlayers.map((a) => a.player_id));
+		const targetIds = new Set(transferCore.target.map((u) => u.id));
+		const base = users.filter((u) => !inPool.has(u.id) && !targetIds.has(u.id));
+		if (selectedOrgIds.length === 0) {
+			transferCore.source = base;
+		} else {
+			const memberIds = memberIdsOfSelectedOrgs();
+			transferCore.source = base.filter((u) => memberIds.has(u.id));
+		}
+		// Drop stale selections referencing users no longer in the source.
+		transferCore.selectedSourceItems.clear();
+		transferCore.sourceSearchQuery = '';
+	}
+
+	const filteredMemberCount = $derived(memberIdsOfSelectedOrgs().size);
 
 	// Persists the transfer-list state: adds players that moved into the
 	// target, removes players that moved back to the source.
@@ -478,9 +550,47 @@
 				</p>
 				{#if transferCore}
 					<div class="mt-4">
+						<div class="mb-4 flex flex-wrap items-center gap-2">
+							<span class="text-sm font-medium">Organizations</span>
+							{#if organizations.length === 0}
+								<span class="text-sm text-muted-foreground">
+									No organizations yet.
+								</span>
+							{:else}
+								<button
+									type="button"
+									class="rounded-full border px-3 py-1 text-sm transition-colors {selectedOrgIds.length === 0
+										? 'border-primary bg-primary text-primary-foreground'
+										: 'border-input text-muted-foreground hover:text-foreground'}"
+									onclick={() => {
+										selectedOrgIds = [];
+										recomputeSource();
+									}}
+								>
+									All users
+								</button>
+								{#each organizations as org (org.id)}
+									<button
+										type="button"
+										class="rounded-full border px-3 py-1 text-sm transition-colors {isOrgSelected(org.id)
+											? 'border-primary bg-primary text-primary-foreground'
+											: 'border-input text-muted-foreground hover:text-foreground'}"
+										onclick={() => toggleOrg(org.id)}
+									>
+										{org.name}
+									</button>
+								{/each}
+							{/if}
+						</div>
 						<TransferList.Root direction="horizontal">
 							<TransferList.Container>
-								<TransferList.Title title="All players" />
+								<TransferList.Title
+									title={
+										selectedOrgIds.length > 0
+											? `All players (filtered) — ${filteredMemberCount} member${filteredMemberCount === 1 ? '' : 's'}`
+											: 'All players'
+									}
+								/>
 								<TransferList.Toolbar
 									variant="source"
 									core={transferCore}


### PR DESCRIPTION
Implements #147.

## Summary
Adds an Organization multi-select filter to the "Available players" tab on the Draft setup page. A season's draft pool can now be built from a subset of Users (e.g. men's pool, women's pool, Club A vs Club B).

## Design
- **Transient UI filter only** — no schema change, nothing persisted on the Draft.
- **Hard pool boundary** — with orgs selected, `transferCore.source` is recomputed to only members of the selected orgs minus persisted pool minus in-progress target additions, so non-members can never be moved into the pool (including via "move all").
- Multi-select = **union** of members. No selection = all Users (unchanged behavior).
- Target ("Available for draft") is untouched: anyone already in the pool stays and can be removed even if not in a selected org.
- Persistence uses the existing `handleSavePlayers()` diff logic — no changes needed.
- Org toggles are driven one-way with explicit `onclick` handlers writing to `$state` (avoids the Svelte 5 object-key / `#each`-item bind no-op).

## Data
`load()` now also fetches `listOrganizations()` and, per org, `listMembers(orgId)`, building a `userIdsByOrg: Map<string, Set<string>>`.

## UI
- Toggle chips above the source transfer-list container ("All users" + one chip per org).
- When a filter is active the source title becomes "All players (filtered) — N members".

## Tests
- New e2e test in `draft-setup.spec.ts` covering: union/member-only source, hard boundary, and deselection restoring all users.

## Verification
- `cd ui && npm run check` passes (0 errors / 0 warnings).
- `make e2e` passes (24/24) across three full parallel runs.