### PR TITLE
Player availability: API + UI (#156)

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"intraclub/database"
 	"intraclub/model"
 	"intraclub/route"
+	"intraclub/route/availability"
 	"intraclub/route/draft"
 	"intraclub/route/format"
 	"intraclub/route/organization"
@@ -128,6 +129,8 @@ func main() {
 	team.RegisterRoutes(rg, db)
 
 	week.RegisterRoutes(rg, db)
+
+	availability.RegisterRoutes(rg, db)
 
 	schedule.RegisterRoutes(rg, db)
 

--- a/model/availability.go
+++ b/model/availability.go
@@ -37,10 +37,10 @@ func (opt AvailabilityOption) Valid() bool {
 }
 
 type Availability struct {
-	ID        database.RecordId `json:"id"`
-	UserId    database.UserId
-	WeekId    WeekId
-	Available AvailabilityOption
+	ID        database.RecordId  `json:"id"`
+	UserId    database.UserId    `json:"user_id"`
+	WeekId    WeekId             `json:"week_id"`
+	Available AvailabilityOption `json:"available"`
 }
 
 func (a *Availability) GetOwner() database.UserId {

--- a/route/availability/availability.go
+++ b/route/availability/availability.go
@@ -1,0 +1,281 @@
+package availability
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"intraclub/api"
+	"intraclub/database"
+	"intraclub/model"
+
+	"github.com/gin-gonic/gin"
+)
+
+// BaseRoute is the base path for the Availability REST surface. It matches the
+// singular route convention used by the generic CRUD routes (derived from
+// Availability.Type()).
+const BaseRoute = "/availability"
+
+// EmptyBody is used by routes that do not accept a request body.
+type EmptyBody struct{}
+
+func (b *EmptyBody) StaticallyValid() error {
+	return nil
+}
+
+// SetAvailabilityBody is the request body for SetAvailability.
+type SetAvailabilityBody struct {
+	// WeekId is the week the availability applies to.
+	WeekId model.WeekId `json:"week_id"`
+	// Available is the participant's availability option for the week.
+	Available model.AvailabilityOption `json:"available"`
+}
+
+// StaticallyValid ensures the availability option is a valid one before any
+// handler logic runs.
+func (b *SetAvailabilityBody) StaticallyValid() error {
+	if !b.Available.Valid() {
+		return errors.New("available must be a valid availability option")
+	}
+	return nil
+}
+
+// isSeasonParticipant reports whether the given user participates in the season
+// the week belongs to (a commissioner, late addition, or member of a season
+// team). Only participants may set availability.
+func isSeasonParticipant(ctx context.Context, db database.Provider, week *model.Week, userId database.UserId) (bool, error) {
+	draft, err := database.GetExistingRecordById(ctx, db, &model.Draft{}, week.DraftId.RecordId())
+	if err != nil {
+		return false, err
+	}
+	season, err := draft.GetSeason(ctx, db)
+	if err != nil {
+		return false, err
+	}
+	if season == nil {
+		// No season exists yet for the week's draft, so there are no
+		// participants to set availability for.
+		return false, nil
+	}
+	return season.IsUserIdASeasonParticipant(ctx, db, userId)
+}
+
+// SetAvailability creates or updates the requesting user's availability for a
+// week. Only the user themselves may set their availability (the record owner
+// is always the requesting user), and only if they are a participant in the
+// week's season. If the user has already set availability for the week, the
+// existing record is updated (upsert); otherwise a new record is created. The
+// per-user+week uniqueness rule in the model prevents duplicates.
+type SetAvailability struct{}
+
+func (c SetAvailability) Path() (api.HttpMethod, string) {
+	return api.HttpMethodPost, BaseRoute + "/set"
+}
+
+func (c SetAvailability) RequestBody() (*SetAvailabilityBody, bool) {
+	return &SetAvailabilityBody{}, true
+}
+
+func (c SetAvailability) Handler(req api.Request[*SetAvailabilityBody]) (any, int, error) {
+	if req.Token == nil {
+		return nil, http.StatusUnauthorized, errors.New("token is required")
+	}
+
+	week, err := database.GetExistingRecordById(req.Context, req.DatabaseProvider, &model.Week{}, req.Body.WeekId.RecordId())
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+
+	participant, err := isSeasonParticipant(req.Context, req.DatabaseProvider, week, req.Token.UserId)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	if !participant {
+		return nil, http.StatusForbidden, errors.New("only a season participant may set availability")
+	}
+
+	// Upsert: update the existing record for this user+week if present,
+	// otherwise create a new one. Uniqueness (user+week) is enforced by the
+	// model's UniquenessEquivalent, which CreateOne checks against existing
+	// records.
+	existing, err := database.GetAllWhere[*model.Availability](req.Context, req.DatabaseProvider,
+		func(_ context.Context, a *model.Availability) bool {
+			return a.UserId == req.Token.UserId && a.WeekId == req.Body.WeekId
+		})
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+
+	if len(existing) > 0 {
+		existing[0].Available = req.Body.Available
+		if err := database.UpdateOne(req.Context, req.DatabaseProvider, existing[0]); err != nil {
+			return nil, http.StatusBadRequest, err
+		}
+		return gin.H{api.ResourceKey: existing[0]}, http.StatusOK, nil
+	}
+
+	availability := model.NewAvailability()
+	availability.UserId = req.Token.UserId
+	availability.WeekId = req.Body.WeekId
+	availability.Available = req.Body.Available
+	created, err := database.CreateOne(req.Context, req.DatabaseProvider, availability)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	return gin.H{api.ResourceKey: created}, http.StatusOK, nil
+}
+
+// GetForUser returns the requesting user's (or a specified user's) availability
+// for the weeks of a draft. If user_id is omitted, the requesting user's own
+// availability is returned. Only the user themselves or a system administrator
+// may view a user's availability.
+type GetForUser struct{}
+
+func (c GetForUser) Path() (api.HttpMethod, string) {
+	return api.HttpMethodGet, BaseRoute
+}
+
+func (c GetForUser) RequestBody() (*EmptyBody, bool) {
+	return &EmptyBody{}, false
+}
+
+func (c GetForUser) Handler(req api.Request[*EmptyBody]) (any, int, error) {
+	if req.Token == nil {
+		return nil, http.StatusUnauthorized, errors.New("token is required")
+	}
+
+	query := req.HTTPRequest().URL.Query()
+	draftStr := query.Get("draft_id")
+	if draftStr == "" {
+		return nil, http.StatusBadRequest, errors.New("draft_id query parameter is required")
+	}
+	draftId, err := database.RecordIdFromString(draftStr)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+
+	userId := req.Token.UserId
+	if uidStr := query.Get("user_id"); uidStr != "" {
+		parsed, err := database.RecordIdFromString(uidStr)
+		if err != nil {
+			return nil, http.StatusBadRequest, err
+		}
+		if database.UserId(parsed) != req.Token.UserId {
+			isSysAdmin, err := database.SysAdminCheck(req.Context, req.DatabaseProvider, req.Token.UserId)
+			if err != nil {
+				return nil, http.StatusBadRequest, err
+			}
+			if !isSysAdmin {
+				return nil, http.StatusForbidden, errors.New("only a user may view their own availability")
+			}
+		}
+		userId = database.UserId(parsed)
+	}
+
+	avail, err := model.GetAvailabilityForUser(req.Context, req.DatabaseProvider, userId, model.DraftId(draftId))
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	return gin.H{api.ResourceKey: avail}, http.StatusOK, nil
+}
+
+// isCaptainOrCoCaptain reports whether the given user is the team's captain or
+// a co-captain, or a system administrator. Team availability is only viewable
+// by these roles.
+func isCaptainOrCoCaptain(ctx context.Context, db database.Provider, team *model.Team, userId database.UserId) (bool, error) {
+	captain, err := team.GetCaptain(ctx, db)
+	if err != nil {
+		return false, err
+	}
+	if captain == userId {
+		return true, nil
+	}
+
+	coCaptains, err := team.GetCoCaptains(ctx, db)
+	if err != nil {
+		return false, err
+	}
+	for _, c := range coCaptains {
+		if c == userId {
+			return true, nil
+		}
+	}
+
+	isSysAdmin, err := database.SysAdminCheck(ctx, db, userId)
+	if err != nil {
+		return false, err
+	}
+	return isSysAdmin, nil
+}
+
+// TeamAvailabilityEntry is a single user's availability within the team
+// availability response. It is used instead of a map keyed by user ID because
+// Go's encoding/json serializes map keys of integer-backed types as decimal,
+// which would not match the hex user IDs used everywhere else in the API.
+type TeamAvailabilityEntry struct {
+	UserId         database.UserId       `json:"user_id"`
+	Availabilities []*model.Availability `json:"availabilities"`
+}
+
+// GetForTeam returns per-user availability for every member of a team across
+// the weeks of a draft. Only the team's captain / co-captains (or a system
+// administrator) may view it. The response is a list of { user_id,
+// availabilities } entries, one per team member.
+type GetForTeam struct{}
+
+func (c GetForTeam) Path() (api.HttpMethod, string) {
+	return api.HttpMethodGet, BaseRoute + "/team"
+}
+
+func (c GetForTeam) RequestBody() (*EmptyBody, bool) {
+	return &EmptyBody{}, false
+}
+
+func (c GetForTeam) Handler(req api.Request[*EmptyBody]) (any, int, error) {
+	if req.Token == nil {
+		return nil, http.StatusUnauthorized, errors.New("token is required")
+	}
+
+	query := req.HTTPRequest().URL.Query()
+	teamStr := query.Get("team_id")
+	if teamStr == "" {
+		return nil, http.StatusBadRequest, errors.New("team_id query parameter is required")
+	}
+	teamId, err := database.RecordIdFromString(teamStr)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	draftStr := query.Get("draft_id")
+	if draftStr == "" {
+		return nil, http.StatusBadRequest, errors.New("draft_id query parameter is required")
+	}
+	draftId, err := database.RecordIdFromString(draftStr)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+
+	team, err := database.GetExistingRecordById(req.Context, req.DatabaseProvider, &model.Team{}, teamId)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+
+	authorized, err := isCaptainOrCoCaptain(req.Context, req.DatabaseProvider, team, req.Token.UserId)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	if !authorized {
+		return nil, http.StatusForbidden, errors.New("only a team captain or co-captain may view team availability")
+	}
+
+	avail, err := model.GetAvailabilityForTeam(req.Context, req.DatabaseProvider, model.TeamId(teamId), model.DraftId(draftId))
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+
+	entries := make([]*TeamAvailabilityEntry, 0, len(avail))
+	for userId, list := range avail {
+		entries = append(entries, &TeamAvailabilityEntry{UserId: userId, Availabilities: list})
+	}
+	return gin.H{api.ResourceKey: entries}, http.StatusOK, nil
+}

--- a/route/availability/availability_test.go
+++ b/route/availability/availability_test.go
@@ -1,0 +1,372 @@
+package availability
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/rand/v2"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"intraclub/api"
+	"intraclub/database"
+	"intraclub/model"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// test setup helpers (mirror route/week and route/team helpers)
+// ---------------------------------------------------------------------------
+
+func newStoredUser(t *testing.T, db database.Provider) *model.User {
+	t.Helper()
+	user := model.NewUser()
+	user.Email = model.EmailAddress(fmt.Sprintf("user%d@email.com", rand.Uint64()))
+	user.FirstName = fmt.Sprintf("Test %d", rand.Uint64())
+	user.LastName = "User"
+	user.PhoneNumber = model.PhoneNumber(fmt.Sprintf("%d", 100_000_0000+rand.Uint32N(999_999_999)))
+	v, err := database.CreateOne(context.Background(), db, user)
+	require.NoError(t, err)
+	return v
+}
+
+// newSeasonWithTeam builds a Season (with a commissioner and a draft) plus a
+// team whose captain is returned. A co-captain and a regular member are added
+// as assignments, and a single week is created for the draft. All four users
+// are season participants (the captain/co-captain/member via team membership,
+// the commissioner via the commissioner join).
+type seasonFixture struct {
+	season       *model.Season
+	draftId      model.DraftId
+	team         *model.Team
+	week         *model.Week
+	captain      database.UserId
+	coCaptain    database.UserId
+	member       database.UserId
+	commissioner database.UserId
+}
+
+func newSeasonWithTeam(t *testing.T, db database.Provider) *seasonFixture {
+	t.Helper()
+	ctx := context.Background()
+
+	commissioner := newStoredUser(t, db)
+
+	draft := model.NewDraft()
+	draft.Owner = commissioner.ID
+	draft.Format = model.FormatId(newStoredFormat(t, db).ID)
+	draftV, err := database.CreateOne(ctx, db, draft)
+	require.NoError(t, err)
+
+	facility := model.NewFacility()
+	facility.UserId = commissioner.ID
+	facility.Name = "Test facility"
+	facility.Address = "Test Rd."
+	facility.NumberOfCourts = 2
+	facilityV, err := database.CreateOne(ctx, db, facility)
+	require.NoError(t, err)
+
+	season := model.NewSeason()
+	season.Name = "Test Season"
+	season.StartTime = model.NewStartTime(8, 30)
+	season.DraftId = draftV.ID
+	season.Facility = facilityV.ID
+	seasonV, err := database.CreateOne(ctx, db, season)
+	require.NoError(t, err)
+	require.NoError(t, seasonV.AddCommissioner(ctx, db, commissioner.ID))
+
+	captain := newStoredUser(t, db)
+	team := model.NewDefaultTeam(captain.ID, "Team A")
+	teamV, err := database.CreateOne(ctx, db, team)
+	require.NoError(t, err)
+	require.NoError(t, seasonV.AddTeam(ctx, db, teamV.ID))
+
+	coCaptain := newStoredUser(t, db)
+	member := newStoredUser(t, db)
+	addAssignment(t, db, teamV, coCaptain, model.TeamRoleCoCaptain)
+	addAssignment(t, db, teamV, member, model.TeamRoleMember)
+
+	week := model.NewWeek()
+	week.DraftId = draftV.ID
+	week.Date = time.Date(2025, 3, 1, 8, 0, 0, 0, time.UTC)
+	week.Note = "week 1"
+	weekV, err := database.CreateOne(ctx, db, week)
+	require.NoError(t, err)
+
+	return &seasonFixture{
+		season:       seasonV,
+		draftId:      draftV.ID,
+		team:         teamV,
+		week:         weekV,
+		captain:      captain.ID,
+		coCaptain:    coCaptain.ID,
+		member:       member.ID,
+		commissioner: commissioner.ID,
+	}
+}
+
+func newStoredFormat(t *testing.T, db database.Provider) *model.Format {
+	t.Helper()
+	user := newStoredUser(t, db)
+	f := model.NewFormat()
+	f.UserId = user.ID
+	f.Name = fmt.Sprintf("format %d", rand.Uint64())
+	v, err := database.CreateOne(context.Background(), db, f)
+	require.NoError(t, err)
+	return v
+}
+
+func addAssignment(t *testing.T, db database.Provider, team *model.Team, user *model.User, role model.TeamRole) *model.TeamAssignment {
+	t.Helper()
+	a := &model.TeamAssignment{TeamId: team.ID, UserId: user.ID, Role: role}
+	v, err := database.CreateOne(context.Background(), db, a)
+	require.NoError(t, err)
+	return v
+}
+
+func newTestRouter(t *testing.T, db database.Provider) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	api.UserType = &model.User{}
+	database.SysAdminCheck = model.IsUserSystemAdministrator
+
+	router := gin.New()
+	group := router.Group("/api")
+	RegisterRoutes(group, db)
+	return router
+}
+
+var (
+	testKeyOnce sync.Once
+	testPubKey  *ecdsa.PublicKey
+	testPrivKey *ecdsa.PrivateKey
+)
+
+func newToken(t *testing.T, userId database.UserId) string {
+	t.Helper()
+	testKeyOnce.Do(func() {
+		pub, priv, err := api.GenerateKeyPair()
+		require.NoError(t, err)
+		testPubKey = pub
+		testPrivKey = priv
+	})
+	api.JwtPublicKey = testPubKey
+	api.JwtPrivateKey = testPrivKey
+	token, err := api.GenerateToken(userId.RecordId())
+	require.NoError(t, err)
+	return token
+}
+
+func doJSON(t *testing.T, router *gin.Engine, method, path string, body any, token string) *httptest.ResponseRecorder {
+	t.Helper()
+	var reader io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		require.NoError(t, err)
+		reader = bytes.NewReader(b)
+	}
+	req, err := http.NewRequest(method, path, reader)
+	require.NoError(t, err)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if token != "" {
+		req.Header.Set(api.AuthTokenHeaderValue, token)
+	}
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+// ---------------------------------------------------------------------------
+// set availability
+// ---------------------------------------------------------------------------
+
+func TestSetAvailabilityCreatesAndUpserts(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	fx := newSeasonWithTeam(t, db)
+
+	// A participant sets availability for the week.
+	w := doJSON(t, router, http.MethodPost, "/api/availability/set",
+		map[string]any{"week_id": fx.week.ID.String(), "available": 1}, newToken(t, fx.member))
+	require.Equal(t, http.StatusOK, w.Code, "set: %s", w.Body.String())
+	var created struct {
+		Resource *model.Availability `json:"resource"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &created))
+	require.NotNil(t, created.Resource)
+	require.Equal(t, fx.member, created.Resource.UserId)
+	require.Equal(t, fx.week.ID, created.Resource.WeekId)
+	require.Equal(t, model.AvailabilityAvailable, created.Resource.Available)
+
+	// Setting the same week again updates (upserts) instead of duplicating.
+	w = doJSON(t, router, http.MethodPost, "/api/availability/set",
+		map[string]any{"week_id": fx.week.ID.String(), "available": 3}, newToken(t, fx.member))
+	require.Equal(t, http.StatusOK, w.Code, "re-set: %s", w.Body.String())
+	var updated struct {
+		Resource *model.Availability `json:"resource"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &updated))
+	require.Equal(t, model.AvailabilityNotAvailable, updated.Resource.Available)
+	require.Equal(t, created.Resource.ID, updated.Resource.ID, "expected the same record to be updated, not a new one")
+
+	// Exactly one record exists for this user+week.
+	all, err := database.GetAllWhere[*model.Availability](context.Background(), db,
+		func(_ context.Context, a *model.Availability) bool {
+			return a.UserId == fx.member && a.WeekId == fx.week.ID
+		})
+	require.NoError(t, err)
+	require.Len(t, all, 1)
+}
+
+func TestSetAvailabilityRejectsNonParticipant(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	fx := newSeasonWithTeam(t, db)
+	outsider := newStoredUser(t, db)
+
+	w := doJSON(t, router, http.MethodPost, "/api/availability/set",
+		map[string]any{"week_id": fx.week.ID.String(), "available": 1}, newToken(t, outsider.ID))
+	require.Equal(t, http.StatusForbidden, w.Code, "outsider set: %s", w.Body.String())
+
+	// No token -> unauthorized.
+	w = doJSON(t, router, http.MethodPost, "/api/availability/set",
+		map[string]any{"week_id": fx.week.ID.String(), "available": 1}, "")
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestSetAvailabilityRejectsInvalidOption(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	fx := newSeasonWithTeam(t, db)
+
+	w := doJSON(t, router, http.MethodPost, "/api/availability/set",
+		map[string]any{"week_id": fx.week.ID.String(), "available": 99}, newToken(t, fx.member))
+	require.Equal(t, http.StatusBadRequest, w.Code, "invalid option: %s", w.Body.String())
+}
+
+// ---------------------------------------------------------------------------
+// duplicate user+week prevention
+// ---------------------------------------------------------------------------
+
+func TestAvailabilityDuplicateUserWeekRejected(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	fx := newSeasonWithTeam(t, db)
+
+	// Generic create of the same user+week twice is rejected by the model's
+	// uniqueness constraint.
+	body := map[string]any{"user_id": fx.member.String(), "week_id": fx.week.ID.String(), "available": 1}
+	token := newToken(t, fx.member)
+	w := doJSON(t, router, http.MethodPost, "/api/availability", body, token)
+	require.Equal(t, http.StatusOK, w.Code, "first create: %s", w.Body.String())
+
+	w = doJSON(t, router, http.MethodPost, "/api/availability", body, token)
+	require.Equal(t, http.StatusBadRequest, w.Code, "second create: %s", w.Body.String())
+}
+
+// ---------------------------------------------------------------------------
+// per-user query
+// ---------------------------------------------------------------------------
+
+func TestGetForUserReturnsOwnAvailability(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	fx := newSeasonWithTeam(t, db)
+
+	doJSON(t, router, http.MethodPost, "/api/availability/set",
+		map[string]any{"week_id": fx.week.ID.String(), "available": 1}, newToken(t, fx.member))
+
+	// Member queries their own availability.
+	w := doJSON(t, router, http.MethodGet, "/api/availability?draft_id="+fx.draftId.String(), nil, newToken(t, fx.member))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var mine struct {
+		Resource []*model.Availability `json:"resource"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &mine))
+	require.Len(t, mine.Resource, 1)
+	require.Equal(t, fx.member, mine.Resource[0].UserId)
+
+	// A different, non-sysadmin user cannot view another user's availability.
+	w = doJSON(t, router, http.MethodGet,
+		"/api/availability?draft_id="+fx.draftId.String()+"&user_id="+fx.member.String(),
+		nil, newToken(t, fx.captain))
+	require.Equal(t, http.StatusForbidden, w.Code, "view another user's: %s", w.Body.String())
+
+	// The owner may view their own availability even with an explicit user_id.
+	w = doJSON(t, router, http.MethodGet,
+		"/api/availability?draft_id="+fx.draftId.String()+"&user_id="+fx.member.String(),
+		nil, newToken(t, fx.member))
+	require.Equal(t, http.StatusOK, w.Code, "owner self view: %s", w.Body.String())
+}
+
+// ---------------------------------------------------------------------------
+// per-team query
+// ---------------------------------------------------------------------------
+
+func TestGetForTeamCaptainAndCoCaptain(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	fx := newSeasonWithTeam(t, db)
+
+	// Captain, co-captain, and member each set availability.
+	for _, uid := range []database.UserId{fx.captain, fx.coCaptain, fx.member} {
+		w := doJSON(t, router, http.MethodPost, "/api/availability/set",
+			map[string]any{"week_id": fx.week.ID.String(), "available": 1}, newToken(t, uid))
+		require.Equal(t, http.StatusOK, w.Code, "set for %s: %s", uid, w.Body.String())
+	}
+
+	path := "/api/availability/team?team_id=" + fx.team.ID.String() + "&draft_id=" + fx.draftId.String()
+
+	// Captain can view the team's availability.
+	w := doJSON(t, router, http.MethodGet, path, nil, newToken(t, fx.captain))
+	require.Equal(t, http.StatusOK, w.Code, "captain view: %s", w.Body.String())
+	var capView struct {
+		Resource []*TeamAvailabilityEntry `json:"resource"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &capView))
+	require.Len(t, capView.Resource, 3, "expected availability for captain, co-captain, and member")
+	for _, entry := range capView.Resource {
+		require.Len(t, entry.Availabilities, 1)
+		require.Equal(t, model.AvailabilityAvailable, entry.Availabilities[0].Available)
+	}
+
+	// Co-captain can view it too.
+	w = doJSON(t, router, http.MethodGet, path, nil, newToken(t, fx.coCaptain))
+	require.Equal(t, http.StatusOK, w.Code, "co-captain view: %s", w.Body.String())
+
+	// A regular member cannot view the team's availability.
+	w = doJSON(t, router, http.MethodGet, path, nil, newToken(t, fx.member))
+	require.Equal(t, http.StatusForbidden, w.Code, "member view: %s", w.Body.String())
+
+	// An outsider cannot view it either.
+	outsider := newStoredUser(t, db)
+	w = doJSON(t, router, http.MethodGet, path, nil, newToken(t, outsider.ID))
+	require.Equal(t, http.StatusForbidden, w.Code, "outsider view: %s", w.Body.String())
+
+	// No token -> unauthorized.
+	w = doJSON(t, router, http.MethodGet, path, nil, "")
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+// ---------------------------------------------------------------------------
+// body validation
+// ---------------------------------------------------------------------------
+
+func TestSetAvailabilityBodyValidation(t *testing.T) {
+	b := &SetAvailabilityBody{}
+	b.Available = model.AvailabilityUnset
+	require.NoError(t, b.StaticallyValid(), "unset is a valid option")
+
+	b.Available = model.AvailabilityOption(99)
+	require.Error(t, b.StaticallyValid(), "invalid option should be rejected")
+}

--- a/route/availability/routes.go
+++ b/route/availability/routes.go
@@ -1,0 +1,37 @@
+package availability
+
+import (
+	"intraclub/api"
+	"intraclub/database"
+	"intraclub/model"
+
+	"github.com/gin-gonic/gin"
+)
+
+// RegisterRoutes wires up the Availability REST surface.
+//
+// The generic CRUD routes cover single-record reads, create, update, and delete
+// (get-many is deliberately not registered because GET /availability is the
+// per-user query). Custom routes add the participant-facing "set my
+// availability for a week" upsert (POST /availability/set) and the per-user /
+// per-team availability queries. Access control comes from the Availability
+// model: a record is only editable by its owner (the participant who set it)
+// and accessible to the owner's team members.
+func RegisterRoutes(e *gin.RouterGroup, db database.Provider) {
+	// Generic create/update/delete/get-one on the Availability records. The
+	// create route auto-assigns ownership to the requesting user; the model's
+	// per-user+week uniqueness prevents duplicate records.
+	crud := api.NewCrudCommon(model.NewAvailability, false, db)
+	crud.HandleRouteTypes(e,
+		api.CrudWrapperFunctionGetOne,
+		api.CrudWrapperFunctionCreate,
+		api.CrudWrapperFunctionUpdate,
+		api.CrudWrapperFunctionDelete,
+	)
+
+	setFamily := api.RouteFamily[*SetAvailabilityBody]{DatabaseProvider: db}
+	setFamily.Handle(e, SetAvailability{})
+
+	queryFamily := api.RouteFamily[*EmptyBody]{DatabaseProvider: db}
+	queryFamily.Handle(e, GetForUser{}, GetForTeam{})
+}

--- a/ui/e2e/availability.spec.ts
+++ b/ui/e2e/availability.spec.ts
@@ -1,0 +1,175 @@
+import { expect, test, type Page } from '@playwright/test';
+import { waitForHydration } from './helpers';
+
+const API = 'http://127.0.0.1:8080/api';
+
+// Log in through the UI (dev mode returns the magic-link token in the
+// one_time_password response, rendered as a clickable link on the login page).
+async function login(page: Page, email: string) {
+	await page.goto('/login');
+	await page.waitForLoadState('networkidle');
+	await page.getByLabel('Email').fill(email);
+	await page.getByRole('button', { name: 'Send login link' }).click();
+	const link = page.getByRole('main').getByRole('link', { name: 'Log in' });
+	await expect(link).toBeVisible();
+	await link.click();
+	await expect(page).toHaveURL('/');
+}
+
+test('season participant sets availability and captain sees team view', async ({ page }) => {
+	await login(page, 'jdarthur@gatech.edu');
+	const token = await page.evaluate(() => localStorage.getItem('intraclub_jwt') ?? '');
+	expect(token).toBeTruthy();
+
+	const unique = Date.now();
+
+	// Two captains + two roster players is enough to complete a two-team draft.
+	const people = [
+		{ first: `CapA${unique}`, last: 'One' },
+		{ first: `CapB${unique}`, last: 'Two' },
+		{ first: `PlayA${unique}`, last: 'One' },
+		{ first: `PlayB${unique}`, last: 'Two' }
+	];
+	const csv = [
+		'First Name, Last Name, Email',
+		...people.map((p) => `${p.first}, ${p.last}, ${p.first.toLowerCase()}@example.com`)
+	].join('\n');
+	const importRes = await page.request.post(`${API}/import_users_from_csv`, {
+		form: { file: csv }
+	});
+	expect(importRes.ok()).toBeTruthy();
+	const importBody = await importRes.json();
+	const imported = [...importBody.Created, ...importBody.AlreadyExisting] as {
+		id: string;
+		email: string;
+	}[];
+	const idFor = (email: string) => imported.find((u) => u.email === email)!.id;
+	const captainAId = idFor(`${people[0].first.toLowerCase()}@example.com`);
+	const captainBId = idFor(`${people[1].first.toLowerCase()}@example.com`);
+	const playerAId = idFor(`${people[2].first.toLowerCase()}@example.com`);
+	const playerBId = idFor(`${people[3].first.toLowerCase()}@example.com`);
+	const captainAEmail = `${people[0].first.toLowerCase()}@example.com`;
+
+	const facilityRes = await page.request.post(`${API}/facility`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { name: `Avail Facility ${unique}`, address: `${unique} Main St`, courts: 4 }
+	});
+	expect(facilityRes.ok()).toBeTruthy();
+	const facilityId = (await facilityRes.json()).resource.id as string;
+
+	const formats = (await (await page.request.get(`${API}/format`)).json()).resource as {
+		id: string;
+		name: string;
+	}[];
+	const format = formats.find((f) => f.name === "Men's Intraclub");
+	expect(format).toBeTruthy();
+
+	const draftRes = await page.request.post(`${API}/draft`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { name: `Avail Draft ${unique}`, format: format!.id }
+	});
+	expect(draftRes.ok()).toBeTruthy();
+	const draftId = (await draftRes.json()).resource.id as string;
+
+	const initRes = await page.request.post(`${API}/draft/${draftId}/initialize`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { captains: [captainAId, captainBId] }
+	});
+	expect(initRes.ok(), `initialize failed: ${await initRes.text()}`).toBeTruthy();
+	await page.request.post(`${API}/draft/${draftId}/assign_draftable_players`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { players: [playerAId, playerBId] }
+	});
+
+	const ratings = (
+		await (
+			await page.request.get(`${API}/format/${format!.id}/possible_ratings`, {
+				headers: { 'X-INTRACLUB-TOKEN': token }
+			})
+		).json()
+	).resource as { id: string }[];
+	expect(ratings.length).toBeGreaterThanOrEqual(2);
+	await page.request.post(`${API}/draft/${draftId}/assign_rating_cutoff`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { rating: ratings[0].id, cutoff: 1 }
+	});
+	await page.request.post(`${API}/draft/${draftId}/assign_rating_cutoff`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { rating: ratings[1].id, cutoff: 5 }
+	});
+
+	const tokenFor = async (email: string) => {
+		const res = await page.request.post(`${API}/one_time_password`, { data: { email } });
+		expect(res.ok()).toBeTruthy();
+		const { token: otp } = await res.json();
+		const jwtRes = await page.request.post(`${API}/token`, { data: { token: otp } });
+		expect(jwtRes.ok()).toBeTruthy();
+		return (await jwtRes.json()).jwt as string;
+	};
+	const captainAToken = await tokenFor(captainAEmail);
+	const captainBToken = await tokenFor(`${people[1].first.toLowerCase()}@example.com`);
+
+	// Complete the draft: A, B, B, A snake order.
+	const pickPlan = [
+		{ player: playerAId, token: captainAToken },
+		{ player: playerBId, token: captainBToken },
+		{ player: captainBId, token: captainBToken },
+		{ player: captainAId, token: captainAToken }
+	];
+	for (const { player, token: pickToken } of pickPlan) {
+		const res = await page.request.post(`${API}/draft/${draftId}/select`, {
+			headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': pickToken },
+			data: { player_id: player }
+		});
+		expect(res.ok(), `pick failed: ${await res.text()}`).toBeTruthy();
+	}
+
+	const seasonName = `Avail ${unique}`;
+	const seasonRes = await page.request.post(`${API}/draft/${draftId}/create_season`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { name: seasonName, facility: facilityId, start_time: '08:30' }
+	});
+	expect(seasonRes.ok()).toBeTruthy();
+	const season = (await seasonRes.json()).resource as { id: string };
+
+	const weekRes = await page.request.post(`${API}/week`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { draft_id: draftId, date: '2026-01-05T08:00:00Z', note: 'Week 1' }
+	});
+	expect(weekRes.ok()).toBeTruthy();
+
+	// --- log in as a team captain (season participant) and set availability ---
+	await login(page, captainAEmail);
+	await page.goto(`/seasons/${season.id}`);
+	await waitForHydration(page);
+	await expect(page.getByRole('heading', { name: seasonName })).toBeVisible();
+
+	const availCard = page.getByText('Player availability', { exact: true });
+	await expect(availCard).toBeVisible();
+
+	// A captain sees the team availability table.
+	await expect(page.getByText(/team availability/)).toBeVisible();
+
+	// Set captain A's availability for Week 1 to "Available".
+	await page.getByLabel(/Week 1/).selectOption({ label: 'Available' });
+
+	// The backend records exactly one availability for captain A for the week.
+	await expect
+		.poll(async () => {
+			const mine = await page.request.get(`${API}/availability?draft_id=${draftId}`, {
+				headers: { 'X-INTRACLUB-TOKEN': captainAToken }
+			});
+			const body = await mine.json();
+			return body.resource?.length;
+		})
+		.toBe(1);
+
+	// The value persists in the team availability table for captain A.
+	await expect(page.locator('table').getByText('Available')).toBeVisible();
+
+	// Clean up the draft so the table doesn't accumulate rows across runs.
+	const cleanup = await page.request.delete(`${API}/draft/${draftId}`, {
+		headers: { 'X-INTRACLUB-TOKEN': token }
+	});
+	expect(cleanup.ok()).toBeTruthy();
+});

--- a/ui/src/lib/availability.ts
+++ b/ui/src/lib/availability.ts
@@ -1,0 +1,77 @@
+// Availability API client. Player availability is exposed via the REST surface
+// registered in route/availability (see main.go):
+//
+//	POST /api/availability/set               body: { week_id, available } -> { resource: Availability }
+//	GET  /api/availability?draft_id=:id      -> { resource: Availability[] }  (own availability)
+//	GET  /api/availability?draft_id=:id&user_id=:id -> { resource: Availability[] } (sysadmin only)
+//	GET  /api/availability/team?team_id=:id&draft_id=:id -> { resource: TeamAvailabilityEntry[] } (captain/co-captain)
+//
+// Availability options are numeric: 0 = unset, 1 = available, 2 = maybe,
+// 3 = not available. Only a season participant may set availability, and only
+// for themselves. Team availability is viewable by a team's captain/co-captain.
+// Record IDs are 16-char hex strings.
+import { authFetch } from '$lib/auth';
+
+export const AVAILABILITY_UNSET = 0;
+export const AVAILABILITY_AVAILABLE = 1;
+export const AVAILABILITY_MAYBE = 2;
+export const AVAILABILITY_NOT_AVAILABLE = 3;
+
+export type AvailabilityOption = typeof AVAILABILITY_UNSET | typeof AVAILABILITY_AVAILABLE | typeof AVAILABILITY_MAYBE | typeof AVAILABILITY_NOT_AVAILABLE;
+
+export interface Availability {
+	id: string;
+	user_id: string;
+	week_id: string;
+	available: AvailabilityOption;
+}
+
+export interface TeamAvailabilityEntry {
+	user_id: string;
+	availabilities: Availability[];
+}
+
+export const AVAILABILITY_OPTIONS: { value: AvailabilityOption; label: string }[] = [
+	{ value: AVAILABILITY_UNSET, label: 'Unset' },
+	{ value: AVAILABILITY_AVAILABLE, label: 'Available' },
+	{ value: AVAILABILITY_MAYBE, label: 'Maybe' },
+	{ value: AVAILABILITY_NOT_AVAILABLE, label: 'Not available' }
+];
+
+export function availabilityLabel(option: number): string {
+	return AVAILABILITY_OPTIONS.find((o) => o.value === option)?.label ?? 'Unset';
+}
+
+async function unwrap(res: Response): Promise<any> {
+	if (!res.ok) {
+		let message = `Request failed (${res.status})`;
+		try {
+			const body = await res.json();
+			if (body?.error) message = body.error;
+		} catch {
+			// non-JSON error body; fall back to the status message
+		}
+		throw new Error(message);
+	}
+	const body = await res.json();
+	return body?.resource;
+}
+
+export async function setAvailability(weekId: string, available: number): Promise<Availability> {
+	return unwrap(
+		await authFetch('/api/availability/set', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ week_id: weekId, available })
+		})
+	);
+}
+
+export async function getAvailabilityForUser(draftId: string, userId?: string): Promise<Availability[]> {
+	const query = userId ? `?draft_id=${draftId}&user_id=${userId}` : `?draft_id=${draftId}`;
+	return unwrap(await authFetch(`/api/availability${query}`));
+}
+
+export async function getAvailabilityForTeam(teamId: string, draftId: string): Promise<TeamAvailabilityEntry[]> {
+	return unwrap(await authFetch(`/api/availability/team?team_id=${teamId}&draft_id=${draftId}`));
+}

--- a/ui/src/routes/seasons/[id]/+page.svelte
+++ b/ui/src/routes/seasons/[id]/+page.svelte
@@ -14,6 +14,16 @@
 	import { getCurrentUserId } from '$lib/auth';
 	import { listWeeksForSeason } from '$lib/week';
 	import type { Week } from '$lib/week';
+	import { listTeams } from '$lib/team';
+	import type { TeamRoster } from '$lib/team';
+	import {
+		AVAILABILITY_OPTIONS,
+		getAvailabilityForUser,
+		getAvailabilityForTeam,
+		setAvailability,
+		availabilityLabel
+	} from '$lib/availability';
+	import type { AvailabilityOption } from '$lib/availability';
 	import {
 		createSchedule,
 		getScheduleForSeason,
@@ -47,6 +57,13 @@
 	let weeks = $state<Week[]>([]);
 	let scheduleDetail = $state<ScheduleDetail | null>(null);
 
+	// player availability state
+	let rosters = $state<TeamRoster[]>([]);
+	let myAvailability = $state<Record<string, AvailabilityOption>>({});
+	let teamAvailability = $state<Record<string, Record<string, AvailabilityOption>>>({});
+	let availabilityError = $state('');
+	let savingWeek = $state<string | null>(null);
+
 	let loading = $state(true);
 	let loadError = $state('');
 
@@ -79,7 +96,8 @@
 				ratingList,
 				facilityList,
 				weekList,
-				scheduleData
+				scheduleData,
+				rosterList
 			] = await Promise.all([
 				getSeason(id()),
 				listSeasonTeams(),
@@ -89,7 +107,8 @@
 				listRatings(),
 				listFacilities(),
 				listWeeksForSeason(id()),
-				getScheduleForSeason(id())
+				getScheduleForSeason(id()),
+				listTeams()
 			]);
 			season = seasonData;
 			seasonTeams = seasonTeamList.filter((st) => st.season_id === seasonData.id);
@@ -100,6 +119,8 @@
 			facilities = facilityList;
 			weeks = weekList;
 			scheduleDetail = scheduleData;
+			rosters = rosterList;
+			await loadAvailability();
 		} catch (e) {
 			loadError = e instanceof Error ? e.message : 'Failed to load season';
 		} finally {
@@ -147,6 +168,34 @@
 			})
 	);
 
+	// --- player availability derived state --------------------------------
+
+	const currentUserId = $derived(getCurrentUserId() ?? '');
+
+	// The teams in this season that the current user is on (from the
+	// reconstructed roster), used to gate the "set my availability" inputs.
+	const myTeams = $derived(
+		teams.filter((t) => t.members.some((m) => m.user_id === currentUserId))
+	);
+
+	// The teams in this season where the current user is a captain or
+	// co-captain (from the role-bearing TeamRoster list), which gate the team
+	// availability view.
+	const myCaptainTeamIds = $derived(
+		rosters
+			.filter((r) =>
+				r.assignments.some(
+					(a) =>
+						a.user_id === currentUserId &&
+						(a.role === 'captain' || a.role === 'co_captain')
+				)
+			)
+			.map((r) => r.team.id)
+			.filter((tid) => teams.some((t) => t.teamId === tid))
+	);
+
+	const captainTeam = $derived(teams.find((t) => myCaptainTeamIds.includes(t.teamId)));
+
 	function sortedMembers(members: TeamRating[]) {
 		return [...members].sort((a, b) => userName(a.user_id).localeCompare(userName(b.user_id)));
 	}
@@ -163,6 +212,57 @@
 		const d = new Date(week.date);
 		const date = Number.isNaN(d.getTime()) ? week.date : d.toLocaleDateString();
 		return week.note ? `${date} — ${week.note}` : date;
+	}
+
+	// --- player availability actions --------------------------------------
+
+	// loadAvailability fetches the current user's availability for the season's
+	// weeks, and (when they are a captain/co-captain) their team's availability
+	// for the team view.
+	async function loadAvailability() {
+		if (!season || !currentUserId) return;
+		const draftId = season.draft_id;
+		try {
+			const mine = await getAvailabilityForUser(draftId);
+			myAvailability = Object.fromEntries(mine.map((a) => [a.week_id, a.available]));
+			availabilityError = '';
+		} catch (e) {
+			availabilityError = e instanceof Error ? e.message : 'Failed to load availability';
+			return;
+		}
+
+		if (myCaptainTeamIds.length === 0) return;
+		try {
+			const combined: Record<string, Record<string, AvailabilityOption>> = {};
+			for (const teamId of myCaptainTeamIds) {
+				const entries = await getAvailabilityForTeam(teamId, draftId);
+				for (const entry of entries) {
+					combined[entry.user_id] = Object.fromEntries(
+						entry.availabilities.map((a) => [a.week_id, a.available])
+					);
+				}
+			}
+			teamAvailability = combined;
+		} catch (e) {
+			availabilityError = e instanceof Error ? e.message : 'Failed to load team availability';
+		}
+	}
+
+	// setWeekAvailability saves the current user's availability for a week and
+	// refreshes the availability data (including the team view, if shown) from
+	// the API so the UI reflects the saved value.
+	async function setWeekAvailability(weekId: string, value: string) {
+		const option = Number(value) as AvailabilityOption;
+		savingWeek = weekId;
+		availabilityError = '';
+		try {
+			await setAvailability(weekId, option);
+			await loadAvailability();
+		} catch (e) {
+			availabilityError = e instanceof Error ? e.message : 'Failed to save availability';
+		} finally {
+			savingWeek = null;
+		}
 	}
 
 	// --- schedule create / assign actions -----------------------------------
@@ -430,6 +530,100 @@
 						{/each}
 					</ul>
 				{/if}
+			{/if}
+		</CardContent>
+	</Card>
+
+	<!-- Player availability -->
+	<Card class="mt-6">
+		<CardHeader>
+			<CardTitle class="text-base">Player availability</CardTitle>
+		</CardHeader>
+		<CardContent>
+			{#if availabilityError}
+				<p class="mb-4 text-sm font-medium text-destructive">{availabilityError}</p>
+			{/if}
+
+			{#if weeks.length === 0}
+				<p class="text-sm text-muted-foreground">
+					No weeks have been added to this season yet.
+				</p>
+			{:else if myTeams.length === 0}
+				<p class="text-sm text-muted-foreground">
+					You are not on a team in this season, so there is nothing to set.
+				</p>
+			{:else}
+				<p class="mb-4 text-sm text-muted-foreground">
+					Set your availability for each week. Captains and co-captains can also view their
+					team's availability below.
+				</p>
+				<ul class="flex flex-col gap-3">
+					{#each weeks as week (week.id)}
+						<li class="flex items-center justify-between gap-4">
+							<Label for={`availability-${week.id}`} class="text-sm font-medium">
+								{weekLabel(week)}
+							</Label>
+							<div class="flex items-center gap-3">
+								{#if savingWeek === week.id}
+									<span class="text-xs text-muted-foreground">Saving…</span>
+								{/if}
+								<NativeSelect
+									id={`availability-${week.id}`}
+									value={String(myAvailability[week.id] ?? 0)}
+									oninput={(e) =>
+										setWeekAvailability(
+											week.id,
+											(e.currentTarget as HTMLSelectElement).value
+										)
+									}
+								>
+									{#each AVAILABILITY_OPTIONS as opt}
+										<NativeSelectOption value={String(opt.value)}>
+											{opt.label}
+										</NativeSelectOption>
+									{/each}
+								</NativeSelect>
+							</div>
+						</li>
+					{/each}
+				</ul>
+			{/if}
+
+			{#if captainTeam}
+				<div class="mt-6">
+					<h3 class="mb-2 text-sm font-semibold">
+						{captainTeam.name} — team availability
+					</h3>
+					<div class="overflow-x-auto">
+						<table class="w-full text-sm">
+							<thead>
+								<tr class="border-b text-left text-muted-foreground">
+									<th class="py-1 pr-4 font-medium">Player</th>
+									{#each weeks as week}
+										<th class="py-1 pr-4 font-medium">{weekLabel(week)}</th>
+									{/each}
+								</tr>
+							</thead>
+							<tbody>
+								{#each sortedMembers(captainTeam.members) as member}
+									<tr class="border-b">
+										<td class="py-1 pr-4">
+											{userName(member.user_id)}
+											{#if member.user_id === captainTeam.captainId}
+												<span class="text-xs text-muted-foreground">(captain)</span>
+											{/if}
+										</td>
+										{#each weeks as week}
+											<td class="py-1 pr-4">
+												{availabilityLabel(teamAvailability[member.user_id]?.[week.id] ?? 0)}
+											</td>
+										{/each}
+									</tr>
+								{/each}
+							</tbody>
+						</table>
+					</div>
+				</div>
 			{/if}
 		</CardContent>
 	</Card>


### PR DESCRIPTION
Implements #156 — "Input availability".

## What
Adds a REST surface and UI for player availability per season week.

**Backend** (`route/availability`, wired in `main.go`):
- Generic CRUD for `Availability` (get-one, create, update, delete).
- `POST /api/availability/set` — participant-facing upsert of their own
  availability for a week (season-participant-only).
- `GET /api/availability?draft_id=` — a user's availability (self or sysadmin).
- `GET /api/availability/team?team_id=&draft_id=` — team availability,
  viewable only by the team's captain / co-captains (or a sysadmin).
- Duplicate user+week prevented by the model's uniqueness constraint.
- Added snake_case json tags to the `Availability` model.

**UI** (`$lib/availability` + season page):
- "Player availability" card: participants set yes/maybe/no per week;
  captains / co-captains see a team availability table.

## Acceptance criteria
- [x] A season participant can set availability for each week
- [x] Team availability is viewable by captain/co-captain
- [x] Duplicate user+week prevented (model uniqueness)
- [x] `make e2e` green (29/29, including new `availability.spec.ts`)

## Verification
- `go test ./...` + `go vet ./...` green
- `npm run check` (svelte-check + typecheck) green
- `make e2e` green (29 tests)

Closes #156