### PR TITLE
Allow draft owners to delete a draft from the setup page

### DIFF
--- a/ui/e2e/draft.spec.ts
+++ b/ui/e2e/draft.spec.ts
@@ -52,3 +52,30 @@ test('draft create navigates to its setup page and appears in the list', async (
 	});
 	expect(res.ok()).toBeTruthy();
 });
+
+test('a created draft can be deleted by its owner from the setup page', async ({ page }) => {
+	await login(page);
+
+	const unique = Date.now();
+	const draftName = `Delete Me Draft ${unique}`;
+
+	// Create
+	await page.goto('/drafts');
+	await page.getByRole('link', { name: 'New draft' }).click();
+	await waitForHydration(page);
+	await page.getByLabel('Name').fill(draftName);
+	await page.getByLabel('Format').selectOption({ label: SEED_FORMAT });
+	await page.getByRole('button', { name: 'Create draft' }).click();
+
+	// Lands on the setup page, which shows the delete control for the owner.
+	await expect(page).toHaveURL(/\/drafts\/[0-9a-f]+$/);
+	await expect(page.getByRole('heading', { name: draftName })).toBeVisible();
+	const deleteTrigger = page.getByRole('button', { name: 'Delete draft' });
+	await expect(deleteTrigger).toBeVisible();
+
+	// Confirm deletion; the page navigates back to the list.
+	await deleteTrigger.click();
+	await page.getByRole('button', { name: 'Delete', exact: true }).click();
+	await expect(page).toHaveURL(/\/drafts$/);
+	await expect(page.getByRole('link', { name: draftName })).toHaveCount(0);
+});

--- a/ui/src/routes/drafts/[id]/+page.svelte
+++ b/ui/src/routes/drafts/[id]/+page.svelte
@@ -1,11 +1,14 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { page } from '$app/state';
+	import { goto } from '$app/navigation';
+	import { getCurrentUserId } from '$lib/auth';
 	import {
 		getDraft,
 		initializeDraft,
 		assignDraftablePlayers,
-		assignRatingCutoff
+		assignRatingCutoff,
+		deleteDraft
 	} from '$lib/draft';
 	import type { Draft } from '$lib/draft';
 	import { listFormats } from '$lib/format';
@@ -30,7 +33,7 @@
 	import { listDraftPicks } from '$lib/draftPick';
 	import type { DraftPick } from '$lib/draftPick';
 	import { Badge } from '$lib/components/ui/badge/index.js';
-	import { Button } from '$lib/components/ui/button/index.js';
+	import { Button, buttonVariants } from '$lib/components/ui/button/index.js';
 	import {
 		Card,
 		CardContent,
@@ -42,6 +45,14 @@
 		NativeSelect,
 		NativeSelectOption
 	} from '$lib/components/ui/native-select/index.js';
+	import {
+		Popover,
+		PopoverClose,
+		PopoverContent,
+		PopoverHeader,
+		PopoverTitle,
+		PopoverTrigger
+	} from '$lib/components/ui/popover/index.js';
 	import {
 		Tabs,
 		TabsContent,
@@ -85,6 +96,27 @@
 
 	// Which setup section is shown in the sidebar at a time.
 	let activeTab = $state('captains');
+
+	// Delete the draft (owner only). Deleting cascades to all of the draft's
+	// join rows (see model.Draft.PostDelete).
+	let deleting = $state(false);
+	let deleteOpen = $state(false);
+
+	// The owner of the draft, from the JWT `sub` claim.
+	const currentUserId = getCurrentUserId();
+
+	async function handleDelete() {
+		deleteOpen = false;
+		actionError = '';
+		deleting = true;
+		try {
+			await deleteDraft(id());
+			await goto('/drafts');
+		} catch (e) {
+			actionError = e instanceof Error ? e.message : 'Failed to delete draft';
+			deleting = false;
+		}
+	}
 
 	async function load() {
 		loading = true;
@@ -312,6 +344,29 @@
 		<a href={`/drafts/${id()}/results`} class="text-sm text-muted-foreground hover:text-foreground">
 			Results →
 		</a>
+		{#if currentUserId !== null && draft?.owner === currentUserId}
+			<Popover bind:open={deleteOpen}>
+				<PopoverTrigger
+					disabled={deleting}
+					class={buttonVariants({ variant: 'destructive', size: 'sm' })}
+				>
+					{deleting ? 'Deleting...' : 'Delete draft'}
+				</PopoverTrigger>
+				<PopoverContent class="w-80">
+					<PopoverHeader>
+						<PopoverTitle>Delete draft?</PopoverTitle>
+						<p class="text-sm text-muted-foreground">
+							This permanently removes this draft, its teams, players and picks, and
+							cannot be undone.
+						</p>
+					</PopoverHeader>
+					<div class="flex justify-end gap-2">
+						<PopoverClose class={buttonVariants({ variant: 'outline', size: 'sm' })}>Cancel</PopoverClose>
+						<Button variant="destructive" size="sm" onclick={handleDelete}>Delete</Button>
+					</div>
+				</PopoverContent>
+			</Popover>
+		{/if}
 		<a href="/drafts" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to drafts</a>
 	</div>
 </div>


### PR DESCRIPTION
## What

Adds a **Delete draft** button (owner-only) to the draft setup page (`/drafts/[id]`), with a confirmation popover. Clicking it calls the existing `DELETE /api/draft/:id` endpoint, which the backend already permits for the owner (`Draft.EditableBy` returns the owner) and cascades to the draft's join rows via `Draft.PostDelete`.

Previously the backend supported deleting a draft, but the UI had no way to trigger it — so a draft created with the wrong teams/info was effectively stuck.

## Verification
- `npm run check` (svelte-check + typecheck): 0 errors, 0 warnings
- `make e2e`: full suite green (25 tests), including a new e2e test `a created draft can be deleted by its owner from the setup page`

## Notes
- Delete is shown only to the draft owner (JWT `sub` vs `draft.owner`). Non-owners don't see the button; the backend independently enforces authorization.
- Button is available for created and initialized-but-not-completed drafts (as requested); it also works for completed drafts since the backend permits owner deletion generally.