### PR TITLE
Teams: rosters & co-captain promotion (constrained surface)

### DIFF
--- a/database/contract_test_helpers_test.go
+++ b/database/contract_test_helpers_test.go
@@ -66,6 +66,15 @@ CREATE TABLE private_record (
 	shared_to TEXT,
 	value     TEXT
 );
+CREATE TABLE reentrant_group (
+	id    TEXT PRIMARY KEY,
+	name  TEXT
+);
+CREATE TABLE reentrant_membership (
+	id       TEXT PRIMARY KEY,
+	group_id TEXT,
+	user_id  TEXT
+);
 `
 
 // contractSqliteMemorySeq ensures each SQLite in-memory contract-test provider

--- a/database/reentrant_access_test.go
+++ b/database/reentrant_access_test.go
@@ -1,0 +1,135 @@
+package database
+
+import (
+	"context"
+	"testing"
+)
+
+// Regression coverage for the re-entrant-provider deadlock (the in-memory
+// provider held its non-reentrant mutex while running a where predicate, so a
+// record whose AccessibleTo/EditableBy re-enters the provider deadlocked — e.g.
+// Team → TeamAssignment). See unit_test_db_provider.go GetAllWhere.
+
+// reentrantGroup models a record whose AccessibleTo resolves its members by
+// reading the reentrantMembership join table, i.e. it re-enters the provider
+// from inside an access-control query. This mirrors model.Team (whose
+// AccessibleTo calls GetMembers → GetAllWhere[TeamAssignment]).
+type reentrantGroup struct {
+	ID   RecordId `json:"id"`
+	Name string   `json:"name"`
+}
+
+func (g *reentrantGroup) GetOwner() UserId            { return InvalidUserId }
+func (g *reentrantGroup) SetOwner(UserId)             {}
+func (g *reentrantGroup) Type() string                { return "reentrant_group" }
+func (g *reentrantGroup) GetId() RecordId             { return g.ID }
+func (g *reentrantGroup) SetId(id RecordId)           { g.ID = id }
+func (g *reentrantGroup) NewRecord() CrudRecord       { return new(reentrantGroup) }
+func (g *reentrantGroup) StaticallyValid() error      { return nil }
+func (g *reentrantGroup) DynamicallyValid(context.Context, Provider) error { return nil }
+func (g *reentrantGroup) EditableBy(context.Context, Provider) []UserId     { return nil }
+
+// AccessibleTo re-enters the provider by reading this group's memberships.
+func (g *reentrantGroup) AccessibleTo(ctx context.Context, db Provider) []UserId {
+	members, err := GetAllWhere[*reentrantMembership](ctx, db, func(_ context.Context, m *reentrantMembership) bool {
+		return m.GroupId == g.ID
+	})
+	if err != nil {
+		return nil
+	}
+	ids := make([]UserId, 0, len(members))
+	for _, m := range members {
+		ids = append(ids, m.UserId)
+	}
+	return ids
+}
+
+// reentrantMembership is a join row linking a user to a group.
+type reentrantMembership struct {
+	ID      RecordId `json:"id"`
+	GroupId RecordId `json:"group_id"`
+	UserId  UserId   `json:"user_id"`
+}
+
+func (m *reentrantMembership) GetOwner() UserId              { return InvalidUserId }
+func (m *reentrantMembership) SetOwner(UserId)               {}
+func (m *reentrantMembership) Type() string                  { return "reentrant_membership" }
+func (m *reentrantMembership) GetId() RecordId               { return m.ID }
+func (m *reentrantMembership) SetId(id RecordId)             { m.ID = id }
+func (m *reentrantMembership) NewRecord() CrudRecord         { return new(reentrantMembership) }
+func (m *reentrantMembership) StaticallyValid() error        { return nil }
+func (m *reentrantMembership) DynamicallyValid(context.Context, Provider) error { return nil }
+func (m *reentrantMembership) EditableBy(context.Context, Provider) []UserId     { return nil }
+func (m *reentrantMembership) AccessibleTo(context.Context, Provider) []UserId   { return AccessibleToEveryone }
+
+func newStoredReentrantGroup(t *testing.T, db Provider) *reentrantGroup {
+	t.Helper()
+	g := &reentrantGroup{}
+	v, err := CreateOne(context.Background(), db, g)
+	if err != nil {
+		t.Fatalf("create group: %v", err)
+	}
+	return v
+}
+
+func addReentrantMembership(t *testing.T, db Provider, groupId RecordId, userId UserId) {
+	t.Helper()
+	m := &reentrantMembership{GroupId: groupId, UserId: userId}
+	if _, err := CreateOne(context.Background(), db, m); err != nil {
+		t.Fatalf("create membership: %v", err)
+	}
+}
+
+// testGetAllWithReentrantAccessibleTo exercises WithAccessControl.GetAll over a
+// record whose AccessibleTo re-enters the provider. On the in-memory provider
+// this previously deadlocked because the outer GetAllWhere held the mutex while
+// the access-control filter issued a nested read.
+func testGetAllWithReentrantAccessibleTo(t *testing.T, db Provider) {
+	memberA := UserId(NewRecordId())
+	memberB := UserId(NewRecordId())
+	outsider := UserId(NewRecordId())
+
+	// Group 1 is shared with A and B; group 2 belongs to nobody the caller knows.
+	g1 := newStoredReentrantGroup(t, db)
+	addReentrantMembership(t, db, g1.ID, memberA)
+	addReentrantMembership(t, db, g1.ID, memberB)
+	g2 := newStoredReentrantGroup(t, db)
+
+	// A can see only group 1.
+	wac := WithAccessControl[*reentrantGroup]{Database: db, AccessControlUser: memberA}
+	results, err := wac.GetAll(context.Background())
+	if err != nil {
+		t.Fatalf("GetAll with re-entrant AccessibleTo: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 group for member A, got %d", len(results))
+	}
+	if results[0].ID != g1.ID {
+		t.Fatalf("expected group 1, got %s", results[0].ID)
+	}
+
+	// An outsider with no memberships sees no groups.
+	wacOutsider := WithAccessControl[*reentrantGroup]{Database: db, AccessControlUser: outsider}
+	results, err = wacOutsider.GetAll(context.Background())
+	if err != nil {
+		t.Fatalf("GetAll (outsider): %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("expected 0 groups for outsider, got %d", len(results))
+	}
+
+	// g2 has no members, so it is not visible to anyone via GetAll.
+	if _, exists, err := wac.GetOneById(context.Background(), g2, g2.ID); err != nil {
+		t.Fatalf("GetOneById group 2: %v", err)
+	} else if exists {
+		t.Fatalf("group 2 should not be visible to member A")
+	}
+}
+
+// TestReentrantAccessContract runs the re-entrant access-control regression
+// across every provider kind (memory, SQLite in-memory, SQLite on-disk).
+func TestReentrantAccessContract(t *testing.T) {
+	runContractTests(t, []contractTest{
+		{name: "TestGetAllWithReentrantAccessibleTo", fn: testGetAllWithReentrantAccessibleTo},
+	})
+}

--- a/database/unit_test_db_provider.go
+++ b/database/unit_test_db_provider.go
@@ -53,11 +53,23 @@ func (u *UnitTestDbProvider) GetAll(ctx context.Context, recordType CrudRecord) 
 }
 
 func (u *UnitTestDbProvider) GetAllWhere(ctx context.Context, recordType CrudRecord, where WhereFunc) ([]CrudRecord, error) {
+	// Snapshot the records under the lock, then evaluate the where predicate
+	// outside it. The predicate may itself re-enter the provider — e.g. a
+	// record's AccessibleTo/EditableBy resolving its members via another
+	// GetAllWhere/GetOne (Team → TeamAssignment). Because u.mu is a plain,
+	// non-reentrant Mutex, holding it while running the predicate would
+	// deadlock on that nested read. The snapshot is stable, so the predicate
+	// is safe to run unlocked.
 	u.mu.Lock()
-	defer u.mu.Unlock()
-	output := make([]CrudRecord, 0)
 	cache := u.getOrCreateRecordCache(recordType)
+	records := make([]CrudRecord, 0, len(cache))
 	for _, record := range cache {
+		records = append(records, record)
+	}
+	u.mu.Unlock()
+
+	output := make([]CrudRecord, 0, len(records))
+	for _, record := range records {
 		if where == nil || where(ctx, record) {
 			output = append(output, record)
 		}

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ import (
 	"intraclub/route/format"
 	"intraclub/route/organization"
 	"intraclub/route/ruleset"
+	"intraclub/route/team"
 	"intraclub/route/user"
 
 	"github.com/gin-gonic/gin"
@@ -116,6 +117,13 @@ func main() {
 	seasonTeams.HandleRouteTypes(rg, api.CrudWrapperFunctionGetOne, api.CrudWrapperFunctionGetMany)
 	teamRatings := api.NewCrudCommon(func() *model.TeamRating { return &model.TeamRating{} }, false, db)
 	teamRatings.HandleRouteTypes(rg, api.CrudWrapperFunctionGetOne, api.CrudWrapperFunctionGetMany)
+
+	// Teams are largely immutable after the draft finalizes: they are exposed
+	// only through the constrained read + role-assignment surface in
+	// route/team (no generic create/update/delete on the raw records). Roster
+	// reads are restricted to team members, sysadmins, and season
+	// commissioners; only a team's captain / co-captains can assign roles.
+	team.RegisterRoutes(rg, db)
 
 	playoffStructures := api.NewCrudCommon(model.NewPlayoffStructure, false, db)
 	playoffStructures.HandleRouteTypes(rg, api.CrudWrapperFunctionAll...)

--- a/route/team/promote.go
+++ b/route/team/promote.go
@@ -1,0 +1,105 @@
+package team
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"intraclub/api"
+	"intraclub/database"
+	"intraclub/model"
+
+	"github.com/gin-gonic/gin"
+)
+
+// BaseRoute is the base API route for Team records. It matches the model's
+// Type() ("team").
+var BaseRoute = "/team"
+
+// PromoteCoCaptainBody is the request body for PromoteCoCaptain.
+type PromoteCoCaptainBody struct {
+	// UserId is the team member to promote to co-captain.
+	UserId database.UserId `json:"user_id"`
+}
+
+// StaticallyValid ensures a user was provided.
+func (b *PromoteCoCaptainBody) StaticallyValid() error {
+	if b.UserId == database.InvalidUserId {
+		return errors.New("user_id must not be empty")
+	}
+	return nil
+}
+
+// PromoteCoCaptain promotes an existing team member to co-captain by updating
+// their TeamAssignment role. This is a constrained role-assignment endpoint:
+// it is the only way to change a team's roster roles (there is no generic
+// create/update/delete on Team / TeamAssignment records), and only the team's
+// captain / co-captains may use it.
+//
+// The captain cannot be demoted and members who are already co-captains are
+// rejected, keeping the roster largely immutable after the draft finalizes.
+type PromoteCoCaptain struct{}
+
+func (c PromoteCoCaptain) Path() (api.HttpMethod, string) {
+	return api.HttpMethodPost, api.AppendPathId(BaseRoute) + "/promote_co_captain"
+}
+
+func (c PromoteCoCaptain) RequestBody() (*PromoteCoCaptainBody, bool) {
+	return &PromoteCoCaptainBody{}, true
+}
+
+func (c PromoteCoCaptain) Handler(req api.Request[*PromoteCoCaptainBody]) (any, int, error) {
+	if req.Token == nil {
+		return nil, http.StatusUnauthorized, errors.New("token is required")
+	}
+
+	team, err := database.GetExistingRecordById(req.Context, req.DatabaseProvider, &model.Team{}, req.PathId)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+
+	// Only the team's captain / co-captains may assign roles.
+	wac := database.NewWithAccessControl[*model.Team](req.Context, req.DatabaseProvider, req.Token.UserId)
+	if !wac.CanUserEdit(team) {
+		return nil, http.StatusForbidden, errors.New("not authorized to modify this team")
+	}
+
+	assignment, err := findAssignment(req, team.ID, req.Body.UserId)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	if assignment == nil {
+		return nil, http.StatusNotFound, errors.New("user is not a member of this team")
+	}
+
+	if assignment.Role == model.TeamRoleCaptain {
+		return nil, http.StatusBadRequest, errors.New("the captain cannot be promoted to co-captain")
+	}
+	if assignment.Role == model.TeamRoleCoCaptain {
+		return nil, http.StatusBadRequest, errors.New("user is already a co-captain of this team")
+	}
+
+	assignment.Role = model.TeamRoleCoCaptain
+	if err := database.UpdateOne(req.Context, req.DatabaseProvider, assignment); err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+
+	return gin.H{api.ResourceKey: assignment}, http.StatusOK, nil
+}
+
+// findAssignment looks up the TeamAssignment join record linking the given
+// team and user, returning nil if it does not exist.
+func findAssignment[T database.Validatable](req api.Request[T], teamId model.TeamId, userId database.UserId) (*model.TeamAssignment, error) {
+	assignments, err := database.GetAllWhere[*model.TeamAssignment](req.Context, req.DatabaseProvider,
+		func(_ context.Context, a *model.TeamAssignment) bool {
+			return a.TeamId == teamId && a.UserId == userId
+		})
+	if err != nil {
+		return nil, fmt.Errorf("failed to look up team assignment: %w", err)
+	}
+	if len(assignments) == 0 {
+		return nil, nil
+	}
+	return assignments[0], nil
+}

--- a/route/team/promote_test.go
+++ b/route/team/promote_test.go
@@ -1,0 +1,345 @@
+package team
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/rand/v2"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"intraclub/api"
+	"intraclub/database"
+	"intraclub/model"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// test setup helpers (mirror route/organization/membership_test.go)
+// ---------------------------------------------------------------------------
+
+func newStoredUser(t *testing.T, db database.Provider) *model.User {
+	t.Helper()
+	user := model.NewUser()
+	user.Email = model.EmailAddress(fmt.Sprintf("user%d@email.com", rand.Uint64()))
+	user.FirstName = fmt.Sprintf("Test %d", rand.Uint64())
+	user.LastName = "User"
+	user.PhoneNumber = model.PhoneNumber(fmt.Sprintf("%d", 100_000_0000+rand.Uint32N(999_999_999)))
+	v, err := database.CreateOne(context.Background(), db, user)
+	require.NoError(t, err)
+	return v
+}
+
+// newTestRouter builds a gin engine with the Team read-only surface + the
+// promote endpoint registered (as in main.go) and the auth globals wired up so
+// real tokens validate.
+func newTestRouter(t *testing.T, db database.Provider) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	api.UserType = &model.User{}
+	database.SysAdminCheck = model.IsUserSystemAdministrator
+
+	router := gin.New()
+	group := router.Group("/api")
+
+	RegisterRoutes(group, db)
+
+	return router
+}
+
+// testKeyOnce generates a single JWT keypair shared by every token minted in a
+// test process, so tokens issued by different helpers all verify.
+var (
+	testKeyOnce sync.Once
+	testPubKey  *ecdsa.PublicKey
+	testPrivKey *ecdsa.PrivateKey
+)
+
+// newToken returns a signed JWT for the given user ID without touching key
+// files on disk.
+func newToken(t *testing.T, userId database.UserId) string {
+	t.Helper()
+	testKeyOnce.Do(func() {
+		pub, priv, err := api.GenerateKeyPair()
+		require.NoError(t, err)
+		testPubKey = pub
+		testPrivKey = priv
+	})
+	api.JwtPublicKey = testPubKey
+	api.JwtPrivateKey = testPrivKey
+	token, err := api.GenerateToken(userId.RecordId())
+	require.NoError(t, err)
+	return token
+}
+
+// doJSON performs an authenticated HTTP request against the router.
+func doJSON(t *testing.T, router *gin.Engine, method, path string, body any, token string) *httptest.ResponseRecorder {
+	t.Helper()
+	var reader io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		require.NoError(t, err)
+		reader = bytes.NewReader(b)
+	}
+	req, err := http.NewRequest(method, path, reader)
+	require.NoError(t, err)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if token != "" {
+		req.Header.Set(api.AuthTokenHeaderValue, token)
+	}
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+// newStoredTeam creates a Team record with the given user as captain (as the
+// draft finalize flow would) and returns it.
+func newStoredTeam(t *testing.T, db database.Provider, captain *model.User) *model.Team {
+	t.Helper()
+	team := model.NewDefaultTeam(captain.ID, "Team 1")
+	team, err := database.CreateOne(context.Background(), db, team)
+	require.NoError(t, err)
+	return team
+}
+
+// addAssignment adds a TeamAssignment row for the given user on the team.
+func addAssignment(t *testing.T, db database.Provider, team *model.Team, user *model.User, role model.TeamRole) *model.TeamAssignment {
+	t.Helper()
+	a := &model.TeamAssignment{TeamId: team.ID, UserId: user.ID, Role: role}
+	v, err := database.CreateOne(context.Background(), db, a)
+	require.NoError(t, err)
+	return v
+}
+
+func assignmentRole(t *testing.T, db database.Provider, team *model.Team, user *model.User) model.TeamRole {
+	t.Helper()
+	assignments, err := database.GetAllWhere[*model.TeamAssignment](context.Background(), db,
+		func(_ context.Context, a *model.TeamAssignment) bool { return a.TeamId == team.ID && a.UserId == user.ID })
+	require.NoError(t, err)
+	require.Len(t, assignments, 1)
+	return assignments[0].Role
+}
+
+// ---------------------------------------------------------------------------
+// Promote endpoint
+// ---------------------------------------------------------------------------
+
+func TestPromoteCoCaptain(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	captain := newStoredUser(t, db)
+	member := newStoredUser(t, db)
+
+	team := newStoredTeam(t, db, captain)
+	addAssignment(t, db, team, member, model.TeamRoleMember)
+
+	// The captain promotes the member.
+	w := doJSON(t, router, http.MethodPost, "/api/team/"+team.ID.String()+"/promote_co_captain",
+		map[string]any{"user_id": member.ID.String()}, newToken(t, captain.ID))
+	require.Equal(t, http.StatusOK, w.Code, "promote: %s", w.Body.String())
+
+	var promoted struct {
+		Resource *model.TeamAssignment `json:"resource"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &promoted))
+	require.NotNil(t, promoted.Resource)
+	require.Equal(t, model.TeamRoleCoCaptain, promoted.Resource.Role)
+	require.Equal(t, model.TeamRoleCoCaptain, assignmentRole(t, db, team, member))
+}
+
+func TestPromoteCoCaptainByCoCaptain(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	captain := newStoredUser(t, db)
+	coCaptain := newStoredUser(t, db)
+	member := newStoredUser(t, db)
+
+	team := newStoredTeam(t, db, captain)
+	addAssignment(t, db, team, coCaptain, model.TeamRoleCoCaptain)
+	addAssignment(t, db, team, member, model.TeamRoleMember)
+
+	// A co-captain may also assign roles.
+	w := doJSON(t, router, http.MethodPost, "/api/team/"+team.ID.String()+"/promote_co_captain",
+		map[string]any{"user_id": member.ID.String()}, newToken(t, coCaptain.ID))
+	require.Equal(t, http.StatusOK, w.Code, "promote by co-captain: %s", w.Body.String())
+	require.Equal(t, model.TeamRoleCoCaptain, assignmentRole(t, db, team, member))
+}
+
+func TestPromoteCoCaptainAuthz(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	captain := newStoredUser(t, db)
+	member := newStoredUser(t, db)
+	outsider := newStoredUser(t, db)
+
+	team := newStoredTeam(t, db, captain)
+	addAssignment(t, db, team, member, model.TeamRoleMember)
+
+	// A non-member cannot promote.
+	w := doJSON(t, router, http.MethodPost, "/api/team/"+team.ID.String()+"/promote_co_captain",
+		map[string]any{"user_id": member.ID.String()}, newToken(t, outsider.ID))
+	require.Equal(t, http.StatusForbidden, w.Code, "outsider promote: %s", w.Body.String())
+	require.Equal(t, model.TeamRoleMember, assignmentRole(t, db, team, member))
+
+	// Unauthenticated request is rejected.
+	w = doJSON(t, router, http.MethodPost, "/api/team/"+team.ID.String()+"/promote_co_captain",
+		map[string]any{"user_id": member.ID.String()}, "")
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestPromoteCoCaptainInvalidCases(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	captain := newStoredUser(t, db)
+	coCaptain := newStoredUser(t, db)
+	member := newStoredUser(t, db)
+	nonMember := newStoredUser(t, db)
+
+	team := newStoredTeam(t, db, captain)
+	addAssignment(t, db, team, coCaptain, model.TeamRoleCoCaptain)
+	addAssignment(t, db, team, member, model.TeamRoleMember)
+
+	captainToken := newToken(t, captain.ID)
+
+	// Cannot promote the captain.
+	w := doJSON(t, router, http.MethodPost, "/api/team/"+team.ID.String()+"/promote_co_captain",
+		map[string]any{"user_id": captain.ID.String()}, captainToken)
+	require.Equal(t, http.StatusBadRequest, w.Code)
+
+	// Cannot promote an existing co-captain.
+	w = doJSON(t, router, http.MethodPost, "/api/team/"+team.ID.String()+"/promote_co_captain",
+		map[string]any{"user_id": coCaptain.ID.String()}, captainToken)
+	require.Equal(t, http.StatusBadRequest, w.Code)
+
+	// Cannot promote a user who is not on the team.
+	w = doJSON(t, router, http.MethodPost, "/api/team/"+team.ID.String()+"/promote_co_captain",
+		map[string]any{"user_id": nonMember.ID.String()}, captainToken)
+	require.Equal(t, http.StatusNotFound, w.Code)
+
+	// Missing user_id is rejected statically.
+	w = doJSON(t, router, http.MethodPost, "/api/team/"+team.ID.String()+"/promote_co_captain",
+		map[string]any{}, captainToken)
+	require.Equal(t, http.StatusBadRequest, w.Code)
+
+	// Unknown team id.
+	w = doJSON(t, router, http.MethodPost, "/api/team/999/promote_co_captain",
+		map[string]any{"user_id": member.ID.String()}, captainToken)
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// ---------------------------------------------------------------------------
+// Commissioner read access
+// ---------------------------------------------------------------------------
+
+func TestSeasonCommissionerCanViewTeam(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	captain := newStoredUser(t, db)
+	member := newStoredUser(t, db)
+	commissioner := newStoredUser(t, db)
+
+	team := newStoredTeam(t, db, captain)
+	addAssignment(t, db, team, member, model.TeamRoleMember)
+
+	// Wire the team into a season with the commissioner attached.
+	season := model.NewSeason()
+	season.Name = "Test Season"
+	season.StartTime = model.NewStartTime(8, 30)
+	season, err := database.CreateOne(context.Background(), db, season)
+	require.NoError(t, err)
+
+	seasonTeam := &model.SeasonTeam{SeasonId: season.ID, TeamId: team.ID}
+	_, err = database.CreateOne(context.Background(), db, seasonTeam)
+	require.NoError(t, err)
+
+	seasonCommissioner := &model.SeasonCommissioner{SeasonId: season.ID, UserId: commissioner.ID}
+	_, err = database.CreateOne(context.Background(), db, seasonCommissioner)
+	require.NoError(t, err)
+
+	// The commissioner can view the team (list + detail) ...
+	w := doJSON(t, router, http.MethodGet, "/api/team/"+team.ID.String(), nil, newToken(t, commissioner.ID))
+	require.Equal(t, http.StatusOK, w.Code, "commissioner get team: %s", w.Body.String())
+
+	w = doJSON(t, router, http.MethodGet, "/api/team", nil, newToken(t, commissioner.ID))
+	require.Equal(t, http.StatusOK, w.Code)
+	var many struct {
+		Resource []TeamRoster `json:"resource"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &many))
+	require.Len(t, many.Resource, 1)
+
+	// ... but cannot promote a member (role assignment is a team function).
+	w = doJSON(t, router, http.MethodPost, "/api/team/"+team.ID.String()+"/promote_co_captain",
+		map[string]any{"user_id": member.ID.String()}, newToken(t, commissioner.ID))
+	require.Equal(t, http.StatusForbidden, w.Code, "commissioner promote: %s", w.Body.String())
+	require.Equal(t, model.TeamRoleMember, assignmentRole(t, db, team, member))
+}
+
+// ---------------------------------------------------------------------------
+// Read-only surface: no generic create/update/delete on raw records
+// ---------------------------------------------------------------------------
+
+func TestTeamReadSurface(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	captain := newStoredUser(t, db)
+	member := newStoredUser(t, db)
+	outsider := newStoredUser(t, db)
+
+	team := newStoredTeam(t, db, captain)
+	addAssignment(t, db, team, member, model.TeamRoleMember)
+
+	// GET one + GET many work for a team member.
+	w := doJSON(t, router, http.MethodGet, "/api/team/"+team.ID.String(), nil, newToken(t, captain.ID))
+	require.Equal(t, http.StatusOK, w.Code, "get team: %s", w.Body.String())
+	var one struct {
+		Resource TeamRoster `json:"resource"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &one))
+	require.Equal(t, team.ID, one.Resource.Team.ID)
+	require.Len(t, one.Resource.Assignments, 2)
+
+	w = doJSON(t, router, http.MethodGet, "/api/team", nil, newToken(t, captain.ID))
+	require.Equal(t, http.StatusOK, w.Code)
+	var many struct {
+		Resource []TeamRoster `json:"resource"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &many))
+	require.Len(t, many.Resource, 1)
+
+	// A non-member cannot see the team.
+	w = doJSON(t, router, http.MethodGet, "/api/team", nil, newToken(t, outsider.ID))
+	require.Equal(t, http.StatusOK, w.Code)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &many))
+	require.Empty(t, many.Resource)
+
+	w = doJSON(t, router, http.MethodGet, "/api/team/"+team.ID.String(), nil, newToken(t, outsider.ID))
+	require.Equal(t, http.StatusNotFound, w.Code)
+
+	// Raw create/update/delete on Team and TeamAssignment are not registered:
+	// they must not be routable.
+	for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodDelete} {
+		path := "/api/team"
+		if method != http.MethodPost {
+			path += "/" + team.ID.String()
+		}
+		w = doJSON(t, router, method, path, map[string]any{"name": "x"}, newToken(t, captain.ID))
+		require.Equal(t, http.StatusNotFound, w.Code, "%s %s should not be routable", method, path)
+
+		path = "/api/team_assignment"
+		if method != http.MethodPost {
+			path += "/1"
+		}
+		w = doJSON(t, router, method, path, map[string]any{}, newToken(t, captain.ID))
+		require.Equal(t, http.StatusNotFound, w.Code, "%s %s should not be routable", method, path)
+	}
+}

--- a/route/team/roster.go
+++ b/route/team/roster.go
@@ -1,0 +1,182 @@
+package team
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"intraclub/api"
+	"intraclub/database"
+	"intraclub/model"
+
+	"github.com/gin-gonic/gin"
+)
+
+// TeamRoster is the read shape returned for a team: the Team record itself
+// plus its member assignments (with roles). It is used by both the list and
+// detail endpoints.
+type TeamRoster struct {
+	Team        *model.Team             `json:"team"`
+	Assignments []*model.TeamAssignment `json:"assignments"`
+}
+
+// loadAccessibleTeam fetches the Team referenced by the request's path ID and
+// verifies the requesting user may view it (member, sysadmin, or a season
+// commissioner). Returns the team, or the appropriate HTTP status + error if
+// the user cannot access it.
+func loadAccessibleTeam[T database.Validatable](req api.Request[T]) (*model.Team, int, error) {
+	if req.Token == nil {
+		return nil, http.StatusUnauthorized, errors.New("token is required")
+	}
+
+	team, err := database.GetExistingRecordById(req.Context, req.DatabaseProvider, &model.Team{}, req.PathId)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+
+	ok, err := canAccessTeam(req, team, req.Token.UserId)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	if !ok {
+		return nil, http.StatusNotFound, errors.New("team not found")
+	}
+	return team, http.StatusOK, nil
+}
+
+// canAccessTeam reports whether the given user may view the team: its members,
+// a sysadmin, or a commissioner of any season the team belongs to. Role
+// assignment (promote) is a separate, stricter check in PromoteCoCaptain.
+func canAccessTeam[T database.Validatable](req api.Request[T], team *model.Team, userId database.UserId) (bool, error) {
+	isMember, err := team.IsTeamMember(req.Context, req.DatabaseProvider, userId)
+	if err != nil {
+		return false, err
+	}
+	if isMember {
+		return true, nil
+	}
+
+	isSysAdmin, err := database.SysAdminCheck(req.Context, req.DatabaseProvider, userId)
+	if err != nil {
+		return false, err
+	}
+	if isSysAdmin {
+		return true, nil
+	}
+
+	return isSeasonCommissionerOfTeam(req.Context, req.DatabaseProvider, team.ID, userId)
+}
+
+// isSeasonCommissionerOfTeam reports whether the user is a commissioner of any
+// season that includes the given team.
+func isSeasonCommissionerOfTeam(ctx context.Context, db database.Provider, teamId model.TeamId, userId database.UserId) (bool, error) {
+	seasonTeams, err := database.GetAllWhere[*model.SeasonTeam](ctx, db,
+		func(_ context.Context, st *model.SeasonTeam) bool { return st.TeamId == teamId })
+	if err != nil {
+		return false, err
+	}
+	if len(seasonTeams) == 0 {
+		return false, nil
+	}
+
+	seasonIds := make(map[model.SeasonId]struct{}, len(seasonTeams))
+	for _, st := range seasonTeams {
+		seasonIds[st.SeasonId] = struct{}{}
+	}
+
+	commissioners, err := database.GetAllWhere[*model.SeasonCommissioner](ctx, db,
+		func(_ context.Context, sc *model.SeasonCommissioner) bool { return sc.UserId == userId })
+	if err != nil {
+		return false, err
+	}
+	for _, sc := range commissioners {
+		if _, ok := seasonIds[sc.SeasonId]; ok {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// buildRoster loads the team's member assignments (with roles).
+func buildRoster[T database.Validatable](req api.Request[T], team *model.Team) ([]*model.TeamAssignment, error) {
+	assignments, err := database.GetAllWhere[*model.TeamAssignment](req.Context, req.DatabaseProvider,
+		func(_ context.Context, a *model.TeamAssignment) bool { return a.TeamId == team.ID })
+	if err != nil {
+		return nil, err
+	}
+	return assignments, nil
+}
+
+// EmptyBody is used by routes that do not accept a request body.
+type EmptyBody struct{}
+
+func (b *EmptyBody) StaticallyValid() error {
+	return nil
+}
+
+// ListTeams returns the teams the requesting user may view (members, sysadmins,
+// and season commissioners), each with its roster. This is the read surface for
+// the /teams list page. Team records are deliberately not exposed via generic
+// CRUD.
+type ListTeams struct{}
+
+func (c ListTeams) Path() (api.HttpMethod, string) {
+	return api.HttpMethodGet, BaseRoute
+}
+
+func (c ListTeams) RequestBody() (*EmptyBody, bool) {
+	return &EmptyBody{}, false
+}
+
+func (c ListTeams) Handler(req api.Request[*EmptyBody]) (any, int, error) {
+	if req.Token == nil {
+		return nil, http.StatusUnauthorized, errors.New("token is required")
+	}
+
+	teams, err := database.GetAll[*model.Team](req.Context, req.DatabaseProvider)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+
+	rosters := make([]TeamRoster, 0, len(teams))
+	for _, team := range teams {
+		ok, err := canAccessTeam(req, team, req.Token.UserId)
+		if err != nil {
+			return nil, http.StatusBadRequest, err
+		}
+		if !ok {
+			continue
+		}
+		assignments, err := buildRoster(req, team)
+		if err != nil {
+			return nil, http.StatusBadRequest, err
+		}
+		rosters = append(rosters, TeamRoster{Team: team, Assignments: assignments})
+	}
+
+	return gin.H{api.ResourceKey: rosters}, http.StatusOK, nil
+}
+
+// GetTeam returns a single team and its roster, if the requesting user is a
+// member (or sysadmin).
+type GetTeam struct{}
+
+func (c GetTeam) Path() (api.HttpMethod, string) {
+	return api.HttpMethodGet, api.AppendPathId(BaseRoute)
+}
+
+func (c GetTeam) RequestBody() (*EmptyBody, bool) {
+	return &EmptyBody{}, false
+}
+
+func (c GetTeam) Handler(req api.Request[*EmptyBody]) (any, int, error) {
+	team, status, err := loadAccessibleTeam(req)
+	if err != nil {
+		return nil, status, err
+	}
+	assignments, err := buildRoster(req, team)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	return gin.H{api.ResourceKey: TeamRoster{Team: team, Assignments: assignments}}, http.StatusOK, nil
+}

--- a/route/team/routes.go
+++ b/route/team/routes.go
@@ -1,0 +1,22 @@
+package team
+
+import (
+	"intraclub/api"
+	"intraclub/database"
+
+	"github.com/gin-gonic/gin"
+)
+
+// RegisterRoutes wires up the constrained Team REST surface.
+//
+// Team and TeamAssignment records are exposed read-only (GET one / GET many,
+// registered in main.go) — there is deliberately no generic create/update/delete
+// on the raw records, since rosters are fixed at draft finalize time. This
+// function adds the single mutation endpoint, co-captain role assignment.
+func RegisterRoutes(e *gin.RouterGroup, db database.Provider) {
+	rosterFamily := api.RouteFamily[*EmptyBody]{DatabaseProvider: db}
+	rosterFamily.Handle(e, ListTeams{}, GetTeam{})
+
+	promoteFamily := api.RouteFamily[*PromoteCoCaptainBody]{DatabaseProvider: db}
+	promoteFamily.Handle(e, PromoteCoCaptain{})
+}

--- a/ui/e2e/teams.spec.ts
+++ b/ui/e2e/teams.spec.ts
@@ -1,0 +1,182 @@
+import { expect, test, type Page } from '@playwright/test';
+import { waitForHydration } from './helpers';
+
+// The Go backend runs with --dev-token from the repo root (see
+// playwright.config.ts), so POST /api/one_time_password returns the magic-link
+// token in the response body. Login with the user seeded by SeedDevData.
+async function login(page: Page) {
+	await page.goto('/login');
+	await page.waitForLoadState('networkidle');
+	await page.getByLabel('Email').fill('jdarthur@gatech.edu');
+	await page.getByRole('button', { name: 'Send login link' }).click();
+	const link = page.getByRole('main').getByRole('link', { name: 'Log in' });
+	await expect(link).toBeVisible();
+	await link.click();
+	await expect(page).toHaveURL('/');
+}
+
+// SeedDevData creates a format named "Men's Intraclub".
+const SEED_FORMAT = "Men's Intraclub";
+const API = 'http://127.0.0.1:8080/api';
+
+async function tokenFor(page: Page, email: string): Promise<string> {
+	const res = await page.request.post(`${API}/one_time_password`, { data: { email } });
+	expect(res.ok()).toBeTruthy();
+	const { token } = await res.json();
+	const jwtRes = await page.request.post(`${API}/token`, { data: { token } });
+	expect(jwtRes.ok()).toBeTruthy();
+	const { jwt } = await jwtRes.json();
+	return jwt;
+}
+
+test('teams list, roster, and promote to co-captain', async ({ page }) => {
+	await login(page);
+	const token = await page.evaluate(() => localStorage.getItem('intraclub_jwt') ?? '');
+	expect(token).toBeTruthy();
+
+	const unique = Date.now();
+
+	// One captain plus one roster player is enough to complete a draft.
+	const people = [
+		{ first: `TCap${unique}`, last: 'One' },
+		{ first: `TPlay${unique}`, last: 'One' }
+	];
+	const csv = [
+		'First Name, Last Name, Email',
+		...people.map((p) => `${p.first}, ${p.last}, ${p.first.toLowerCase()}@example.com`)
+	].join('\n');
+	const importRes = await page.request.post(`${API}/import_users_from_csv`, {
+		form: { file: csv }
+	});
+	expect(importRes.ok()).toBeTruthy();
+	const importBody = await importRes.json();
+	const [captainId, playerId] = [...importBody.Created, ...importBody.AlreadyExisting].map(
+		(u: { id: string }) => u.id
+	);
+
+	const facilityRes = await page.request.post(`${API}/facility`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { name: `Team Facility ${unique}`, address: `${unique} Main St`, courts: 4 }
+	});
+	expect(facilityRes.ok()).toBeTruthy();
+	const facilityId = (await facilityRes.json()).resource.id as string;
+
+	const formats = (await (await page.request.get(`${API}/format`)).json()).resource as {
+		id: string;
+		name: string;
+	}[];
+	const format = formats.find((f) => f.name === SEED_FORMAT);
+	expect(format).toBeTruthy();
+
+	const draftRes = await page.request.post(`${API}/draft`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { name: `Team Draft ${unique}`, format: format!.id }
+	});
+	expect(draftRes.ok()).toBeTruthy();
+	const draftId = (await draftRes.json()).resource.id as string;
+
+	await page.request.post(`${API}/draft/${draftId}/initialize`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { captains: [captainId] }
+	});
+	await page.request.post(`${API}/draft/${draftId}/assign_draftable_players`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { players: [playerId] }
+	});
+
+	const ratings = (
+		await (
+			await page.request.get(`${API}/format/${format!.id}/possible_ratings`, {
+				headers: { 'X-INTRACLUB-TOKEN': token }
+			})
+		).json()
+	).resource as { id: string }[];
+	expect(ratings.length).toBeGreaterThanOrEqual(2);
+	await page.request.post(`${API}/draft/${draftId}/assign_rating_cutoff`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { rating: ratings[0].id, cutoff: 1 }
+	});
+	await page.request.post(`${API}/draft/${draftId}/assign_rating_cutoff`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { rating: ratings[1].id, cutoff: 5 }
+	});
+
+	const captainToken = await tokenFor(page, `${people[0].first.toLowerCase()}@example.com`);
+
+	// The captain drafts the roster player, then themselves -> 2 picks = complete.
+	for (const player of [playerId, captainId]) {
+		const res = await page.request.post(`${API}/draft/${draftId}/select`, {
+			headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': captainToken },
+			data: { player_id: player }
+		});
+		expect(res.ok(), `pick failed: ${await res.text()}`).toBeTruthy();
+	}
+
+	// Finalize: assign the drafted players to their team (creates the
+	// team_assignment / team_rating roster rows).
+	const assignRes = await page.request.post(`${API}/draft/${draftId}/assign_drafted_players_to_teams`, {
+		headers: { 'X-INTRACLUB-TOKEN': token }
+	});
+	expect(assignRes.ok()).toBeTruthy();
+
+	const seasonRes = await page.request.post(`${API}/draft/${draftId}/create_season`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { name: `Team Season ${unique}`, facility: facilityId, start_time: '08:30' }
+	});
+	expect(seasonRes.ok()).toBeTruthy();
+	const season = (await seasonRes.json()).resource as { id: string };
+
+	// Resolve the team ID the season contains.
+	const seasonTeams = (
+		await (await page.request.get(`${API}/season_team`, { headers: { 'X-INTRACLUB-TOKEN': token } })).json()
+	).resource as { season_id: string; team_id: string }[];
+	const seasonTeam = seasonTeams.find((st) => st.season_id === season.id);
+	expect(seasonTeam).toBeTruthy();
+	const teamId = seasonTeam!.team_id;
+
+	// The commissioner can see the team (via season commissioner access).
+	const asCommissioner = await page.request.get(`${API}/team/${teamId}`, {
+		headers: { 'X-INTRACLUB-TOKEN': token }
+	});
+	expect(asCommissioner.ok()).toBeTruthy();
+
+	// Log in as the captain (a team member) to exercise the promote UI.
+	await page.evaluate((jwt) => localStorage.setItem('intraclub_jwt', jwt), captainToken);
+	await page.goto('/teams');
+	await waitForHydration(page);
+
+	// The teams list shows the team with the captain + player.
+	await expect(page.getByRole('heading', { name: 'Teams' })).toBeVisible();
+	const teamLink = page.getByRole('link', { name: /Team 1/ });
+	await expect(teamLink).toBeVisible();
+	await teamLink.click();
+	await page.waitForURL(`/teams/${teamId}`);
+	await waitForHydration(page);
+
+	// Members tab lists both members with role badges.
+	await expect(page.getByRole('heading', { name: 'Team 1' })).toBeVisible();
+	const membersTab = page.getByLabel('Members');
+	await expect(membersTab.getByText(people[0].first, { exact: false })).toBeVisible();
+	await expect(membersTab.getByText(people[1].first, { exact: false })).toBeVisible();
+
+	// The captain can manage co-captains: promote the player.
+	await page.getByRole('tab', { name: 'Co-captains' }).click();
+	const promoteButton = page.getByRole('button', { name: 'Promote to co-captain' });
+	await expect(promoteButton).toBeVisible();
+	await promoteButton.click();
+
+	await expect(page.getByText(`${people[1].first} One is now a co-captain.`)).toBeVisible();
+
+	// After promotion the player is no longer promotable.
+	await expect(page.getByRole('button', { name: 'Promote to co-captain' })).not.toBeVisible();
+
+	// The Members tab reflects the new co-captain role.
+	await page.getByRole('tab', { name: 'Members' }).click();
+	await expect(page.getByLabel('Members').getByText('Co-captain')).toBeVisible();
+
+	// Clean up the draft so the table doesn't accumulate rows across runs.
+	const cleanup = await page.request.delete(`${API}/draft/${draftId}`, {
+		headers: { 'X-INTRACLUB-TOKEN': token }
+	});
+	expect(cleanup.ok()).toBeTruthy();
+});

--- a/ui/src/lib/components/NavBar.svelte
+++ b/ui/src/lib/components/NavBar.svelte
@@ -49,6 +49,7 @@
 				</PopoverContent>
 			</Popover>
 			<a href="/drafts" class="rounded-md px-2 py-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground">Drafts</a>
+			<a href="/teams" class="rounded-md px-2 py-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground">Teams</a>
 			<a href="/photos" class="rounded-md px-2 py-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground">Photos</a>
 			<a href="/users" class="rounded-md px-2 py-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground">Users</a>
 		</nav>

--- a/ui/src/lib/season.ts
+++ b/ui/src/lib/season.ts
@@ -4,13 +4,13 @@
 //
 //	GET  /api/season            -> { resource: Season[] }
 //	GET  /api/season/:id        -> { resource: Season }
-//	GET  /api/team              -> { resource: Team[] }
 //	GET  /api/season_team       -> { resource: SeasonTeam[] }   (join)
-//	GET  /api/team_assignment   -> { resource: TeamAssignment[] } (members)
 //	GET  /api/team_rating       -> { resource: TeamRating[] }   (draft rating)
 //
-// Record IDs are 16-char hex strings. A Season's start_time is the daily kickoff
-// time as a 24-hour "HH:MM" string (e.g. "08:30").
+// Teams and their member assignments are exposed via the constrained surface
+// in src/lib/team.ts (see GET /api/team, GET /api/team/:id). Record IDs are
+// 16-char hex strings. A Season's start_time is the daily kickoff time as a
+// 24-hour "HH:MM" string (e.g. "08:30").
 import { authFetch } from '$lib/auth';
 
 export interface Season {

--- a/ui/src/lib/team.ts
+++ b/ui/src/lib/team.ts
@@ -1,0 +1,77 @@
+// Team API client. Teams are largely immutable after a draft finalizes, so the
+// backend exposes them through a constrained surface in route/team rather than
+// generic CRUD:
+//
+//	GET  /api/team              -> { resource: TeamRoster[] }  (teams I can see)
+//	GET  /api/team/:id          -> { resource: TeamRoster }
+//	POST /api/team/:id/promote_co_captain -> { resource: TeamAssignment }
+//
+// A TeamRoster bundles a Team with its member assignments (each with a role of
+// `captain` / `co_captain` / `member`). Record IDs are 16-char hex strings.
+import { authFetch } from '$lib/auth';
+
+export type TeamRole = 'captain' | 'co_captain' | 'member';
+
+export interface TeamColor {
+	name: string;
+	hex: string;
+}
+
+export interface Team {
+	id: string;
+	name: string;
+	color: TeamColor;
+	created_at: string;
+	updated_at: string;
+	deleted_at: string | null;
+}
+
+export interface TeamAssignment {
+	id: string;
+	team_id: string;
+	user_id: string;
+	role: TeamRole;
+	created_at: string;
+	updated_at: string;
+	deleted_at: string | null;
+}
+
+export interface TeamRoster {
+	team: Team;
+	assignments: TeamAssignment[];
+}
+
+// unwrap parses a response (`{ resource: ... }`) and throws the backend error
+// message on non-2xx responses so callers can surface it.
+async function unwrap(res: Response): Promise<any> {
+	if (!res.ok) {
+		let message = `Request failed (${res.status})`;
+		try {
+			const body = await res.json();
+			if (body?.error) message = body.error;
+		} catch {
+			// non-JSON error body; fall back to the status message
+		}
+		throw new Error(message);
+	}
+	const body = await res.json();
+	return body?.resource;
+}
+
+export async function listTeams(): Promise<TeamRoster[]> {
+	return unwrap(await authFetch('/api/team'));
+}
+
+export async function getTeam(id: string): Promise<TeamRoster> {
+	return unwrap(await authFetch(`/api/team/${id}`));
+}
+
+export async function promoteCoCaptain(teamId: string, userId: string): Promise<TeamAssignment> {
+	return unwrap(
+		await authFetch(`/api/team/${teamId}/promote_co_captain`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ user_id: userId })
+		})
+	);
+}

--- a/ui/src/routes/seasons/[id]/+page.svelte
+++ b/ui/src/routes/seasons/[id]/+page.svelte
@@ -146,7 +146,14 @@
 			{#each teams as team}
 				<Card>
 					<CardHeader>
-						<CardTitle class="text-base">{team.name}</CardTitle>
+						<CardTitle class="text-base">
+							<a
+								href={`/teams/${team.teamId}`}
+								class="text-primary underline-offset-4 hover:underline"
+							>
+								{team.name}
+							</a>
+						</CardTitle>
 					</CardHeader>
 					<CardContent>
 						{#if team.members.length === 0}

--- a/ui/src/routes/teams/+page.svelte
+++ b/ui/src/routes/teams/+page.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { listTeams } from '$lib/team';
+	import type { TeamRoster } from '$lib/team';
+	import {
+		Table,
+		TableBody,
+		TableCell,
+		TableHead,
+		TableHeader,
+		TableRow
+	} from '$lib/components/ui/table/index.js';
+
+	let rosters = $state<TeamRoster[]>([]);
+	let loading = $state(true);
+	let error = $state('');
+
+	onMount(async () => {
+		try {
+			rosters = await listTeams();
+		} catch (e) {
+			error = e instanceof Error ? e.message : 'Failed to load teams';
+		} finally {
+			loading = false;
+		}
+	});
+</script>
+
+<svelte:head>
+	<title>Intraclub | Teams</title>
+</svelte:head>
+
+<div class="flex items-center gap-4">
+	<h1 class="text-2xl font-semibold tracking-tight">Teams</h1>
+</div>
+
+{#if loading}
+	<p class="text-muted-foreground">Loading...</p>
+{:else if error}
+	<p class="text-sm font-medium text-destructive">{error}</p>
+{:else if rosters.length === 0}
+	<p class="text-muted-foreground">
+		You aren't on any teams. Teams are created when a draft is finalized and are only visible to their members.
+	</p>
+{:else}
+	<div class="mt-4 overflow-hidden rounded-lg border">
+		<Table>
+			<TableHeader>
+				<TableRow>
+					<TableHead>Team</TableHead>
+					<TableHead>Members</TableHead>
+				</TableRow>
+			</TableHeader>
+			<TableBody>
+				{#each rosters as roster}
+					<TableRow>
+						<TableCell>
+							<a
+								href={`/teams/${roster.team.id}`}
+								class="font-medium text-primary underline-offset-4 hover:underline"
+							>
+								{roster.team.name}
+							</a>
+						</TableCell>
+						<TableCell class="text-muted-foreground">
+							{roster.assignments.length}
+						</TableCell>
+					</TableRow>
+				{/each}
+			</TableBody>
+		</Table>
+	</div>
+{/if}

--- a/ui/src/routes/teams/[id]/+page.svelte
+++ b/ui/src/routes/teams/[id]/+page.svelte
@@ -1,0 +1,177 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { page } from '$app/state';
+	import { getTeam, promoteCoCaptain } from '$lib/team';
+	import type { TeamAssignment, TeamRoster, TeamRole } from '$lib/team';
+	import { getCurrentUserId } from '$lib/auth';
+	import { listUsers, fullName } from '$lib/user';
+	import type { User } from '$lib/user';
+	import { Badge } from '$lib/components/ui/badge/index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import {
+		Card,
+		CardContent,
+		CardHeader,
+		CardTitle
+	} from '$lib/components/ui/card/index.js';
+	import {
+		Tabs,
+		TabsContent,
+		TabsList,
+		TabsTrigger
+	} from '$lib/components/ui/tabs/index.js';
+
+	const id = () => page.params.id as string;
+
+	let roster = $state<TeamRoster | null>(null);
+	let users = $state<User[]>([]);
+	let activeTab = $state('members');
+	let loading = $state(true);
+	let loadError = $state('');
+	let actionError = $state('');
+	let actionMessage = $state('');
+
+	onMount(load);
+
+	async function load() {
+		loading = true;
+		loadError = '';
+		try {
+			const [teamRoster, userList] = await Promise.all([getTeam(id()), listUsers()]);
+			roster = teamRoster;
+			users = userList;
+		} catch (e) {
+			loadError = e instanceof Error ? e.message : 'Failed to load team';
+		} finally {
+			loading = false;
+		}
+	}
+
+	function userName(userId: string): string {
+		const u = users.find((x) => x.id === userId);
+		return u ? fullName(u) : userId;
+	}
+
+	function roleLabel(role: TeamRole): string {
+		switch (role) {
+			case 'captain':
+				return 'Captain';
+			case 'co_captain':
+				return 'Co-captain';
+			default:
+				return 'Member';
+		}
+	}
+
+	// The current user can assign co-captains if they are this team's captain or
+	// a co-captain themselves (mirrors the backend's EditableBy).
+	const canManage = $derived.by(() => {
+		const me = getCurrentUserId();
+		if (!me || !roster) return false;
+		return roster.assignments.some((a) => a.user_id === me && a.role !== 'member');
+	});
+
+	const sortedAssignments = $derived(
+		roster ? [...roster.assignments].sort((a, b) => userName(a.user_id).localeCompare(userName(b.user_id))) : []
+	);
+
+	// Members eligible to be promoted to co-captain (regular members only).
+	const promotableMembers = $derived(
+		sortedAssignments.filter((a) => a.role === 'member')
+	);
+
+	async function promote(userId: string) {
+		actionError = '';
+		actionMessage = '';
+		try {
+			await promoteCoCaptain(id(), userId);
+			actionMessage = `${userName(userId)} is now a co-captain.`;
+			await load();
+		} catch (e) {
+			actionError = e instanceof Error ? e.message : 'Failed to promote member';
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>Intraclub | {roster ? roster.team.name : 'Team'}</title>
+</svelte:head>
+
+<div class="flex items-center gap-4">
+	<h1 class="text-2xl font-semibold tracking-tight">{roster?.team.name ?? 'Team'}</h1>
+	<a href="/teams" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to teams</a>
+</div>
+
+{#if loading}
+	<p class="mt-4 text-muted-foreground">Loading...</p>
+{:else if loadError}
+	<p class="mt-4 text-sm font-medium text-destructive">{loadError}</p>
+{:else if roster}
+	<Card class="mt-6">
+		<CardHeader>
+			<CardTitle class="text-base">Team</CardTitle>
+		</CardHeader>
+		<CardContent>
+			<div class="flex flex-wrap items-center gap-4 text-sm">
+				<Badge variant="secondary">{roster.assignments.length} members</Badge>
+				<span class="text-muted-foreground">{roster.team.color.name}</span>
+			</div>
+		</CardContent>
+	</Card>
+
+	<Tabs bind:value={activeTab} class="mt-6 w-full">
+		<TabsList>
+			<TabsTrigger value="members">Members</TabsTrigger>
+			<TabsTrigger value="co-captains">Co-captains</TabsTrigger>
+		</TabsList>
+		<TabsContent value="members">
+			{#if sortedAssignments.length === 0}
+				<p class="mt-4 text-sm text-muted-foreground">No players assigned.</p>
+			{:else}
+				<ul class="mt-4 space-y-2 text-sm">
+					{#each sortedAssignments as assignment}
+						<li class="flex items-center justify-between gap-3 rounded-lg border px-3 py-2">
+							<span class="font-medium">{userName(assignment.user_id)}</span>
+							<Badge variant={assignment.role === 'captain' ? 'default' : 'secondary'}>
+								{roleLabel(assignment.role)}
+							</Badge>
+						</li>
+					{/each}
+				</ul>
+			{/if}
+		</TabsContent>
+		<TabsContent value="co-captains">
+			<p class="mt-4 text-sm text-muted-foreground">
+				Co-captains help manage the team roster. Rosters are otherwise fixed after the draft is finalized.
+			</p>
+
+			{#if actionError}
+				<p class="mt-3 text-sm font-medium text-destructive">{actionError}</p>
+			{/if}
+			{#if actionMessage}
+				<p class="mt-3 text-sm font-medium text-emerald-600">{actionMessage}</p>
+			{/if}
+
+			{#if canManage}
+				{#if promotableMembers.length === 0}
+					<p class="mt-4 text-sm text-muted-foreground">There are no members to promote.</p>
+				{:else}
+					<ul class="mt-4 space-y-2 text-sm">
+						{#each promotableMembers as assignment}
+							<li class="flex items-center justify-between gap-3 rounded-lg border px-3 py-2">
+								<span class="font-medium">{userName(assignment.user_id)}</span>
+								<Button size="sm" onclick={() => promote(assignment.user_id)}>
+									Promote to co-captain
+								</Button>
+							</li>
+						{/each}
+					</ul>
+				{/if}
+			{:else}
+				<p class="mt-4 text-sm text-muted-foreground">
+					Only this team's captain or co-captains can assign roles.
+				</p>
+			{/if}
+		</TabsContent>
+	</Tabs>
+{/if}


### PR DESCRIPTION
Implements #153.

## What changed
Teams are now surfaced via a **constrained** REST + UI surface — no generic create/update/delete on the raw `Team` / `TeamAssignment` / `TeamRating` records (consistent with the revised ticket scope: team data is largely immutable once a season is created).

### Backend (route/team)
- `GET /api/team` and `GET /api/team/:id` — read-only rosters (team + member assignments with roles), restricted to team members, sysadmins, and the season's commissioners.
- `POST /api/team/:id/promote_co_captain` — the only mutation: promote an existing member to co-captain. Only the team's captain / co-captains may do it; the captain cannot be promoted and already-co-captains are rejected.
- Raw `Team` / `TeamAssignment` records are deliberately not exposed via `CrudCommon` (no create/update/delete routes).

### Database deadlock fix (platform bug)
`UnitTestDbProvider.GetAllWhere` held its non-reentrant mutex while running the `where` predicate. A record whose `AccessibleTo`/`EditableBy` re-enters the provider (e.g. `Team` → `TeamAssignment`) therefore deadlocked during `WithAccessControl.GetAll`. Now the record cache is snapshotted under the lock and the predicate runs outside it. Adds a cross-provider regression test (`TestReentrantAccessContract`). The SQLite provider was not affected.

### UI
- `/teams` list and `/teams/[id]` detail pages (informational). Detail has a **Members** tab (role badges) and a **Co-captains** tab (promote controls for captain/co-captains).
- Teams link added to the nav; season team cards link to `/teams/[id]`.

### Tests
- Backend: `route/team` tests (promote happy path, co-captain promotion, authz, invalid cases, commissioner read access, no generic CRUD routes) and the database deadlock regression test.
- e2e: `teams.spec.ts` (roster view + promote flow). Full `make e2e` suite green (27 tests).

## Verification
- `go build ./...`, `go vet ./...`, `go test ./...` — green
- `npm run check` (svelte-check) — 0 errors; `npm run test` — 8/8
- `make e2e` — 27 passed
- Security review: no privilege-exploitable issues
