### PR TITLE
Schedule builder: API + season-page UI for weekly matchups

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ import (
 	"intraclub/route/format"
 	"intraclub/route/organization"
 	"intraclub/route/ruleset"
+	"intraclub/route/schedule"
 	"intraclub/route/team"
 	"intraclub/route/user"
 	"intraclub/route/week"
@@ -127,6 +128,8 @@ func main() {
 	team.RegisterRoutes(rg, db)
 
 	week.RegisterRoutes(rg, db)
+
+	schedule.RegisterRoutes(rg, db)
 
 	playoffStructures := api.NewCrudCommon(model.NewPlayoffStructure, false, db)
 	playoffStructures.HandleRouteTypes(rg, api.CrudWrapperFunctionAll...)

--- a/model/schedule.go
+++ b/model/schedule.go
@@ -17,9 +17,22 @@ func (id ScheduleId) String() string {
 	return id.RecordId().String()
 }
 
+func (id ScheduleId) MarshalJSON() ([]byte, error) {
+	return id.RecordId().MarshalJSON()
+}
+
+func (id *ScheduleId) UnmarshalJSON(bytes []byte) error {
+	rid := id.RecordId()
+	if err := (*database.RecordId)(&rid).UnmarshalJSON(bytes); err != nil {
+		return err
+	}
+	*id = ScheduleId(rid)
+	return nil
+}
+
 type Schedule struct {
 	ID       ScheduleId `json:"id"`
-	SeasonId SeasonId
+	SeasonId SeasonId   `json:"season_id"`
 }
 
 func (s *Schedule) GetOwner() database.UserId {

--- a/model/weekly_matchup.go
+++ b/model/weekly_matchup.go
@@ -17,14 +17,27 @@ func (id WeeklyMatchupId) String() string {
 	return id.RecordId().String()
 }
 
+func (id WeeklyMatchupId) MarshalJSON() ([]byte, error) {
+	return id.RecordId().MarshalJSON()
+}
+
+func (id *WeeklyMatchupId) UnmarshalJSON(bytes []byte) error {
+	rid := id.RecordId()
+	if err := (*database.RecordId)(&rid).UnmarshalJSON(bytes); err != nil {
+		return err
+	}
+	*id = WeeklyMatchupId(rid)
+	return nil
+}
+
 // TeamMatchup is a lightweight value type representing a single matchup entry
 // (home vs away, or a bye). It is no longer stored inline within WeeklyMatchup;
 // instead each entry is normalized into a WeeklyMatchupTeamMatchup record.
 // This type remains for API serialization and convenience constructors.
 type TeamMatchup struct {
-	HomeTeam TeamId
-	AwayTeam TeamId
-	Bye      bool
+	HomeTeam TeamId `json:"home_team_id"`
+	AwayTeam TeamId `json:"away_team_id"`
+	Bye      bool   `json:"bye"`
 }
 
 // Validate checks that the matchup entry is well-formed: bye entries have no away team,
@@ -70,8 +83,8 @@ func teamMatchupFromRecord(wmtm *WeeklyMatchupTeamMatchup) *TeamMatchup {
 // WeeklyMatchupTeamMatchup records rather than inline.
 type WeeklyMatchup struct {
 	ID       WeeklyMatchupId `json:"id"`
-	WeekId   WeekId   // Week that this WeeklyMatchup corresponds to, i.e. a particular date
-	SeasonId SeasonId // Season that this WeeklyMatchup corresponds to
+	WeekId   WeekId          `json:"week_id"`   // Week that this WeeklyMatchup corresponds to, i.e. a particular date
+	SeasonId SeasonId        `json:"season_id"` // Season that this WeeklyMatchup corresponds to
 }
 
 func (w *WeeklyMatchup) GetOwner() database.UserId {

--- a/route/schedule/routes.go
+++ b/route/schedule/routes.go
@@ -1,0 +1,42 @@
+package schedule
+
+import (
+	"intraclub/api"
+	"intraclub/database"
+	"intraclub/model"
+
+	"github.com/gin-gonic/gin"
+)
+
+// RegisterRoutes wires up the Schedule REST surface.
+//
+// Schedules and their weekly matchups are managed only by the Season
+// commissioner; other participants can only view them. Creation and matchup
+// assignment therefore go through the custom CreateSchedule /
+// AssignWeeklyMatchup routes, which enforce the commissioner-only rule and
+// write the sysadmin-owned join records (ScheduleMatchup,
+// WeeklyMatchupTeamMatchup) on the commissioner's behalf. The underlying
+// records are exposed read-only here.
+func RegisterRoutes(e *gin.RouterGroup, db database.Provider) {
+	create := api.RouteFamily[*CreateScheduleBody]{DatabaseProvider: db}
+	create.Handle(e, CreateSchedule{})
+
+	list := api.RouteFamily[*ScheduleQuery]{DatabaseProvider: db}
+	list.Handle(e, ListSchedules{})
+
+	detail := api.RouteFamily[*EmptyBody]{DatabaseProvider: db}
+	detail.Handle(e, GetScheduleDetail{})
+
+	assign := api.RouteFamily[*AssignWeeklyMatchupBody]{DatabaseProvider: db}
+	assign.Handle(e, AssignWeeklyMatchup{})
+
+	// Read-only generic surface for the underlying schedule records.
+	weeklyMatchups := api.NewCrudCommon(model.NewWeeklyMatchup, false, db)
+	weeklyMatchups.HandleRouteTypes(e, api.CrudWrapperFunctionGetOne, api.CrudWrapperFunctionGetMany)
+
+	scheduleMatchups := api.NewCrudCommon(func() *model.ScheduleMatchup { return &model.ScheduleMatchup{} }, false, db)
+	scheduleMatchups.HandleRouteTypes(e, api.CrudWrapperFunctionGetOne, api.CrudWrapperFunctionGetMany)
+
+	weeklyMatchupTeamMatchups := api.NewCrudCommon(func() *model.WeeklyMatchupTeamMatchup { return &model.WeeklyMatchupTeamMatchup{} }, false, db)
+	weeklyMatchupTeamMatchups.HandleRouteTypes(e, api.CrudWrapperFunctionGetOne, api.CrudWrapperFunctionGetMany)
+}

--- a/route/schedule/schedule.go
+++ b/route/schedule/schedule.go
@@ -1,0 +1,375 @@
+package schedule
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"intraclub/api"
+	"intraclub/database"
+	"intraclub/model"
+
+	"github.com/gin-gonic/gin"
+)
+
+// BaseRoute is the base path for the Schedule REST surface. It matches the
+// singular route convention used by the generic CRUD routes (derived from
+// Schedule.Type()).
+const BaseRoute = "/schedule"
+
+// isSeasonCommissioner reports whether the requesting user is one of the
+// season's commissioners (the only role allowed to create / modify the
+// schedule and its weekly matchups). Everyone else is view-only.
+func isSeasonCommissioner[T database.Validatable](req api.Request[T], seasonId model.SeasonId) bool {
+	if req.Token == nil {
+		return false
+	}
+	for _, uid := range model.EditableBySeason(req.Context, req.DatabaseProvider, seasonId) {
+		if uid == req.Token.UserId {
+			return true
+		}
+	}
+	return false
+}
+
+// CreateScheduleBody is the request body for CreateSchedule.
+type CreateScheduleBody struct {
+	// SeasonId is the season this schedule belongs to. Only one schedule may
+	// exist per season (enforced by Schedule.UniquenessEquivalent).
+	SeasonId model.SeasonId `json:"season_id"`
+}
+
+// StaticallyValid ensures a season is specified before any handler logic runs.
+func (b *CreateScheduleBody) StaticallyValid() error {
+	if b.SeasonId.RecordId() == database.InvalidRecordId {
+		return errors.New("season_id must be set")
+	}
+	return nil
+}
+
+// CreateSchedule creates a Schedule for a Season. Only a season commissioner
+// may create the schedule; other participants may only view it.
+type CreateSchedule struct{}
+
+func (c CreateSchedule) Path() (api.HttpMethod, string) {
+	return api.HttpMethodPost, BaseRoute
+}
+
+func (c CreateSchedule) RequestBody() (*CreateScheduleBody, bool) {
+	return &CreateScheduleBody{}, true
+}
+
+func (c CreateSchedule) Handler(req api.Request[*CreateScheduleBody]) (any, int, error) {
+	if req.Token == nil {
+		return nil, http.StatusUnauthorized, errors.New("token is required")
+	}
+
+	// The season must already exist before a schedule can reference it.
+	if _, err := database.GetExistingRecordById(req.Context, req.DatabaseProvider, &model.Season{}, req.Body.SeasonId.RecordId()); err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+
+	if !isSeasonCommissioner(req, req.Body.SeasonId) {
+		return nil, http.StatusForbidden, errors.New("only a season commissioner may create a schedule")
+	}
+
+	schedule := model.NewSchedule()
+	schedule.SeasonId = req.Body.SeasonId
+	// One schedule per season is enforced by Schedule.UniquenessEquivalent,
+	// which CreateOne checks against existing schedules.
+	created, err := database.CreateOne(req.Context, req.DatabaseProvider, schedule)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	return gin.H{api.ResourceKey: created}, http.StatusOK, nil
+}
+
+// WeeklyMatchupDTO is the wire representation of a weekly matchup plus its
+// assigned team matchups (home/away/bye entries) for a schedule.
+type WeeklyMatchupDTO struct {
+	ID       model.WeeklyMatchupId `json:"id"`
+	WeekId   model.WeekId          `json:"week_id"`
+	SeasonId model.SeasonId        `json:"season_id"`
+	Matchups []*model.TeamMatchup  `json:"matchups"`
+}
+
+// ScheduleDetail is the wire representation of a Schedule with its ordered
+// weekly matchups and the season's commissioners (so the UI can determine
+// whether the current user may edit).
+type ScheduleDetail struct {
+	Schedule      *model.Schedule      `json:"schedule"`
+	Commissioners []database.UserId    `json:"commissioners"`
+	WeeklyMatchups []*WeeklyMatchupDTO `json:"weekly_matchups"`
+}
+
+// buildWeeklyMatchupDTO converts a stored WeeklyMatchup into its wire form.
+func buildWeeklyMatchupDTO(ctx context.Context, db database.Provider, wm *model.WeeklyMatchup) (*WeeklyMatchupDTO, error) {
+	matchups, err := wm.GetMatchups(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+	return &WeeklyMatchupDTO{
+		ID:       wm.ID,
+		WeekId:   wm.WeekId,
+		SeasonId: wm.SeasonId,
+		Matchups: matchups,
+	}, nil
+}
+
+// scheduleDetailForSeason builds the ScheduleDetail for a season. If the
+// season has no schedule yet, Schedule is nil (so the UI can still learn the
+// commissioners and offer to create one).
+func scheduleDetailForSeason(ctx context.Context, db database.Provider, season *model.Season) (*ScheduleDetail, error) {
+	commissioners, err := season.GetCommissioners(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+
+	detail := &ScheduleDetail{Commissioners: commissioners, WeeklyMatchups: []*WeeklyMatchupDTO{}}
+
+	if season.ScheduleID.RecordId() == database.InvalidRecordId {
+		return detail, nil
+	}
+
+	schedule, err := database.GetExistingRecordById(ctx, db, &model.Schedule{}, season.ScheduleID.RecordId())
+	if err != nil {
+		return nil, err
+	}
+	detail.Schedule = schedule
+
+	matchups, err := schedule.GetMatchups(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+	for _, wm := range matchups {
+		// Weekly matchups may exist even if their team entries haven't been
+		// filled in yet; GetMatchups on the schedule resolves them lazily.
+		dto, err := buildWeeklyMatchupDTO(ctx, db, wm)
+		if err != nil {
+			return nil, err
+		}
+		detail.WeeklyMatchups = append(detail.WeeklyMatchups, dto)
+	}
+	return detail, nil
+}
+
+// ScheduleQuery holds the optional query parameters for ListSchedules.
+type ScheduleQuery struct {
+	// SeasonId, when set, restricts the response to a single ScheduleDetail
+	// for that season (Schedule may be null if no schedule exists yet).
+	SeasonId model.SeasonId `json:"season_id"`
+}
+
+// StaticallyValid has no static constraints.
+func (q *ScheduleQuery) StaticallyValid() error { return nil }
+
+// ListSchedules returns all schedules, or a single ScheduleDetail for a season
+// when the `season_id` query parameter is provided. Schedules are viewable by
+// everyone.
+type ListSchedules struct{}
+
+func (c ListSchedules) Path() (api.HttpMethod, string) {
+	return api.HttpMethodGet, BaseRoute
+}
+
+func (c ListSchedules) RequestBody() (*ScheduleQuery, bool) {
+	return &ScheduleQuery{}, false
+}
+
+func (c ListSchedules) Handler(req api.Request[*ScheduleQuery]) (any, int, error) {
+	query := req.HTTPRequest().URL.Query()
+
+	if seasonStr := query.Get("season_id"); seasonStr != "" {
+		seasonId, err := database.RecordIdFromString(seasonStr)
+		if err != nil {
+			return nil, http.StatusBadRequest, err
+		}
+		season, err := database.GetExistingRecordById(req.Context, req.DatabaseProvider, &model.Season{}, seasonId)
+		if err != nil {
+			return nil, http.StatusBadRequest, err
+		}
+		detail, err := scheduleDetailForSeason(req.Context, req.DatabaseProvider, season)
+		if err != nil {
+			return nil, http.StatusBadRequest, err
+		}
+		return gin.H{api.ResourceKey: detail}, http.StatusOK, nil
+	}
+
+	schedules, err := database.GetAll[*model.Schedule](req.Context, req.DatabaseProvider)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	details := make([]*ScheduleDetail, 0, len(schedules))
+	for _, sched := range schedules {
+		season, err := database.GetExistingRecordById(req.Context, req.DatabaseProvider, &model.Season{}, sched.SeasonId.RecordId())
+		if err != nil {
+			return nil, http.StatusBadRequest, err
+		}
+		detail, err := scheduleDetailForSeason(req.Context, req.DatabaseProvider, season)
+		if err != nil {
+			return nil, http.StatusBadRequest, err
+		}
+		details = append(details, detail)
+	}
+	return gin.H{api.ResourceKey: details}, http.StatusOK, nil
+}
+
+// GetScheduleDetail returns the ScheduleDetail for a specific schedule. It is
+// viewable by everyone.
+type GetScheduleDetail struct{}
+
+func (c GetScheduleDetail) Path() (api.HttpMethod, string) {
+	return api.HttpMethodGet, api.AppendPathId(BaseRoute)
+}
+
+func (c GetScheduleDetail) RequestBody() (*EmptyBody, bool) {
+	return &EmptyBody{}, false
+}
+
+func (c GetScheduleDetail) Handler(req api.Request[*EmptyBody]) (any, int, error) {
+	schedule, err := database.GetExistingRecordById(req.Context, req.DatabaseProvider, &model.Schedule{}, req.PathId)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	season, err := database.GetExistingRecordById(req.Context, req.DatabaseProvider, &model.Season{}, schedule.SeasonId.RecordId())
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	detail, err := scheduleDetailForSeason(req.Context, req.DatabaseProvider, season)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	return gin.H{api.ResourceKey: detail}, http.StatusOK, nil
+}
+
+// AssignWeeklyMatchupBody is the request body for AssignWeeklyMatchup.
+type AssignWeeklyMatchupBody struct {
+	// WeekId is the week of the season this weekly matchup corresponds to.
+	WeekId model.WeekId `json:"week_id"`
+	// Matchups are the home/away/bye entries for the week. Together they must
+	// cover every team in the season exactly once (validated by the model).
+	Matchups []*model.TeamMatchup `json:"matchups"`
+}
+
+// StaticallyValid ensures a week is specified.
+func (b *AssignWeeklyMatchupBody) StaticallyValid() error {
+	if b.WeekId.RecordId() == database.InvalidRecordId {
+		return errors.New("week_id must be set")
+	}
+	return nil
+}
+
+// AssignWeeklyMatchup creates or replaces the weekly matchup for a single week
+// of a season's schedule (home/away/bye entries), and ensures it is assigned to
+// the schedule. Only a season commissioner may modify the schedule.
+type AssignWeeklyMatchup struct{}
+
+func (c AssignWeeklyMatchup) Path() (api.HttpMethod, string) {
+	return api.HttpMethodPost, api.AppendPathId(BaseRoute) + "/weekly_matchup"
+}
+
+func (c AssignWeeklyMatchup) RequestBody() (*AssignWeeklyMatchupBody, bool) {
+	return &AssignWeeklyMatchupBody{}, true
+}
+
+func (c AssignWeeklyMatchup) Handler(req api.Request[*AssignWeeklyMatchupBody]) (any, int, error) {
+	if req.Token == nil {
+		return nil, http.StatusUnauthorized, errors.New("token is required")
+	}
+
+	schedule, err := database.GetExistingRecordById(req.Context, req.DatabaseProvider, &model.Schedule{}, req.PathId)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+
+	if !isSeasonCommissioner(req, schedule.SeasonId) {
+		return nil, http.StatusForbidden, errors.New("only a season commissioner may modify the schedule")
+	}
+
+	season, err := database.GetExistingRecordById(req.Context, req.DatabaseProvider, &model.Season{}, schedule.SeasonId.RecordId())
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+
+	week, err := database.GetExistingRecordById(req.Context, req.DatabaseProvider, &model.Week{}, req.Body.WeekId.RecordId())
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	// The week must belong to this season's draft.
+	if week.DraftId != season.DraftId {
+		return nil, http.StatusBadRequest, errors.New("week does not belong to this season")
+	}
+
+	// Find (or create) the WeeklyMatchup for this season + week.
+	existing, err := database.GetAllWhere[*model.WeeklyMatchup](req.Context, req.DatabaseProvider, func(_ context.Context, wm *model.WeeklyMatchup) bool {
+		return wm.SeasonId == season.ID && wm.WeekId == week.ID
+	})
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	var wm *model.WeeklyMatchup
+	if len(existing) > 0 {
+		wm = existing[0]
+	} else {
+		wm = model.NewWeeklyMatchup()
+		wm.WeekId = week.ID
+		wm.SeasonId = season.ID
+		wm, err = database.CreateOne(req.Context, req.DatabaseProvider, wm)
+		if err != nil {
+			return nil, http.StatusBadRequest, err
+		}
+	}
+
+	// Capture the previous entries so we can restore them if the new ones fail
+	// validation (the model enforces no double-booking and that every team has
+	// exactly one matchup or bye).
+	previous, err := wm.GetMatchups(req.Context, req.DatabaseProvider)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+
+	if err := wm.SetMatchups(req.Context, req.DatabaseProvider, req.Body.Matchups); err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	if err := wm.DynamicallyValid(req.Context, req.DatabaseProvider); err != nil {
+		_ = wm.SetMatchups(req.Context, req.DatabaseProvider, previous)
+		return nil, http.StatusBadRequest, err
+	}
+
+	// Ensure this weekly matchup is assigned to the schedule (position = append).
+	if err := ensureScheduleMatchup(req.Context, req.DatabaseProvider, schedule, wm.ID); err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+
+	dto, err := buildWeeklyMatchupDTO(req.Context, req.DatabaseProvider, wm)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	return gin.H{api.ResourceKey: dto}, http.StatusOK, nil
+}
+
+// ensureScheduleMatchup adds a ScheduleMatchup join (schedule <-> weekly
+// matchup) if one doesn't already exist, appending at the end of the schedule.
+func ensureScheduleMatchup(ctx context.Context, db database.Provider, schedule *model.Schedule, wmId model.WeeklyMatchupId) error {
+	existing, err := database.GetAllWhere[*model.ScheduleMatchup](ctx, db, func(_ context.Context, sm *model.ScheduleMatchup) bool {
+		return sm.ScheduleId == schedule.ID
+	})
+	if err != nil {
+		return err
+	}
+	for _, sm := range existing {
+		if sm.WeeklyMatchupId == wmId {
+			return nil
+		}
+	}
+	position := len(existing)
+	sm := model.NewScheduleMatchup(schedule.ID, wmId, position)
+	_, err = database.CreateOne(ctx, db, sm)
+	return err
+}
+
+// EmptyBody is a placeholder request body for routes that take no body.
+type EmptyBody struct{}
+
+// StaticallyValid has no static constraints.
+func (b *EmptyBody) StaticallyValid() error { return nil }

--- a/route/schedule/schedule_test.go
+++ b/route/schedule/schedule_test.go
@@ -1,0 +1,411 @@
+package schedule
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/rand/v2"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"intraclub/api"
+	"intraclub/database"
+	"intraclub/model"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// test helpers (mirror route/week)
+// ---------------------------------------------------------------------------
+
+func newStoredUser(t *testing.T, db database.Provider) *model.User {
+	t.Helper()
+	user := model.NewUser()
+	user.Email = model.EmailAddress(fmt.Sprintf("user%d@email.com", rand.Uint64()))
+	user.FirstName = fmt.Sprintf("Test %d", rand.Uint64())
+	user.LastName = "User"
+	user.PhoneNumber = model.PhoneNumber(fmt.Sprintf("%d", 100_000_0000+rand.Uint32N(999_999_999)))
+	v, err := database.CreateOne(context.Background(), db, user)
+	require.NoError(t, err)
+	return v
+}
+
+func newStoredRating(t *testing.T, db database.Provider) *model.Rating {
+	t.Helper()
+	user := newStoredUser(t, db)
+	r := model.NewRating()
+	r.UserId = user.ID
+	r.Name = fmt.Sprintf("Rating %s", database.NewRecordId())
+	r.Description = "test description"
+	v, err := database.CreateOne(context.Background(), db, r)
+	require.NoError(t, err)
+	return v
+}
+
+func newDefaultFormat(t *testing.T, db database.Provider) *model.Format {
+	t.Helper()
+	user := newStoredUser(t, db)
+	f := model.NewFormat()
+	f.UserId = user.ID
+	f.Name = "default format"
+	created, err := database.CreateOne(context.Background(), db, f)
+	require.NoError(t, err)
+
+	lines := []model.FormatLine{
+		{Player1Rating: newStoredRating(t, db).ID, Player2Rating: newStoredRating(t, db).ID},
+		{Player1Rating: newStoredRating(t, db).ID, Player2Rating: newStoredRating(t, db).ID},
+	}
+	var ratings model.RatingList
+	for _, l := range lines {
+		ratings = appendUniqueRating(ratings, l.Player1Rating)
+		ratings = appendUniqueRating(ratings, l.Player2Rating)
+	}
+	require.NoError(t, created.SetPossibleRatings(context.Background(), db, ratings))
+	require.NoError(t, created.SetLines(context.Background(), db, lines))
+	return created
+}
+
+func appendUniqueRating(ratings model.RatingList, r model.RatingId) model.RatingList {
+	for _, existing := range ratings {
+		if existing == r {
+			return ratings
+		}
+	}
+	return append(ratings, r)
+}
+
+// newSeasonWithTeams builds a Season (with a commissioner and a draft) plus
+// numTeams teams whose captains are returned. The teams are assigned to the
+// season, making their captains "participants" who must not be able to create
+// or modify the schedule.
+func newSeasonWithTeams(t *testing.T, db database.Provider, commissionerID database.UserId, numTeams int) (*model.Season, []*model.Team) {
+	t.Helper()
+	ctx := context.Background()
+
+	format := newDefaultFormat(t, db)
+	draft := model.NewDraft()
+	draft.Owner = commissionerID
+	draft.Format = format.ID
+	draftV, err := database.CreateOne(ctx, db, draft)
+	require.NoError(t, err)
+
+	facility := model.NewFacility()
+	facility.UserId = commissionerID
+	facility.Name = fmt.Sprintf("Test facility %d", rand.Uint64())
+	facility.Address = fmt.Sprintf("Test Rd %d", rand.Uint64())
+	facility.NumberOfCourts = 2
+	facilityV, err := database.CreateOne(ctx, db, facility)
+	require.NoError(t, err)
+
+	season := model.NewSeason()
+	season.Name = "Test Season"
+	season.StartTime = model.NewStartTime(8, 30)
+	season.DraftId = draftV.ID
+	season.Facility = facilityV.ID
+	seasonV, err := database.CreateOne(ctx, db, season)
+	require.NoError(t, err)
+	require.NoError(t, seasonV.AddCommissioner(ctx, db, commissionerID))
+
+	teams := make([]*model.Team, 0, numTeams)
+	for i := 0; i < numTeams; i++ {
+		captain := newStoredUser(t, db)
+		team := model.NewDefaultTeam(captain.ID, fmt.Sprintf("Team %d", i+1))
+		teamV, err := database.CreateOne(ctx, db, team)
+		require.NoError(t, err)
+		require.NoError(t, seasonV.AddTeam(ctx, db, teamV.ID))
+		teams = append(teams, teamV)
+	}
+
+	return seasonV, teams
+}
+
+// newStoredWeek creates a Week for the season's draft.
+func newStoredWeek(t *testing.T, db database.Provider, season *model.Season) *model.Week {
+	t.Helper()
+	week := model.NewWeek()
+	week.DraftId = season.DraftId
+	week.Date = time.Date(2025, 3, 1, 8, 0, 0, 0, time.UTC)
+	week.Note = "week 1"
+	v, err := database.CreateOne(context.Background(), db, week)
+	require.NoError(t, err)
+	return v
+}
+
+func newTestRouter(t *testing.T, db database.Provider) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	api.UserType = &model.User{}
+	database.SysAdminCheck = model.IsUserSystemAdministrator
+
+	router := gin.New()
+	group := router.Group("/api")
+	RegisterRoutes(group, db)
+	return router
+}
+
+var (
+	testKeyOnce sync.Once
+	testPubKey  *ecdsa.PublicKey
+	testPrivKey *ecdsa.PrivateKey
+)
+
+func newToken(t *testing.T, userId database.UserId) string {
+	t.Helper()
+	testKeyOnce.Do(func() {
+		pub, priv, err := api.GenerateKeyPair()
+		require.NoError(t, err)
+		testPubKey = pub
+		testPrivKey = priv
+	})
+	api.JwtPublicKey = testPubKey
+	api.JwtPrivateKey = testPrivKey
+	token, err := api.GenerateToken(userId.RecordId())
+	require.NoError(t, err)
+	return token
+}
+
+func doJSON(t *testing.T, router *gin.Engine, method, path string, body any, token string) *httptest.ResponseRecorder {
+	t.Helper()
+	var reader io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		require.NoError(t, err)
+		reader = bytes.NewReader(b)
+	}
+	req, err := http.NewRequest(method, path, reader)
+	require.NoError(t, err)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if token != "" {
+		req.Header.Set(api.AuthTokenHeaderValue, token)
+	}
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+func createScheduleViaHTTP(t *testing.T, router *gin.Engine, seasonID string, token string) *httptest.ResponseRecorder {
+	t.Helper()
+	return doJSON(t, router, http.MethodPost, "/api/schedule", map[string]any{"season_id": seasonID}, token)
+}
+
+func createSchedule(t *testing.T, router *gin.Engine, season *model.Season, token string) string {
+	t.Helper()
+	w := createScheduleViaHTTP(t, router, season.ID.String(), token)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var created struct {
+		Resource *model.Schedule `json:"resource"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &created))
+	require.NotNil(t, created.Resource)
+	return created.Resource.ID.String()
+}
+
+// ---------------------------------------------------------------------------
+// create schedule: commissioner only, one per season
+// ---------------------------------------------------------------------------
+
+func TestCreateScheduleCommissionerOnly(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	commissioner := newStoredUser(t, db)
+	season, teams := newSeasonWithTeams(t, db, commissioner.ID, 2)
+	_ = teams
+
+	// Commissioner may create the schedule.
+	w := createScheduleViaHTTP(t, router, season.ID.String(), newToken(t, commissioner.ID))
+	require.Equal(t, http.StatusOK, w.Code, "commissioner create: %s", w.Body.String())
+
+	// A team captain (season participant) may NOT create the schedule.
+	captainIDs, err := season.GetTeamCaptains(context.Background(), db)
+	require.NoError(t, err)
+	require.Len(t, captainIDs, 2)
+	w = createScheduleViaHTTP(t, router, season.ID.String(), newToken(t, captainIDs[0]))
+	require.Equal(t, http.StatusForbidden, w.Code, "captain create: %s", w.Body.String())
+
+	// An unrelated user may NOT create the schedule.
+	outsider := newStoredUser(t, db)
+	w = createScheduleViaHTTP(t, router, season.ID.String(), newToken(t, outsider.ID))
+	require.Equal(t, http.StatusForbidden, w.Code, "outsider create: %s", w.Body.String())
+
+	// No token -> unauthorized.
+	w = createScheduleViaHTTP(t, router, season.ID.String(), "")
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestOneSchedulePerSeason(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	commissioner := newStoredUser(t, db)
+	season, _ := newSeasonWithTeams(t, db, commissioner.ID, 2)
+
+	createSchedule(t, router, season, newToken(t, commissioner.ID))
+
+	// A second schedule for the same season must be rejected.
+	w := createScheduleViaHTTP(t, router, season.ID.String(), newToken(t, commissioner.ID))
+	require.Equal(t, http.StatusBadRequest, w.Code, "duplicate schedule: %s", w.Body.String())
+}
+
+// ---------------------------------------------------------------------------
+// assign weekly matchups: commissioner only
+// ---------------------------------------------------------------------------
+
+func assignMatchupViaHTTP(t *testing.T, router *gin.Engine, scheduleID string, body any, token string) *httptest.ResponseRecorder {
+	t.Helper()
+	return doJSON(t, router, http.MethodPost, "/api/schedule/"+scheduleID+"/weekly_matchup", body, token)
+}
+
+func TestAssignWeeklyMatchupCommissionerOnly(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	commissioner := newStoredUser(t, db)
+	season, teams := newSeasonWithTeams(t, db, commissioner.ID, 2)
+	week := newStoredWeek(t, db, season)
+
+	scheduleID := createSchedule(t, router, season, newToken(t, commissioner.ID))
+
+	matchupBody := map[string]any{
+		"week_id": week.ID.String(),
+		"matchups": []map[string]any{
+			{"home_team_id": teams[0].ID.String(), "away_team_id": teams[1].ID.String(), "bye": false},
+		},
+	}
+
+	// Commissioner may assign.
+	w := assignMatchupViaHTTP(t, router, scheduleID, matchupBody, newToken(t, commissioner.ID))
+	require.Equal(t, http.StatusOK, w.Code, "commissioner assign: %s", w.Body.String())
+
+	// A team captain (season participant) may NOT assign.
+	captainIDs, err := season.GetTeamCaptains(context.Background(), db)
+	require.NoError(t, err)
+	w = assignMatchupViaHTTP(t, router, scheduleID, matchupBody, newToken(t, captainIDs[0]))
+	require.Equal(t, http.StatusForbidden, w.Code, "captain assign: %s", w.Body.String())
+
+	// An unrelated user may NOT assign.
+	outsider := newStoredUser(t, db)
+	w = assignMatchupViaHTTP(t, router, scheduleID, matchupBody, newToken(t, outsider.ID))
+	require.Equal(t, http.StatusForbidden, w.Code, "outsider assign: %s", w.Body.String())
+}
+
+func TestAssignWeeklyMatchupWithBye(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	commissioner := newStoredUser(t, db)
+	season, teams := newSeasonWithTeams(t, db, commissioner.ID, 2)
+	week := newStoredWeek(t, db, season)
+
+	scheduleID := createSchedule(t, router, season, newToken(t, commissioner.ID))
+
+	// Both teams are on a bye this week.
+	body := map[string]any{
+		"week_id": week.ID.String(),
+		"matchups": []map[string]any{
+			{"home_team_id": teams[0].ID.String(), "bye": true},
+			{"home_team_id": teams[1].ID.String(), "bye": true},
+		},
+	}
+	w := assignMatchupViaHTTP(t, router, scheduleID, body, newToken(t, commissioner.ID))
+	require.Equal(t, http.StatusOK, w.Code, "bye assign: %s", w.Body.String())
+}
+
+func TestAssignWeeklyMatchupRequiresAllTeamsCovered(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	commissioner := newStoredUser(t, db)
+	season, teams := newSeasonWithTeams(t, db, commissioner.ID, 2)
+	week := newStoredWeek(t, db, season)
+
+	scheduleID := createSchedule(t, router, season, newToken(t, commissioner.ID))
+
+	// A single-team entry (home team with a bye but no away) leaves the second
+	// team uncovered and must be rejected.
+	badBody := map[string]any{
+		"week_id": week.ID.String(),
+		"matchups": []map[string]any{
+			{"home_team_id": teams[0].ID.String(), "away_team_id": teams[1].ID.String(), "bye": false},
+			{"home_team_id": teams[0].ID.String(), "bye": true},
+		},
+	}
+	// home team team[0] double-booked -> rejected.
+	w := assignMatchupViaHTTP(t, router, scheduleID, badBody, newToken(t, commissioner.ID))
+	require.Equal(t, http.StatusBadRequest, w.Code, "bad assign: %s", w.Body.String())
+
+	// The week must belong to the season's draft; a week from another draft is
+	// rejected.
+	otherSeason, otherTeams := newSeasonWithTeams(t, db, newStoredUser(t, db).ID, 2)
+	_ = otherTeams
+	foreignWeek := newStoredWeek(t, db, otherSeason)
+	foreignBody := map[string]any{
+		"week_id": foreignWeek.ID.String(),
+		"matchups": []map[string]any{
+			{"home_team_id": teams[0].ID.String(), "away_team_id": teams[1].ID.String(), "bye": false},
+		},
+	}
+	w = assignMatchupViaHTTP(t, router, scheduleID, foreignBody, newToken(t, commissioner.ID))
+	require.Equal(t, http.StatusBadRequest, w.Code, "foreign week assign: %s", w.Body.String())
+}
+
+// ---------------------------------------------------------------------------
+// view: schedule detail is visible to everyone
+// ---------------------------------------------------------------------------
+
+func TestScheduleDetailVisibleToEveryone(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	commissioner := newStoredUser(t, db)
+	season, teams := newSeasonWithTeams(t, db, commissioner.ID, 2)
+	week := newStoredWeek(t, db, season)
+
+	scheduleID := createSchedule(t, router, season, newToken(t, commissioner.ID))
+
+	assignMatchupViaHTTP(t, router, scheduleID, map[string]any{
+		"week_id": week.ID.String(),
+		"matchups": []map[string]any{
+			{"home_team_id": teams[0].ID.String(), "away_team_id": teams[1].ID.String(), "bye": false},
+		},
+	}, newToken(t, commissioner.ID))
+
+	// A participant (captain) and an outsider can both view the detail.
+	captainIDs, err := season.GetTeamCaptains(context.Background(), db)
+	require.NoError(t, err)
+	for _, tokenUser := range []database.UserId{captainIDs[0], newStoredUser(t, db).ID} {
+		w := doJSON(t, router, http.MethodGet, "/api/schedule/"+scheduleID, nil, newToken(t, tokenUser))
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+		var detail struct {
+			Resource ScheduleDetail `json:"resource"`
+		}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &detail))
+		require.NotNil(t, detail.Resource.Schedule)
+		require.Len(t, detail.Resource.WeeklyMatchups, 1)
+		require.Len(t, detail.Resource.WeeklyMatchups[0].Matchups, 1)
+		require.Equal(t, teams[0].ID, detail.Resource.WeeklyMatchups[0].Matchups[0].HomeTeam)
+	}
+}
+
+func TestScheduleDetailBeforeCreationHasNullSchedule(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	commissioner := newStoredUser(t, db)
+	season, _ := newSeasonWithTeams(t, db, commissioner.ID, 2)
+
+	// No schedule yet: the season-scoped query returns a detail with nil
+	// Schedule but the commissioners listed.
+	w := doJSON(t, router, http.MethodGet, "/api/schedule?season_id="+season.ID.String(), nil, newToken(t, commissioner.ID))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var detail struct {
+		Resource ScheduleDetail `json:"resource"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &detail))
+	require.Nil(t, detail.Resource.Schedule)
+	require.Len(t, detail.Resource.Commissioners, 1)
+	require.Equal(t, commissioner.ID, detail.Resource.Commissioners[0])
+}

--- a/ui/e2e/schedule.spec.ts
+++ b/ui/e2e/schedule.spec.ts
@@ -1,0 +1,195 @@
+import { expect, test, type Page } from '@playwright/test';
+import { waitForHydration } from './helpers';
+
+// The Go backend runs with --dev-token from the repo root (see
+// playwright.config.ts), so POST /api/one_time_password returns the magic-link
+// token in the response body. Login with the user seeded by SeedDevData.
+async function login(page: Page) {
+	await page.goto('/login');
+	await page.waitForLoadState('networkidle');
+	await page.getByLabel('Email').fill('jdarthur@gatech.edu');
+	await page.getByRole('button', { name: 'Send login link' }).click();
+	const link = page.getByRole('main').getByRole('link', { name: 'Log in' });
+	await expect(link).toBeVisible();
+	await link.click();
+	await expect(page).toHaveURL('/');
+}
+
+const SEED_FORMAT = "Men's Intraclub";
+const API = 'http://127.0.0.1:8080/api';
+
+async function tokenFor(page: Page, email: string): Promise<string> {
+	const res = await page.request.post(`${API}/one_time_password`, { data: { email } });
+	expect(res.ok()).toBeTruthy();
+	const { token } = await res.json();
+	const jwtRes = await page.request.post(`${API}/token`, { data: { token } });
+	expect(jwtRes.ok()).toBeTruthy();
+	const { jwt } = await jwtRes.json();
+	return jwt;
+}
+
+test('commissioner builds a season schedule and participants can view it', async ({ page }) => {
+	await login(page);
+	const token = await page.evaluate(() => localStorage.getItem('intraclub_jwt') ?? '');
+	expect(token).toBeTruthy();
+
+	const unique = Date.now();
+
+	// Two captains + two roster players is enough to complete a two-team draft.
+	const people = [
+		{ first: `CapA${unique}`, last: 'One' },
+		{ first: `CapB${unique}`, last: 'Two' },
+		{ first: `PlayA${unique}`, last: 'One' },
+		{ first: `PlayB${unique}`, last: 'Two' }
+	];
+	const csv = [
+		'First Name, Last Name, Email',
+		...people.map((p) => `${p.first}, ${p.last}, ${p.first.toLowerCase()}@example.com`)
+	].join('\n');
+	const importRes = await page.request.post(`${API}/import_users_from_csv`, {
+		form: { file: csv }
+	});
+	expect(importRes.ok()).toBeTruthy();
+	const importBody = await importRes.json();
+	const imported = [...importBody.Created, ...importBody.AlreadyExisting] as {
+		id: string;
+		email: string;
+	}[];
+	const idFor = (email: string) => imported.find((u) => u.email === email)!.id;
+	const captainAId = idFor(`${people[0].first.toLowerCase()}@example.com`);
+	const captainBId = idFor(`${people[1].first.toLowerCase()}@example.com`);
+	const playerAId = idFor(`${people[2].first.toLowerCase()}@example.com`);
+	const playerBId = idFor(`${people[3].first.toLowerCase()}@example.com`);
+
+	const facilityRes = await page.request.post(`${API}/facility`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { name: `Schedule Facility ${unique}`, address: `${unique} Main St`, courts: 4 }
+	});
+	expect(facilityRes.ok()).toBeTruthy();
+	const facilityId = (await facilityRes.json()).resource.id as string;
+
+	const formats = (await (await page.request.get(`${API}/format`)).json()).resource as {
+		id: string;
+		name: string;
+	}[];
+	const format = formats.find((f) => f.name === SEED_FORMAT);
+	expect(format).toBeTruthy();
+
+	const draftRes = await page.request.post(`${API}/draft`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { name: `Schedule Draft ${unique}`, format: format!.id }
+	});
+	expect(draftRes.ok()).toBeTruthy();
+	const draftId = (await draftRes.json()).resource.id as string;
+
+	const initRes = await page.request.post(`${API}/draft/${draftId}/initialize`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { captains: [captainAId, captainBId] }
+	});
+	expect(initRes.ok(), `initialize failed: ${await initRes.text()}`).toBeTruthy();
+	await page.request.post(`${API}/draft/${draftId}/assign_draftable_players`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { players: [playerAId, playerBId] }
+	});
+
+	const ratings = (
+		await (
+			await page.request.get(`${API}/format/${format!.id}/possible_ratings`, {
+				headers: { 'X-INTRACLUB-TOKEN': token }
+			})
+		).json()
+	).resource as { id: string }[];
+	expect(ratings.length).toBeGreaterThanOrEqual(2);
+	await page.request.post(`${API}/draft/${draftId}/assign_rating_cutoff`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { rating: ratings[0].id, cutoff: 1 }
+	});
+	await page.request.post(`${API}/draft/${draftId}/assign_rating_cutoff`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { rating: ratings[1].id, cutoff: 5 }
+	});
+
+	const captainAToken = await tokenFor(page, `${people[0].first.toLowerCase()}@example.com`);
+	const captainBToken = await tokenFor(page, `${people[1].first.toLowerCase()}@example.com`);
+
+
+	// Each captain drafts themselves + one roster player -> 4 picks = complete.
+	// With the default snake pattern and two captains the turn order is A, B, B, A.
+	const pickPlan = [
+		{ player: playerAId, token: captainAToken },
+		{ player: playerBId, token: captainBToken },
+		{ player: captainBId, token: captainBToken }, // captain B drafts themselves
+		{ player: captainAId, token: captainAToken } // captain A drafts themselves
+	];
+	for (const { player, token } of pickPlan) {
+		const res = await page.request.post(`${API}/draft/${draftId}/select`, {
+			headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+			data: { player_id: player }
+		});
+		expect(res.ok(), `pick failed: ${await res.text()}`).toBeTruthy();
+	}
+
+	const seasonName = `Schedule ${unique}`;
+	const seasonRes = await page.request.post(`${API}/draft/${draftId}/create_season`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { name: seasonName, facility: facilityId, start_time: '08:30' }
+	});
+	expect(seasonRes.ok()).toBeTruthy();
+	const season = (await seasonRes.json()).resource as { id: string };
+
+	// Commissioner creates a week for the season's draft.
+	const weekRes = await page.request.post(`${API}/week`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { draft_id: draftId, date: '2026-01-05T08:00:00Z', note: 'Week 1' }
+	});
+	expect(weekRes.ok()).toBeTruthy();
+
+	// --- build the schedule through the UI ---
+	await page.goto(`/seasons/${season.id}`);
+	await waitForHydration(page);
+	await expect(page.getByRole('heading', { name: seasonName })).toBeVisible();
+
+	const scheduleCard = page.getByText('Season schedule', { exact: true });
+	await expect(scheduleCard).toBeVisible();
+
+	await expect(page.getByRole('button', { name: 'Create schedule' })).toBeVisible();
+	await page.getByRole('button', { name: 'Create schedule' }).click();
+	await expect(page.getByRole('button', { name: 'Create schedule' })).toBeHidden();
+
+	await expect(page.getByRole('button', { name: 'Edit' })).toBeVisible();
+	await page.getByRole('button', { name: 'Edit' }).first().click();
+
+	// Fill the matchup: Team 1 (home) vs Team 2 (away).
+	await page.getByLabel('Home').selectOption({ label: 'Team 1' });
+	await page.getByLabel('Away').selectOption({ label: 'Team 2' });
+	await page.getByRole('button', { name: 'Save' }).click();
+
+	// The assigned matchup is visible on the season page.
+	await expect(page.getByText('Team 1 vs Team 2')).toBeVisible();
+
+	// --- participants can view the schedule but not modify it ---
+	const detailRes = await page.request.get(`${API}/schedule?season_id=${season.id}`, {
+		headers: { 'X-INTRACLUB-TOKEN': captainAToken }
+	});
+	expect(detailRes.ok()).toBeTruthy();
+	const detail = await detailRes.json();
+	expect(detail.resource.schedule).toBeTruthy();
+	expect(detail.resource.weekly_matchups.length).toBe(1);
+	expect(detail.resource.weekly_matchups[0].matchups[0].home_team_id).toBeTruthy();
+
+	// A team captain cannot assign a weekly matchup (commissioner-only).
+	const forbidden = await page.request.post(
+		`${API}/schedule/${detail.resource.schedule.id}/weekly_matchup`,
+		{
+			headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': captainAToken },
+			data: { week_id: detail.resource.weekly_matchups[0].week_id, matchups: [] }
+		}
+	);
+	expect(forbidden.status()).toBe(403);
+
+	// Clean up the draft so the table doesn't accumulate rows across runs.
+	const cleanup = await page.request.delete(`${API}/draft/${draftId}`, {
+		headers: { 'X-INTRACLUB-TOKEN': token }
+	});
+	expect(cleanup.ok()).toBeTruthy();
+});

--- a/ui/src/lib/schedule.ts
+++ b/ui/src/lib/schedule.ts
@@ -1,0 +1,81 @@
+// Schedule API client. Schedules and their weekly matchups are exposed via the
+// REST surface registered in route/schedule (see main.go):
+//
+//	POST   /api/schedule                      body: { season_id }
+//	GET    /api/schedule?season_id=:id        -> { resource: ScheduleDetail }
+//	GET    /api/schedule/:id                  -> { resource: ScheduleDetail }
+//	POST   /api/schedule/:id/weekly_matchup   body: { week_id, matchups }
+//
+// Only a season commissioner may create a schedule or assign weekly matchups;
+// everyone else can view. A ScheduleDetail's `schedule` is null when the
+// season has no schedule yet. Record IDs are 16-char hex strings.
+import { authFetch } from '$lib/auth';
+
+export interface TeamMatchup {
+	home_team_id: string;
+	away_team_id: string;
+	bye: boolean;
+}
+
+export interface WeeklyMatchup {
+	id: string;
+	week_id: string;
+	season_id: string;
+	matchups: TeamMatchup[];
+}
+
+export interface Schedule {
+	id: string;
+	season_id: string;
+}
+
+export interface ScheduleDetail {
+	schedule: Schedule | null;
+	commissioners: string[];
+	weekly_matchups: WeeklyMatchup[];
+}
+
+const BASE = '/api/schedule';
+
+async function unwrap(res: Response): Promise<any> {
+	if (!res.ok) {
+		let message = `Request failed (${res.status})`;
+		try {
+			const body = await res.json();
+			if (body?.error) message = body.error;
+		} catch {
+			// non-JSON error body; fall back to the status message
+		}
+		throw new Error(message);
+	}
+	const body = await res.json();
+	return body?.resource;
+}
+
+export async function createSchedule(seasonId: string): Promise<Schedule> {
+	return unwrap(
+		await authFetch(BASE, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ season_id: seasonId })
+		})
+	);
+}
+
+export async function getScheduleForSeason(seasonId: string): Promise<ScheduleDetail> {
+	return unwrap(await authFetch(`${BASE}?season_id=${seasonId}`));
+}
+
+export async function assignWeeklyMatchup(
+	scheduleId: string,
+	weekId: string,
+	matchups: TeamMatchup[]
+): Promise<WeeklyMatchup> {
+	return unwrap(
+		await authFetch(`${BASE}/${scheduleId}/weekly_matchup`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ week_id: weekId, matchups })
+		})
+	);
+}

--- a/ui/src/lib/week.ts
+++ b/ui/src/lib/week.ts
@@ -1,0 +1,34 @@
+// Week API client. Weeks are exposed via the REST surface registered in
+// route/week (see main.go):
+//
+//	GET  /api/week?season_id=:id  -> { resource: Week[] }
+//
+// Weeks are viewable by everyone; only a season commissioner can create them.
+// Record IDs are 16-char hex strings; `date` is an RFC3339 timestamp.
+import { authFetch } from '$lib/auth';
+
+export interface Week {
+	id: string;
+	draft_id: string;
+	date: string;
+	note: string;
+}
+
+async function unwrap(res: Response): Promise<any> {
+	if (!res.ok) {
+		let message = `Request failed (${res.status})`;
+		try {
+			const body = await res.json();
+			if (body?.error) message = body.error;
+		} catch {
+			// non-JSON error body; fall back to the status message
+		}
+		throw new Error(message);
+	}
+	const body = await res.json();
+	return body?.resource;
+}
+
+export async function listWeeksForSeason(seasonId: string): Promise<Week[]> {
+	return unwrap(await authFetch(`/api/week?season_id=${seasonId}`));
+}

--- a/ui/src/routes/seasons/[id]/+page.svelte
+++ b/ui/src/routes/seasons/[id]/+page.svelte
@@ -11,6 +11,15 @@
 	import type { Rating } from '$lib/rating';
 	import { listFacilities } from '$lib/facility';
 	import type { Facility } from '$lib/facility';
+	import { getCurrentUserId } from '$lib/auth';
+	import { listWeeksForSeason } from '$lib/week';
+	import type { Week } from '$lib/week';
+	import {
+		createSchedule,
+		getScheduleForSeason,
+		assignWeeklyMatchup
+	} from '$lib/schedule';
+	import type { ScheduleDetail, WeeklyMatchup } from '$lib/schedule';
 	import { Badge } from '$lib/components/ui/badge/index.js';
 	import {
 		Card,
@@ -18,6 +27,13 @@
 		CardHeader,
 		CardTitle
 	} from '$lib/components/ui/card/index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
+	import {
+		NativeSelect,
+		NativeSelectOption
+	} from '$lib/components/ui/native-select/index.js';
+	import { Checkbox } from '$lib/components/ui/checkbox/index.js';
 
 	const id = () => page.params.id as string;
 
@@ -28,24 +44,53 @@
 	let users = $state<User[]>([]);
 	let ratingsById = $state<Record<string, Rating>>({});
 	let facilities = $state<Facility[]>([]);
+	let weeks = $state<Week[]>([]);
+	let scheduleDetail = $state<ScheduleDetail | null>(null);
 
 	let loading = $state(true);
 	let loadError = $state('');
+
+	// schedule builder state
+	let creatingSchedule = $state(false);
+	let scheduleError = $state('');
+	let editingWeekId = $state<string | null>(null);
+	let draftRows = $state<Record<string, EditRow[]>>({});
+
+	interface EditRow {
+		home: string;
+		away: string;
+		bye: boolean;
+	}
+
+	const isCommissioner = $derived(
+		scheduleDetail !== null && scheduleDetail.commissioners.includes(getCurrentUserId() ?? '')
+	);
 
 	async function load() {
 		loading = true;
 		loadError = '';
 		try {
-			const [seasonData, seasonTeamList, teamRatingList, draftCaptainList, userList, ratingList, facilityList] =
-				await Promise.all([
-					getSeason(id()),
-					listSeasonTeams(),
-					listTeamRatings(),
-					listDraftCaptains(),
-					listUsers(),
-					listRatings(),
-					listFacilities()
-				]);
+			const [
+				seasonData,
+				seasonTeamList,
+				teamRatingList,
+				draftCaptainList,
+				userList,
+				ratingList,
+				facilityList,
+				weekList,
+				scheduleData
+			] = await Promise.all([
+				getSeason(id()),
+				listSeasonTeams(),
+				listTeamRatings(),
+				listDraftCaptains(),
+				listUsers(),
+				listRatings(),
+				listFacilities(),
+				listWeeksForSeason(id()),
+				getScheduleForSeason(id())
+			]);
 			season = seasonData;
 			seasonTeams = seasonTeamList.filter((st) => st.season_id === seasonData.id);
 			teamRatings = teamRatingList;
@@ -53,6 +98,8 @@
 			users = userList;
 			ratingsById = Object.fromEntries(ratingList.map((r) => [r.id, r]));
 			facilities = facilityList;
+			weeks = weekList;
+			scheduleDetail = scheduleData;
 		} catch (e) {
 			loadError = e instanceof Error ? e.message : 'Failed to load season';
 		} finally {
@@ -103,6 +150,103 @@
 	function sortedMembers(members: TeamRating[]) {
 		return [...members].sort((a, b) => userName(a.user_id).localeCompare(userName(b.user_id)));
 	}
+
+	function teamName(teamId: string): string {
+		return teams.find((t) => t.teamId === teamId)?.name ?? teamId;
+	}
+
+	function weeklyMatchupFor(weekId: string): WeeklyMatchup | undefined {
+		return scheduleDetail?.weekly_matchups.find((wm) => wm.week_id === weekId);
+	}
+
+	function weekLabel(week: Week): string {
+		const d = new Date(week.date);
+		const date = Number.isNaN(d.getTime()) ? week.date : d.toLocaleDateString();
+		return week.note ? `${date} — ${week.note}` : date;
+	}
+
+	// --- schedule create / assign actions -----------------------------------
+
+	async function loadSchedule() {
+		scheduleDetail = await getScheduleForSeason(id());
+	}
+
+	async function handleCreateSchedule() {
+		creatingSchedule = true;
+		scheduleError = '';
+		try {
+			await createSchedule(id());
+			await loadSchedule();
+		} catch (e) {
+			scheduleError = e instanceof Error ? e.message : 'Failed to create schedule';
+		} finally {
+			creatingSchedule = false;
+		}
+	}
+
+	function rowsFromMatchup(wm: WeeklyMatchup | undefined): EditRow[] {
+		if (wm && wm.matchups.length > 0) {
+			return wm.matchups.map((m) => ({
+				home: m.home_team_id,
+				away: m.bye ? '' : m.away_team_id,
+				bye: m.bye
+			}));
+		}
+		return [{ home: '', away: '', bye: false }];
+	}
+
+	function startEdit(weekId: string) {
+		draftRows[weekId] = rowsFromMatchup(weeklyMatchupFor(weekId));
+		editingWeekId = weekId;
+		scheduleError = '';
+	}
+
+	function addRow(weekId: string) {
+		draftRows[weekId].push({ home: '', away: '', bye: false });
+	}
+
+	function removeRow(weekId: string, index: number) {
+		draftRows[weekId].splice(index, 1);
+	}
+
+	function setHome(weekId: string, index: number, value: string) {
+		draftRows[weekId][index].home = value;
+	}
+
+	function setAway(weekId: string, index: number, value: string) {
+		draftRows[weekId][index].away = value;
+	}
+
+	function toggleBye(weekId: string, index: number, checked: boolean) {
+		const row = draftRows[weekId][index];
+		row.bye = checked;
+		if (checked) row.away = '';
+	}
+
+	function cancelEdit() {
+		editingWeekId = null;
+		scheduleError = '';
+	}
+
+	async function saveWeek(weekId: string) {
+		if (!scheduleDetail?.schedule) return;
+		scheduleError = '';
+		const rows = draftRows[weekId] ?? [];
+		const matchups = rows
+			.filter((r) => r.home)
+			.map((r) => ({
+				home_team_id: r.home,
+				away_team_id: r.bye ? '' : r.away,
+				bye: r.bye
+			}));
+		try {
+			await assignWeeklyMatchup(scheduleDetail.schedule.id, weekId, matchups);
+			editingWeekId = null;
+			await loadSchedule();
+		} catch (e) {
+			scheduleError = e instanceof Error ? e.message : 'Failed to save weekly matchup';
+		}
+	}
 </script>
 
 <svelte:head>
@@ -136,6 +280,157 @@
 				<span class="text-muted-foreground">Start time: {season.start_time}</span>
 				<span class="text-muted-foreground">{teams.length} teams</span>
 			</div>
+		</CardContent>
+	</Card>
+
+	<!-- Schedule -->
+	<Card class="mt-6">
+		<CardHeader>
+			<CardTitle class="text-base">Season schedule</CardTitle>
+		</CardHeader>
+		<CardContent>
+			{#if scheduleError}
+				<p class="mb-4 text-sm font-medium text-destructive">{scheduleError}</p>
+			{/if}
+
+			{#if scheduleDetail && !scheduleDetail.schedule}
+				{#if isCommissioner}
+					<p class="text-sm text-muted-foreground">
+						No schedule yet. Create one to assign weekly matchups to each week.
+					</p>
+					<Button class="mt-4" onclick={handleCreateSchedule} disabled={creatingSchedule}>
+						{creatingSchedule ? 'Creating…' : 'Create schedule'}
+					</Button>
+				{:else}
+					<p class="text-sm text-muted-foreground">
+						No schedule has been created for this season yet.
+					</p>
+				{/if}
+			{:else if scheduleDetail}
+				{#if weeks.length === 0}
+					<p class="text-sm text-muted-foreground">
+						No weeks have been added to this season yet.
+					</p>
+				{:else}
+					<ul class="flex flex-col gap-4">
+						{#each weeks as week (week.id)}
+							{#if editingWeekId === week.id}
+								<li class="rounded-lg border p-4">
+									<div class="mb-3 flex items-center justify-between">
+										<span class="text-sm font-medium">{weekLabel(week)}</span>
+										<Button
+											type="button"
+											variant="ghost"
+											size="sm"
+											onclick={cancelEdit}
+										>
+											Cancel
+										</Button>
+									</div>
+									{#if teams.length === 0}
+										<p class="text-sm text-muted-foreground">No teams to schedule.</p>
+									{:else}
+										{#each draftRows[week.id] ?? [] as row, i (i)}
+											<div class="mb-3 flex flex-wrap items-end gap-3">
+												<div class="flex flex-col gap-1">
+													<Label for={`${week.id}-home-${i}`} class="text-xs">Home</Label>
+													<NativeSelect
+														id={`${week.id}-home-${i}`}
+														value={row.home}
+														oninput={(e) =>
+															setHome(week.id, i, (e.currentTarget as HTMLSelectElement).value)
+														}
+													>
+														<NativeSelectOption value="" disabled>Select team…</NativeSelectOption>
+														{#each teams as t}
+															<NativeSelectOption value={t.teamId}>{t.name}</NativeSelectOption>
+														{/each}
+													</NativeSelect>
+												</div>
+												<div class="flex flex-col gap-1">
+													<Label for={`${week.id}-away-${i}`} class="text-xs">Away</Label>
+													<NativeSelect
+														id={`${week.id}-away-${i}`}
+														value={row.away}
+														disabled={row.bye}
+														oninput={(e) =>
+															setAway(week.id, i, (e.currentTarget as HTMLSelectElement).value)
+														}
+													>
+														<NativeSelectOption value="" disabled>Select team…</NativeSelectOption>
+														{#each teams as t}
+															<NativeSelectOption value={t.teamId}>{t.name}</NativeSelectOption>
+														{/each}
+													</NativeSelect>
+												</div>
+												<div class="flex items-center gap-2 pb-1">
+													<Checkbox
+														checked={row.bye}
+														onCheckedChange={(checked) => toggleBye(week.id, i, checked)}
+													/>
+													<Label class="text-sm">Bye</Label>
+												</div>
+												<Button
+													type="button"
+													variant="ghost"
+													size="sm"
+													onclick={() => removeRow(week.id, i)}
+												>
+													Remove
+												</Button>
+											</div>
+										{/each}
+										<div class="mt-2 flex items-center gap-3">
+											<Button
+												type="button"
+												variant="outline"
+												size="sm"
+												onclick={() => addRow(week.id)}
+											>
+												Add matchup
+											</Button>
+											<Button type="button" size="sm" onclick={() => saveWeek(week.id)}>
+												Save
+											</Button>
+										</div>
+									{/if}
+								</li>
+							{:else}
+								<li class="rounded-lg border p-4">
+									<div class="mb-2 flex items-center justify-between">
+										<span class="text-sm font-medium">{weekLabel(week)}</span>
+										{#if isCommissioner}
+											<Button
+												type="button"
+												variant="outline"
+												size="sm"
+												onclick={() => startEdit(week.id)}
+											>
+												Edit
+											</Button>
+										{/if}
+									</div>
+									{#if (weeklyMatchupFor(week.id)?.matchups.length ?? 0) > 0}
+										<ul class="flex flex-col gap-1 text-sm">
+											{#each weeklyMatchupFor(week.id)!.matchups as m}
+												<li>
+													{#if m.bye}
+														{teamName(m.home_team_id)} — bye
+													{:else}
+														{teamName(m.home_team_id)} vs {teamName(m.away_team_id)}
+													{/if}
+												</li>
+											{/each}
+										</ul>
+									{:else}
+										<p class="text-sm text-muted-foreground">No matchups assigned.</p>
+									{/if}
+								</li>
+							{/if}
+						{/each}
+					</ul>
+				{/if}
+			{/if}
 		</CardContent>
 	</Card>
 


### PR DESCRIPTION
Implements #155 ("API + UI: Season schedule (weekly matchups)").

**Backend**
- JSON marshal/unmarshal for `ScheduleId`/`WeeklyMatchupId` and wire JSON tags on `Schedule`/`WeeklyMatchup`/`TeamMatchup`.
- New `route/schedule` surface:
  - `POST /api/schedule` — create a schedule for a season (one per season, enforced by model uniqueness). Commissioner-only.
  - `GET /api/schedule?season_id=` and `GET /api/schedule/:id` — schedule detail (schedule + ordered weekly matchups + commissioners). Viewable by everyone.
  - `POST /api/schedule/:id/weekly_matchup` — assign a week's home/away/bye matchups. Commissioner-only; reuses the model's double-booking / every-team-covered validation and restores prior entries on failure.
  - Read-only generic routes for `WeeklyMatchup`, `ScheduleMatchup`, `WeeklyMatchupTeamMatchup`.
- Commissioner-only authz on all writes; everyone can view (same constraint as the weeks surface). Backend tests cover authz, one-schedule-per-season, byes, and view-by-everyone.

**UI**
- `week.ts` + `schedule.ts` API clients.
- Season detail page gains a "Season schedule" card: the commissioner can create the schedule and edit per-week home/away/bye matchups; other participants view them read-only.

**e2e**
- `schedule.spec.ts`: builds a two-team season, creates a schedule, assigns a weekly matchup through the UI, verifies it displays on the season page, and confirms a team captain can view but not modify.

**Verification**
- `go build ./...`, `go test ./...`, `go vet ./...` green
- `npm run check` (svelte-check) and `npm run test` (vitest) green
- `make e2e` green (28 tests)

Closes #155