### PR TITLE
Weeks: commissioner-only authz + API surface

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ import (
 	"intraclub/route/ruleset"
 	"intraclub/route/team"
 	"intraclub/route/user"
+	"intraclub/route/week"
 
 	"github.com/gin-gonic/gin"
 )
@@ -124,6 +125,8 @@ func main() {
 	// reads are restricted to team members, sysadmins, and season
 	// commissioners; only a team's captain / co-captains can assign roles.
 	team.RegisterRoutes(rg, db)
+
+	week.RegisterRoutes(rg, db)
 
 	playoffStructures := api.NewCrudCommon(model.NewPlayoffStructure, false, db)
 	playoffStructures.HandleRouteTypes(rg, api.CrudWrapperFunctionAll...)

--- a/model/week.go
+++ b/model/week.go
@@ -20,11 +20,24 @@ func (id WeekId) String() string {
 	return id.RecordId().String()
 }
 
+func (id WeekId) MarshalJSON() ([]byte, error) {
+	return id.RecordId().MarshalJSON()
+}
+
+func (id *WeekId) UnmarshalJSON(bytes []byte) error {
+	rid := id.RecordId()
+	if err := (*database.RecordId)(&rid).UnmarshalJSON(bytes); err != nil {
+		return err
+	}
+	*id = WeekId(rid)
+	return nil
+}
+
 type Week struct {
-	ID      WeekId `json:"id"`
-	DraftId DraftId
-	Date    time.Time
-	Note    string
+	ID      WeekId    `json:"id"`
+	DraftId DraftId   `json:"draft_id"`
+	Date    time.Time `json:"date"`
+	Note    string    `json:"note"`
 }
 
 func (w *Week) GetOwner() database.UserId {
@@ -105,7 +118,7 @@ func (w *Week) EditableBy(ctx context.Context, db database.Provider) []database.
 	// if Season is set up, then this Week is editable by any of the Season
 	// commissioners. Otherwise, it is only editable by the Draft owner
 	if season != nil {
-		EditableBySeason(ctx, db, season.ID)
+		return EditableBySeason(ctx, db, season.ID)
 	}
 	return []database.UserId{draft.Owner}
 }

--- a/model/week_test.go
+++ b/model/week_test.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"intraclub/database"
+
+	"github.com/stretchr/testify/require"
 )
 
 func newStoredWeek(t *testing.T, db database.Provider, season *Season) *Week {
@@ -91,4 +93,36 @@ func TestWeeksSorted(t *testing.T) {
 	if weeks[2].ID != week2.ID {
 		t.Fatal("expected week2 at index 2")
 	}
+}
+
+func TestWeekEditableBySeasonCommissioner(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	season, seasonCommissioner := newDefaultSeasonWithTeams(t, db, 2)
+
+	week := newStoredWeek(t, db, season)
+
+	editable := week.EditableBy(context.Background(), db)
+	// When the week's Draft is assigned to a Season, only that Season's
+	// commissioner(s) may edit it (not the draft owner / participants).
+	require.ElementsMatch(t, []database.UserId{seasonCommissioner.ID}, editable)
+}
+
+func TestWeekEditableByDraftOwnerWhenNoSeason(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	owner := newStoredUser(t, db)
+
+	draft := NewDraft()
+	draft.Owner = owner.ID
+	draft.Format = newDefaultStoredFormat(t, db).ID
+	draftV, err := database.CreateOne(context.Background(), db, draft)
+	require.NoError(t, err)
+
+	week := NewWeek()
+	week.DraftId = draftV.ID
+	week.Date = time.Now()
+	weekV, err := database.CreateOne(context.Background(), db, week)
+	require.NoError(t, err)
+
+	editable := weekV.EditableBy(context.Background(), db)
+	require.ElementsMatch(t, []database.UserId{owner.ID}, editable)
 }

--- a/route/week/routes.go
+++ b/route/week/routes.go
@@ -1,0 +1,31 @@
+package week
+
+import (
+	"intraclub/api"
+	"intraclub/database"
+	"intraclub/model"
+
+	"github.com/gin-gonic/gin"
+)
+
+// RegisterRoutes wires up the Week REST surface.
+//
+// Weeks are created and managed only by the Season commissioner. Generic
+// create is deliberately NOT registered: creation goes through the custom
+// CreateWeek route, which enforces the commissioner-only rule. The generic
+// get/update/delete routes enforce the same rule via Week.EditableBy (which
+// returns the Season's commissioners).
+func RegisterRoutes(e *gin.RouterGroup, db database.Provider) {
+	weeks := api.NewCrudCommon(model.NewWeek, false, db)
+	weeks.HandleRouteTypes(e,
+		api.CrudWrapperFunctionGetOne,
+		api.CrudWrapperFunctionUpdate,
+		api.CrudWrapperFunctionDelete,
+	)
+
+	queryFamily := api.RouteFamily[*WeekQuery]{DatabaseProvider: db}
+	queryFamily.Handle(e, ListWeeks{})
+
+	createFamily := api.RouteFamily[*CreateWeekBody]{DatabaseProvider: db}
+	createFamily.Handle(e, CreateWeek{})
+}

--- a/route/week/week.go
+++ b/route/week/week.go
@@ -1,0 +1,145 @@
+package week
+
+import (
+	"errors"
+	"net/http"
+	"time"
+
+	"intraclub/api"
+	"intraclub/database"
+	"intraclub/model"
+
+	"github.com/gin-gonic/gin"
+)
+
+// BaseRoute is the base path for the Week REST surface. It matches the
+// singular route convention used by the generic CRUD routes (derived from
+// Week.Type()).
+const BaseRoute = "/week"
+
+// CreateWeekBody is the request body for CreateWeek.
+type CreateWeekBody struct {
+	// DraftId is the Draft the week belongs to.
+	DraftId model.DraftId `json:"draft_id"`
+	// Date is the scheduled playing date for the week.
+	Date time.Time `json:"date"`
+	// Note is an optional note for the week.
+	Note string `json:"note"`
+}
+
+// StaticallyValid ensures the week's date is set before any handler logic runs.
+func (b *CreateWeekBody) StaticallyValid() error {
+	if b.Date.IsZero() {
+		return errors.New("date must not be zero")
+	}
+	return nil
+}
+
+// CreateWeek creates a Week for a Draft. Weeks may only be created by a
+// commissioner of the Season associated with the Draft (or, before a Season
+// exists for the Draft, the Draft's owner) — normal participants and team
+// captains are not authorized.
+type CreateWeek struct{}
+
+func (c CreateWeek) Path() (api.HttpMethod, string) {
+	return api.HttpMethodPost, BaseRoute
+}
+
+func (c CreateWeek) RequestBody() (*CreateWeekBody, bool) {
+	return &CreateWeekBody{}, true
+}
+
+func (c CreateWeek) Handler(req api.Request[*CreateWeekBody]) (any, int, error) {
+	if req.Token == nil {
+		return nil, http.StatusUnauthorized, errors.New("token is required")
+	}
+
+	week := model.NewWeek()
+	week.DraftId = req.Body.DraftId
+	week.Date = req.Body.Date
+	week.Note = req.Body.Note
+
+	// Resolve the users who are allowed to create/edit weeks for this Draft
+	// (Season commissioners, or the Draft owner if no Season exists yet) and
+	// require the requesting user to be among them.
+	allowed := week.EditableBy(req.Context, req.DatabaseProvider)
+	authorized := false
+	for _, uid := range allowed {
+		if uid == req.Token.UserId {
+			authorized = true
+			break
+		}
+	}
+	if !authorized {
+		return nil, http.StatusForbidden, errors.New("only a season commissioner may create weeks")
+	}
+
+	v, err := database.CreateOne(req.Context, req.DatabaseProvider, week)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	return gin.H{api.ResourceKey: v}, http.StatusOK, nil
+}
+
+// WeekQuery holds the optional query parameters for ListWeeks.
+type WeekQuery struct {
+	// DraftId filters the weeks to a single Draft.
+	DraftId model.DraftId `json:"draft_id"`
+	// SeasonId filters the weeks to the Draft of a single Season.
+	SeasonId model.SeasonId `json:"season_id"`
+}
+
+// StaticallyValid has no static constraints.
+func (q *WeekQuery) StaticallyValid() error { return nil }
+
+// ListWeeks returns all weeks, or filters them to a single Draft or Season via
+// the `draft_id` / `season_id` query parameters. Weeks are accessible to
+// everyone (they only carry a scheduled date and note), so no auth gate is
+// applied.
+type ListWeeks struct{}
+
+func (c ListWeeks) Path() (api.HttpMethod, string) {
+	return api.HttpMethodGet, BaseRoute
+}
+
+func (c ListWeeks) RequestBody() (*WeekQuery, bool) {
+	return &WeekQuery{}, false
+}
+
+func (c ListWeeks) Handler(req api.Request[*WeekQuery]) (any, int, error) {
+	query := req.HTTPRequest().URL.Query()
+
+	if draftStr := query.Get("draft_id"); draftStr != "" {
+		draftId, err := database.RecordIdFromString(draftStr)
+		if err != nil {
+			return nil, http.StatusBadRequest, err
+		}
+		weeks, err := model.GetWeeksForDraft(req.Context, req.DatabaseProvider, model.DraftId(draftId))
+		if err != nil {
+			return nil, http.StatusBadRequest, err
+		}
+		return gin.H{api.ResourceKey: weeks}, http.StatusOK, nil
+	}
+
+	if seasonStr := query.Get("season_id"); seasonStr != "" {
+		seasonId, err := database.RecordIdFromString(seasonStr)
+		if err != nil {
+			return nil, http.StatusBadRequest, err
+		}
+		season, err := database.GetExistingRecordById(req.Context, req.DatabaseProvider, &model.Season{}, seasonId)
+		if err != nil {
+			return nil, http.StatusBadRequest, err
+		}
+		weeks, err := model.GetWeeksForDraft(req.Context, req.DatabaseProvider, season.DraftId)
+		if err != nil {
+			return nil, http.StatusBadRequest, err
+		}
+		return gin.H{api.ResourceKey: weeks}, http.StatusOK, nil
+	}
+
+	weeks, err := database.GetAll[*model.Week](req.Context, req.DatabaseProvider)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	return gin.H{api.ResourceKey: weeks}, http.StatusOK, nil
+}

--- a/route/week/week_test.go
+++ b/route/week/week_test.go
@@ -1,0 +1,322 @@
+package week
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/rand/v2"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"intraclub/api"
+	"intraclub/database"
+	"intraclub/model"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// test helpers (mirror route/draft and model test helpers)
+// ---------------------------------------------------------------------------
+
+func newStoredUser(t *testing.T, db database.Provider) *model.User {
+	t.Helper()
+	user := model.NewUser()
+	user.Email = model.EmailAddress(fmt.Sprintf("user%d@email.com", rand.Uint64()))
+	user.FirstName = fmt.Sprintf("Test %d", rand.Uint64())
+	user.LastName = "User"
+	user.PhoneNumber = model.PhoneNumber(fmt.Sprintf("%d", 100_000_0000+rand.Uint32N(999_999_999)))
+	v, err := database.CreateOne(context.Background(), db, user)
+	require.NoError(t, err)
+	return v
+}
+
+func newStoredRating(t *testing.T, db database.Provider) *model.Rating {
+	t.Helper()
+	user := newStoredUser(t, db)
+	r := model.NewRating()
+	r.UserId = user.ID
+	r.Name = fmt.Sprintf("Rating %s", database.NewRecordId())
+	r.Description = "test description"
+	v, err := database.CreateOne(context.Background(), db, r)
+	require.NoError(t, err)
+	return v
+}
+
+func newDefaultFormat(t *testing.T, db database.Provider) *model.Format {
+	t.Helper()
+	user := newStoredUser(t, db)
+	f := model.NewFormat()
+	f.UserId = user.ID
+	f.Name = "default format"
+	created, err := database.CreateOne(context.Background(), db, f)
+	require.NoError(t, err)
+
+	lines := []model.FormatLine{
+		{Player1Rating: newStoredRating(t, db).ID, Player2Rating: newStoredRating(t, db).ID},
+		{Player1Rating: newStoredRating(t, db).ID, Player2Rating: newStoredRating(t, db).ID},
+	}
+	var ratings model.RatingList
+	for _, l := range lines {
+		ratings = appendUniqueRating(ratings, l.Player1Rating)
+		ratings = appendUniqueRating(ratings, l.Player2Rating)
+	}
+	require.NoError(t, created.SetPossibleRatings(context.Background(), db, ratings))
+	require.NoError(t, created.SetLines(context.Background(), db, lines))
+	return created
+}
+
+func appendUniqueRating(ratings model.RatingList, r model.RatingId) model.RatingList {
+	for _, existing := range ratings {
+		if existing == r {
+			return ratings
+		}
+	}
+	return append(ratings, r)
+}
+
+// newSeasonWithTeam builds a Season (with a commissioner and a draft) plus one
+// team whose captain is returned. The team is assigned to the season, making
+// the captain a "participant" who must not be able to create/modify weeks.
+func newSeasonWithTeam(t *testing.T, db database.Provider, commissionerID database.UserId) (*model.Season, *model.User) {
+	t.Helper()
+	ctx := context.Background()
+
+	format := newDefaultFormat(t, db)
+	draft := model.NewDraft()
+	draft.Owner = commissionerID
+	draft.Format = format.ID
+	draftV, err := database.CreateOne(ctx, db, draft)
+	require.NoError(t, err)
+
+	facility := model.NewFacility()
+	facility.UserId = commissionerID
+	facility.Name = "Test facility"
+	facility.Address = "Test Rd."
+	facility.NumberOfCourts = 2
+	facilityV, err := database.CreateOne(ctx, db, facility)
+	require.NoError(t, err)
+
+	season := model.NewSeason()
+	season.Name = "Test Season"
+	season.StartTime = model.NewStartTime(8, 30)
+	season.DraftId = draftV.ID
+	season.Facility = facilityV.ID
+	seasonV, err := database.CreateOne(ctx, db, season)
+	require.NoError(t, err)
+	require.NoError(t, seasonV.AddCommissioner(ctx, db, commissionerID))
+
+	captain := newStoredUser(t, db)
+	team := model.NewDefaultTeam(captain.ID, "Team A")
+	teamV, err := database.CreateOne(ctx, db, team)
+	require.NoError(t, err)
+	require.NoError(t, seasonV.AddTeam(ctx, db, teamV.ID))
+
+	return seasonV, captain
+}
+
+func newTestRouter(t *testing.T, db database.Provider) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	api.UserType = &model.User{}
+	database.SysAdminCheck = model.IsUserSystemAdministrator
+
+	router := gin.New()
+	group := router.Group("/api")
+	RegisterRoutes(group, db)
+	return router
+}
+
+var (
+	testKeyOnce sync.Once
+	testPubKey  *ecdsa.PublicKey
+	testPrivKey *ecdsa.PrivateKey
+)
+
+func newToken(t *testing.T, userId database.UserId) string {
+	t.Helper()
+	testKeyOnce.Do(func() {
+		pub, priv, err := api.GenerateKeyPair()
+		require.NoError(t, err)
+		testPubKey = pub
+		testPrivKey = priv
+	})
+	api.JwtPublicKey = testPubKey
+	api.JwtPrivateKey = testPrivKey
+	token, err := api.GenerateToken(userId.RecordId())
+	require.NoError(t, err)
+	return token
+}
+
+func doJSON(t *testing.T, router *gin.Engine, method, path string, body any, token string) *httptest.ResponseRecorder {
+	t.Helper()
+	var reader io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		require.NoError(t, err)
+		reader = bytes.NewReader(b)
+	}
+	req, err := http.NewRequest(method, path, reader)
+	require.NoError(t, err)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if token != "" {
+		req.Header.Set(api.AuthTokenHeaderValue, token)
+	}
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+// ---------------------------------------------------------------------------
+// commissioner-only create
+// ---------------------------------------------------------------------------
+
+func createWeekViaHTTP(t *testing.T, router *gin.Engine, draftID string, token string) *httptest.ResponseRecorder {
+	t.Helper()
+	return doJSON(t, router, http.MethodPost, "/api/week", map[string]any{
+		"draft_id": draftID,
+		"date":     time.Date(2025, 3, 1, 8, 0, 0, 0, time.UTC),
+		"note":     "week 1",
+	}, token)
+}
+
+func TestCreateWeekCommissionerOnly(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	commissioner := newStoredUser(t, db)
+	season, captain := newSeasonWithTeam(t, db, commissioner.ID)
+	outsider := newStoredUser(t, db)
+
+	draftID := season.DraftId.String()
+
+	// Commissioner may create a week.
+	w := createWeekViaHTTP(t, router, draftID, newToken(t, commissioner.ID))
+	require.Equal(t, http.StatusOK, w.Code, "commissioner create: %s", w.Body.String())
+	var created struct {
+		Resource *model.Week `json:"resource"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &created))
+	require.NotNil(t, created.Resource)
+	require.Equal(t, season.DraftId, created.Resource.DraftId)
+
+	// A team captain (season participant) may NOT create a week.
+	w = createWeekViaHTTP(t, router, draftID, newToken(t, captain.ID))
+	require.Equal(t, http.StatusForbidden, w.Code, "captain create: %s", w.Body.String())
+
+	// An unrelated user (normal participant) may NOT create a week.
+	w = createWeekViaHTTP(t, router, draftID, newToken(t, outsider.ID))
+	require.Equal(t, http.StatusForbidden, w.Code, "outsider create: %s", w.Body.String())
+
+	// No token -> unauthorized.
+	w = createWeekViaHTTP(t, router, draftID, "")
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestWeekUpdateDeleteCommissionerOnly(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	commissioner := newStoredUser(t, db)
+	season, captain := newSeasonWithTeam(t, db, commissioner.ID)
+
+	// Create a week as the commissioner.
+	w := createWeekViaHTTP(t, router, season.DraftId.String(), newToken(t, commissioner.ID))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var created struct {
+		Resource *model.Week `json:"resource"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &created))
+	weekID := created.Resource.ID.String()
+
+	// The captain cannot update the week's date.
+	w = doJSON(t, router, http.MethodPut, "/api/week/"+weekID, map[string]any{
+		"id":      weekID,
+		"draft_id": season.DraftId.String(),
+		"date":    time.Date(2025, 3, 8, 8, 0, 0, 0, time.UTC),
+		"note":    "moved",
+	}, newToken(t, captain.ID))
+	require.Equal(t, http.StatusBadRequest, w.Code, "captain update: %s", w.Body.String())
+
+	// The commissioner can update it.
+	w = doJSON(t, router, http.MethodPut, "/api/week/"+weekID, map[string]any{
+		"id":       weekID,
+		"draft_id": season.DraftId.String(),
+		"date":     time.Date(2025, 3, 8, 8, 0, 0, 0, time.UTC),
+		"note":     "moved",
+	}, newToken(t, commissioner.ID))
+	require.Equal(t, http.StatusOK, w.Code, "commissioner update: %s", w.Body.String())
+
+	// The captain cannot delete the week: the delete is rejected by access
+	// control (CanUserEdit) and the week remains.
+	w = doJSON(t, router, http.MethodDelete, "/api/week/"+weekID, nil, newToken(t, captain.ID))
+	require.Equal(t, http.StatusOK, w.Code, "captain delete: %s", w.Body.String())
+	w = doJSON(t, router, http.MethodGet, "/api/week/"+weekID, nil, newToken(t, captain.ID))
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// An outsider cannot delete it either.
+	outsider := newStoredUser(t, db)
+	w = doJSON(t, router, http.MethodDelete, "/api/week/"+weekID, nil, newToken(t, outsider.ID))
+	require.Equal(t, http.StatusOK, w.Code, "outsider delete: %s", w.Body.String())
+	w = doJSON(t, router, http.MethodGet, "/api/week/"+weekID, nil, newToken(t, commissioner.ID))
+	require.Equal(t, http.StatusOK, w.Code)
+}
+
+// ---------------------------------------------------------------------------
+// query by draft / season
+// ---------------------------------------------------------------------------
+
+func TestWeeksQueryByDraftAndSeason(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	commissioner := newStoredUser(t, db)
+	season, _ := newSeasonWithTeam(t, db, commissioner.ID)
+
+	createWeekViaHTTP(t, router, season.DraftId.String(), newToken(t, commissioner.ID))
+	createWeekViaHTTP(t, router, season.DraftId.String(), newToken(t, commissioner.ID))
+
+	// Query by draft_id.
+	w := doJSON(t, router, http.MethodGet, "/api/week?draft_id="+season.DraftId.String(), nil, newToken(t, commissioner.ID))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var byDraft struct {
+		Resource []*model.Week `json:"resource"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &byDraft))
+	require.Len(t, byDraft.Resource, 2)
+
+	// Query by season_id.
+	w = doJSON(t, router, http.MethodGet, "/api/week?season_id="+season.ID.String(), nil, newToken(t, commissioner.ID))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var bySeason struct {
+		Resource []*model.Week `json:"resource"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &bySeason))
+	require.Len(t, bySeason.Resource, 2)
+
+	// Unfiltered list returns all weeks.
+	w = doJSON(t, router, http.MethodGet, "/api/week", nil, newToken(t, commissioner.ID))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var all struct {
+		Resource []*model.Week `json:"resource"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &all))
+	require.Len(t, all.Resource, 2)
+}
+
+// ---------------------------------------------------------------------------
+// body validation
+// ---------------------------------------------------------------------------
+
+func TestCreateWeekBodyValidation(t *testing.T) {
+	b := &CreateWeekBody{}
+	require.Error(t, b.StaticallyValid())
+	b.Date = time.Now()
+	require.NoError(t, b.StaticallyValid())
+}


### PR DESCRIPTION
## Summary
Makes weeks commissioner-only and adds the Week API surface (the API half of #154).

- **Authz fix:** `Week.EditableBy` now returns the Season's commissioners when the week's Draft is assigned to a Season (previously the computed list was dropped and only the draft owner was returned), so update/delete are commissioner-only. Falls back to the Draft owner only when no Season exists yet.
- **Commissioner-only create:** new `route/week` registers generic get-one/update/delete plus a custom `POST /api/week` create route that rejects non-commissioners (403), and `GET /api/week` with `?draft_id=` / `?season_id=` query support.
- **Wire shape:** added `WeekId` JSON marshal/unmarshal and `json` tags on `Week` fields.
- **Tests:** commissioner-only create, captain/outsider blocked from update/delete, query-by-draft/season, and `EditableBy` unit tests.

## Related
- Closes the authz concern raised alongside #154.
- UI structure overview documented on #154 (comment).

## Verification
- `go build ./...` ✅
- `go vet ./...` ✅
- `go test ./...` ✅
- `make e2e` ✅ (27/27 passed)
