### PR TITLE
Lineups: API + season-page UI for weekly team lineups

### DIFF
--- a/database/migrations/0052_add_lineup_confirmed_official.sql
+++ b/database/migrations/0052_add_lineup_confirmed_official.sql
@@ -1,0 +1,8 @@
+-- 0052_add_lineup_confirmed_official.sql
+-- Add the captain-confirmed and commissioner-official flags to the lineup
+-- table. The Lineup model (model/lineup.go) tracks these so a weekly lineup
+-- must be confirmed by the team captain/co-captains before the season
+-- commissioner marks it official. Stored as INTEGER (0/1), matching the
+-- provider's bool mapping.
+ALTER TABLE lineup ADD COLUMN confirmed INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE lineup ADD COLUMN official INTEGER NOT NULL DEFAULT 0;

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ import (
 	"intraclub/route/availability"
 	"intraclub/route/draft"
 	"intraclub/route/format"
+	"intraclub/route/lineup"
 	"intraclub/route/organization"
 	"intraclub/route/ruleset"
 	"intraclub/route/schedule"
@@ -133,6 +134,8 @@ func main() {
 	availability.RegisterRoutes(rg, db)
 
 	schedule.RegisterRoutes(rg, db)
+
+	lineup.RegisterRoutes(rg, db)
 
 	playoffStructures := api.NewCrudCommon(model.NewPlayoffStructure, false, db)
 	playoffStructures.HandleRouteTypes(rg, api.CrudWrapperFunctionAll...)

--- a/model/lineup.go
+++ b/model/lineup.go
@@ -17,10 +17,25 @@ func (id LineupId) String() string {
 	return id.RecordId().String()
 }
 
+func (id LineupId) MarshalJSON() ([]byte, error) {
+	return id.RecordId().MarshalJSON()
+}
+
+func (id *LineupId) UnmarshalJSON(bytes []byte) error {
+	rid := database.RecordId(0)
+	if err := (*database.RecordId)(&rid).UnmarshalJSON(bytes); err != nil {
+		return err
+	}
+	*id = LineupId(rid)
+	return nil
+}
+
 type Lineup struct {
-	ID     LineupId `json:"id"`
-	TeamId TeamId // TeamId for this particular Lineup
-	WeekId WeekId // Week that this Lineup applies to
+	ID        LineupId `json:"id"`
+	TeamId    TeamId   `json:"team_id"` // TeamId for this particular Lineup
+	WeekId    WeekId   `json:"week_id"` // Week that this Lineup applies to
+	Confirmed bool     `json:"confirmed"` // set by the captain/co-captain once the lineup is final
+	Official  bool     `json:"official"`  // set by the season commissioner, requires Confirmed
 }
 
 func (l *Lineup) GetOwner() database.UserId {
@@ -106,4 +121,10 @@ func (l *Lineup) PostDelete(ctx context.Context, db database.Provider) error {
 
 func (l *Lineup) NewRecord() database.CrudRecord {
 	return new(Lineup)
+}
+
+// NewLineup returns a new Lineup record. It is the conventional constructor
+// used by the generic CRUD route registration.
+func NewLineup() *Lineup {
+	return &Lineup{}
 }

--- a/model/lineup_pairing.go
+++ b/model/lineup_pairing.go
@@ -17,13 +17,26 @@ func (id LineupPairingId) String() string {
 	return id.RecordId().String()
 }
 
+func (id LineupPairingId) MarshalJSON() ([]byte, error) {
+	return id.RecordId().MarshalJSON()
+}
+
+func (id *LineupPairingId) UnmarshalJSON(bytes []byte) error {
+	rid := database.RecordId(0)
+	if err := (*database.RecordId)(&rid).UnmarshalJSON(bytes); err != nil {
+		return err
+	}
+	*id = LineupPairingId(rid)
+	return nil
+}
+
 type LineupPairing struct {
-	ID              LineupPairingId `json:"id"` // unique ID for this LineupPairing
-	LineupId        LineupId        // This correlates a LineupPairing into a group with other pairing and assigns to a Week
-	TeamId          TeamId          // Players must be on this team
-	Player1         database.UserId // Player in slot 1 for the format / line
-	Player2         database.UserId // Player in slot 2 for the format / line
-	FormatLineIndex int             // index in the Format.Lines list that this pairing applies to
+	ID              LineupPairingId `json:"id"`           // unique ID for this LineupPairing
+	LineupId        LineupId        `json:"lineup_id"`   // This correlates a LineupPairing into a group with other pairing and assigns to a Week
+	TeamId          TeamId          `json:"team_id"`     // Players must be on this team
+	Player1         database.UserId `json:"player1"`     // Player in slot 1 for the format / line
+	Player2         database.UserId `json:"player2"`     // Player in slot 2 for the format / line
+	FormatLineIndex int             `json:"format_line_index"` // index in the Format.Lines list that this pairing applies to
 }
 
 func (l *LineupPairing) UniquenessEquivalent(other *LineupPairing) error {
@@ -112,7 +125,11 @@ func (l *LineupPairing) DynamicallyValid(ctx context.Context, db database.Provid
 	if l.FormatLineIndex >= len(lines) {
 		return fmt.Errorf("format line index out of range: %d, max %d", l.FormatLineIndex, len(lines)-1)
 	}
-	return nil
+
+	// enforce that both players carry the ratings required by their format line
+	// (the acceptance criterion for lineups: pairings are validated against team
+	// membership + format ratings).
+	return l.ValidatePlayerRatings(ctx, db)
 }
 
 func (l *LineupPairing) GetFormat(ctx context.Context, db database.Provider) (*Format, error) {
@@ -167,4 +184,10 @@ func (l *LineupPairing) ValidatePlayerRatings(ctx context.Context, db database.P
 
 func (l *LineupPairing) NewRecord() database.CrudRecord {
 	return new(LineupPairing)
+}
+
+// NewLineupPairing returns a new LineupPairing record. It is the conventional
+// constructor used by the generic CRUD route registration.
+func NewLineupPairing() *LineupPairing {
+	return &LineupPairing{}
 }

--- a/model/team_match_test.go
+++ b/model/team_match_test.go
@@ -43,10 +43,23 @@ func newStoredTeamMatch(t *testing.T, db database.Provider) *TeamMatch {
 }
 
 // newStoredLineupPairing builds a LineupPairing belonging to the given lineup,
-// with two freshly-created users added as members of the lineup's team.
+// with two freshly-created users added as members of the lineup's team. The two
+// players are assigned ratings matching the format's line 0 so the pairing
+// passes DynamicallyValid's rating check.
 func newStoredLineupPairing(t *testing.T, db database.Provider, lineup *Lineup, team *Team) *LineupPairing {
 	player1 := newStoredUser(t, db)
 	player2 := newStoredUser(t, db)
+
+	// Resolve the format line 0's required ratings so the players carry them.
+	week, err := database.GetExistingRecordById(context.Background(), db, &Week{}, lineup.WeekId.RecordId())
+	require.NoError(t, err)
+	draft, err := database.GetExistingRecordById(context.Background(), db, &Draft{}, week.DraftId.RecordId())
+	require.NoError(t, err)
+	format, err := database.GetExistingRecordById(context.Background(), db, &Format{}, draft.Format.RecordId())
+	require.NoError(t, err)
+	lines, err := format.GetLines(context.Background(), db)
+	require.NoError(t, err)
+	line := lines[0]
 
 	for _, player := range []database.UserId{player1.ID, player2.ID} {
 		assignment := &TeamAssignment{
@@ -55,6 +68,18 @@ func newStoredLineupPairing(t *testing.T, db database.Provider, lineup *Lineup, 
 			Role:   TeamRoleMember,
 		}
 		_, err := database.CreateOne(context.Background(), db, assignment)
+		require.NoError(t, err)
+	}
+
+	ratings := []database.UserId{player1.ID, player2.ID}
+	required := []RatingId{line.Player1Rating, line.Player2Rating}
+	for i, player := range ratings {
+		teamRating := &TeamRating{
+			TeamId:   team.ID,
+			UserId:   player,
+			RatingId: required[i],
+		}
+		_, err := database.CreateOne(context.Background(), db, teamRating)
 		require.NoError(t, err)
 	}
 

--- a/route/lineup/lineup.go
+++ b/route/lineup/lineup.go
@@ -1,0 +1,346 @@
+package lineup
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"intraclub/api"
+	"intraclub/database"
+	"intraclub/model"
+
+	"github.com/gin-gonic/gin"
+)
+
+// BaseRoute is the base path for the Lineup REST surface. It matches the
+// singular route convention used by the generic CRUD routes (derived from
+// Lineup.Type()).
+const BaseRoute = "/lineup"
+
+// canEditTeamLineup reports whether the requesting user is a captain or
+// co-captain of the given team (the only role allowed to build/confirm it).
+func canEditTeamLineup(ctx context.Context, db database.Provider, userId database.UserId, teamId model.TeamId) bool {
+	for _, uid := range model.EditableByTeamCaptainOrCoCaptains(ctx, db, teamId) {
+		if uid == userId {
+			return true
+		}
+	}
+	return false
+}
+
+// isSeasonCommissioner reports whether the requesting user is one of the
+// season's commissioners (the only role allowed to mark a lineup official).
+func isSeasonCommissioner(ctx context.Context, db database.Provider, userId database.UserId, seasonId model.SeasonId) bool {
+	for _, uid := range model.EditableBySeason(ctx, db, seasonId) {
+		if uid == userId {
+			return true
+		}
+	}
+	return false
+}
+
+// lineupDetailForTeamWeek builds the LineupDetail for a team + week: the
+// lineup record (if any), the format's lines (in index order), and the
+// lineup's pairings.
+func lineupDetailForTeamWeek(ctx context.Context, db database.Provider, teamId model.TeamId, weekId model.WeekId) (*LineupDetail, error) {
+	week, err := database.GetExistingRecordById(ctx, db, &model.Week{}, weekId.RecordId())
+	if err != nil {
+		return nil, err
+	}
+	draft, err := database.GetExistingRecordById(ctx, db, &model.Draft{}, week.DraftId.RecordId())
+	if err != nil {
+		return nil, err
+	}
+	format, err := database.GetExistingRecordById(ctx, db, &model.Format{}, draft.Format.RecordId())
+	if err != nil {
+		return nil, err
+	}
+	lines, err := format.GetLines(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+
+	detail := &LineupDetail{
+		TeamId:   teamId,
+		WeekId:   weekId,
+		Lines:    lines,
+		Pairings: []*model.LineupPairing{},
+	}
+
+	existing, err := database.GetAllWhere[*model.Lineup](ctx, db, func(_ context.Context, l *model.Lineup) bool {
+		return l.TeamId == teamId && l.WeekId == weekId
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(existing) == 0 {
+		return detail, nil
+	}
+	lineup := existing[0]
+	detail.Lineup = lineup
+
+	pairings, err := database.GetAllWhere[*model.LineupPairing](ctx, db, func(_ context.Context, p *model.LineupPairing) bool {
+		return p.LineupId == lineup.ID
+	})
+	if err != nil {
+		return nil, err
+	}
+	detail.Pairings = pairings
+	return detail, nil
+}
+
+// LineupDetail is the wire representation of a team's weekly lineup, including
+// the format lines the captain must fill and the pairings already assigned.
+type LineupDetail struct {
+	TeamId   model.TeamId            `json:"team_id"`
+	WeekId   model.WeekId            `json:"week_id"`
+	Lineup   *model.Lineup           `json:"lineup"`
+	Lines    []model.FormatLine      `json:"lines"`
+	Pairings []*model.LineupPairing  `json:"pairings"`
+}
+
+// LineupQuery holds the query parameters for GetLineupDetail.
+type LineupQuery struct {
+	TeamId model.TeamId `json:"team_id"`
+	WeekId model.WeekId `json:"week_id"`
+}
+
+// StaticallyValid ensures both a team and a week are specified.
+func (q *LineupQuery) StaticallyValid() error {
+	if q.TeamId.RecordId() == database.InvalidRecordId {
+		return errors.New("team_id must be set")
+	}
+	if q.WeekId.RecordId() == database.InvalidRecordId {
+		return errors.New("week_id must be set")
+	}
+	return nil
+}
+
+// GetLineupDetail returns the LineupDetail for a team + week. It is viewable by
+// everyone (team members and commissioners alike).
+type GetLineupDetail struct{}
+
+func (c GetLineupDetail) Path() (api.HttpMethod, string) {
+	return api.HttpMethodGet, BaseRoute + "/detail"
+}
+
+func (c GetLineupDetail) RequestBody() (*LineupQuery, bool) {
+	return &LineupQuery{}, false
+}
+
+func (c GetLineupDetail) Handler(req api.Request[*LineupQuery]) (any, int, error) {
+	query := req.HTTPRequest().URL.Query()
+
+	var teamId model.TeamId
+	var weekId model.WeekId
+
+	if teamStr := query.Get("team_id"); teamStr != "" {
+		rid, err := database.RecordIdFromString(teamStr)
+		if err != nil {
+			return nil, http.StatusBadRequest, err
+		}
+		teamId = model.TeamId(rid)
+	}
+	if weekStr := query.Get("week_id"); weekStr != "" {
+		rid, err := database.RecordIdFromString(weekStr)
+		if err != nil {
+			return nil, http.StatusBadRequest, err
+		}
+		weekId = model.WeekId(rid)
+	}
+
+	if teamId.RecordId() == database.InvalidRecordId {
+		return nil, http.StatusBadRequest, errors.New("team_id must be set")
+	}
+	if weekId.RecordId() == database.InvalidRecordId {
+		return nil, http.StatusBadRequest, errors.New("week_id must be set")
+	}
+
+	detail, err := lineupDetailForTeamWeek(req.Context, req.DatabaseProvider, teamId, weekId)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	return gin.H{api.ResourceKey: detail}, http.StatusOK, nil
+}
+
+// PairingInput is a single format-line assignment in a SetLineup request.
+type PairingInput struct {
+	Player1         database.UserId `json:"player1"`
+	Player2         database.UserId `json:"player2"`
+	FormatLineIndex int             `json:"format_line_index"`
+}
+
+// SetLineupBody is the request body for SetLineup.
+type SetLineupBody struct {
+	TeamId   model.TeamId     `json:"team_id"`
+	WeekId   model.WeekId     `json:"week_id"`
+	Pairings []PairingInput   `json:"pairings"`
+}
+
+// StaticallyValid ensures both a team and a week are specified.
+func (b *SetLineupBody) StaticallyValid() error {
+	if b.TeamId.RecordId() == database.InvalidRecordId {
+		return errors.New("team_id must be set")
+	}
+	if b.WeekId.RecordId() == database.InvalidRecordId {
+		return errors.New("week_id must be set")
+	}
+	return nil
+}
+
+// SetLineup creates (or updates) a team's weekly lineup and replaces its
+// pairings. Only the team's captain/co-captains may build a lineup. Each
+// pairing is validated against team membership and format ratings by the model.
+type SetLineup struct{}
+
+func (c SetLineup) Path() (api.HttpMethod, string) {
+	return api.HttpMethodPost, BaseRoute + "/set"
+}
+
+func (c SetLineup) RequestBody() (*SetLineupBody, bool) {
+	return &SetLineupBody{}, true
+}
+
+func (c SetLineup) Handler(req api.Request[*SetLineupBody]) (any, int, error) {
+	if req.Token == nil {
+		return nil, http.StatusUnauthorized, errors.New("token is required")
+	}
+	if !canEditTeamLineup(req.Context, req.DatabaseProvider, req.Token.UserId, req.Body.TeamId) {
+		return nil, http.StatusForbidden, errors.New("only a team captain or co-captain may build the lineup")
+	}
+
+	// Find (or create) the Lineup for this team + week.
+	var lineup *model.Lineup
+	existing, err := database.GetAllWhere[*model.Lineup](req.Context, req.DatabaseProvider, func(_ context.Context, l *model.Lineup) bool {
+		return l.TeamId == req.Body.TeamId && l.WeekId == req.Body.WeekId
+	})
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	if len(existing) > 0 {
+		lineup = existing[0]
+	} else {
+		lineup = model.NewLineup()
+		lineup.TeamId = req.Body.TeamId
+		lineup.WeekId = req.Body.WeekId
+		lineup, err = database.CreateOne(req.Context, req.DatabaseProvider, lineup)
+		if err != nil {
+			return nil, http.StatusBadRequest, err
+		}
+	}
+
+	// Replace the lineup's pairings. Deleting the existing rows first means an
+	// empty set clears the lineup; creating fresh rows re-validates each one.
+	oldPairings, err := database.GetAllWhere[*model.LineupPairing](req.Context, req.DatabaseProvider, func(_ context.Context, p *model.LineupPairing) bool {
+		return p.LineupId == lineup.ID
+	})
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	for _, p := range oldPairings {
+		if _, _, err := database.DeleteOneById(req.Context, req.DatabaseProvider, p, p.ID.RecordId()); err != nil {
+			return nil, http.StatusBadRequest, err
+		}
+	}
+
+	for _, in := range req.Body.Pairings {
+		pairing := model.NewLineupPairing()
+		pairing.LineupId = lineup.ID
+		pairing.TeamId = req.Body.TeamId
+		pairing.Player1 = in.Player1
+		pairing.Player2 = in.Player2
+		pairing.FormatLineIndex = in.FormatLineIndex
+		if _, err := database.CreateOne(req.Context, req.DatabaseProvider, pairing); err != nil {
+			return nil, http.StatusBadRequest, err
+		}
+	}
+
+	detail, err := lineupDetailForTeamWeek(req.Context, req.DatabaseProvider, req.Body.TeamId, req.Body.WeekId)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	return gin.H{api.ResourceKey: detail}, http.StatusOK, nil
+}
+
+// ConfirmLineup marks a lineup as confirmed by the team's captain/co-captains,
+// which is required before the commissioner can mark it official.
+type ConfirmLineup struct{}
+
+func (c ConfirmLineup) Path() (api.HttpMethod, string) {
+	return api.HttpMethodPost, api.AppendPathId(BaseRoute) + "/confirm"
+}
+
+func (c ConfirmLineup) RequestBody() (*EmptyBody, bool) {
+	return &EmptyBody{}, false
+}
+
+func (c ConfirmLineup) Handler(req api.Request[*EmptyBody]) (any, int, error) {
+	if req.Token == nil {
+		return nil, http.StatusUnauthorized, errors.New("token is required")
+	}
+	lineup, err := database.GetExistingRecordById(req.Context, req.DatabaseProvider, &model.Lineup{}, req.PathId)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	if !canEditTeamLineup(req.Context, req.DatabaseProvider, req.Token.UserId, lineup.TeamId) {
+		return nil, http.StatusForbidden, errors.New("only a team captain or co-captain may confirm the lineup")
+	}
+	lineup.Confirmed = true
+	if err := database.UpdateOne(req.Context, req.DatabaseProvider, lineup); err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	return gin.H{api.ResourceKey: lineup}, http.StatusOK, nil
+}
+
+// MarkOfficial marks a confirmed lineup as official. Only a season
+// commissioner may do this, and the lineup must first be confirmed.
+type MarkOfficial struct{}
+
+func (c MarkOfficial) Path() (api.HttpMethod, string) {
+	return api.HttpMethodPost, api.AppendPathId(BaseRoute) + "/official"
+}
+
+func (c MarkOfficial) RequestBody() (*EmptyBody, bool) {
+	return &EmptyBody{}, false
+}
+
+func (c MarkOfficial) Handler(req api.Request[*EmptyBody]) (any, int, error) {
+	if req.Token == nil {
+		return nil, http.StatusUnauthorized, errors.New("token is required")
+	}
+	lineup, err := database.GetExistingRecordById(req.Context, req.DatabaseProvider, &model.Lineup{}, req.PathId)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	if !lineup.Confirmed {
+		return nil, http.StatusBadRequest, errors.New("lineup must be confirmed before it can be marked official")
+	}
+
+	week, err := database.GetExistingRecordById(req.Context, req.DatabaseProvider, &model.Week{}, lineup.WeekId.RecordId())
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	draft, err := database.GetExistingRecordById(req.Context, req.DatabaseProvider, &model.Draft{}, week.DraftId.RecordId())
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	season, err := draft.GetSeason(req.Context, req.DatabaseProvider)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	if !isSeasonCommissioner(req.Context, req.DatabaseProvider, req.Token.UserId, season.ID) {
+		return nil, http.StatusForbidden, errors.New("only a season commissioner may mark the lineup official")
+	}
+
+	lineup.Official = true
+	if err := database.UpdateOne(req.Context, req.DatabaseProvider, lineup); err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	return gin.H{api.ResourceKey: lineup}, http.StatusOK, nil
+}
+
+// EmptyBody is a placeholder request body for routes that take no body.
+type EmptyBody struct{}
+
+// StaticallyValid has no static constraints.
+func (b *EmptyBody) StaticallyValid() error { return nil }

--- a/route/lineup/lineup_test.go
+++ b/route/lineup/lineup_test.go
@@ -1,0 +1,340 @@
+package lineup
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/rand/v2"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"intraclub/api"
+	"intraclub/database"
+	"intraclub/model"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// test setup helpers (mirror route/availability)
+// ---------------------------------------------------------------------------
+
+func newStoredUser(t *testing.T, db database.Provider) *model.User {
+	t.Helper()
+	user := model.NewUser()
+	user.Email = model.EmailAddress(fmt.Sprintf("user%d@email.com", rand.Uint64()))
+	user.FirstName = fmt.Sprintf("Test %d", rand.Uint64())
+	user.LastName = "User"
+	user.PhoneNumber = model.PhoneNumber(fmt.Sprintf("%d", 100_000_0000+rand.Uint32N(999_999_999)))
+	v, err := database.CreateOne(context.Background(), db, user)
+	require.NoError(t, err)
+	return v
+}
+
+// lineupFixture builds the chain required to build a lineup: a season (with a
+// commissioner and a draft) whose format has a single line (rating1 / rating2),
+// a team whose captain carries rating1 and whose member carries rating2, and a
+// single week. This mirrors how a real drafted team ends up with rated members.
+type lineupFixture struct {
+	season       *model.Season
+	week         *model.Week
+	team         *model.Team
+	line         model.FormatLine
+	captain      database.UserId
+	member       database.UserId
+	commissioner database.UserId
+	outsider     database.UserId
+}
+
+func newLineupFixture(t *testing.T, db database.Provider) *lineupFixture {
+	t.Helper()
+	ctx := context.Background()
+
+	commissioner := newStoredUser(t, db)
+
+	// A format with a single line (rating1 / rating2).
+	rating1 := newStoredRating(t, db, commissioner.ID)
+	rating2 := newStoredRating(t, db, commissioner.ID)
+	format := model.NewFormat()
+	format.UserId = commissioner.ID
+	format.Name = fmt.Sprintf("format %d", rand.Uint64())
+	formatV, err := database.CreateOne(ctx, db, format)
+	require.NoError(t, err)
+	line := model.FormatLine{Player1Rating: rating1, Player2Rating: rating2}
+	require.NoError(t, formatV.SetPossibleRatings(ctx, db, model.RatingList{rating1, rating2}))
+	require.NoError(t, formatV.SetLines(ctx, db, []model.FormatLine{line}))
+
+	draft := model.NewDraft()
+	draft.Owner = commissioner.ID
+	draft.Format = formatV.ID
+	draftV, err := database.CreateOne(ctx, db, draft)
+	require.NoError(t, err)
+
+	facility := model.NewFacility()
+	facility.UserId = commissioner.ID
+	facility.Name = "Test facility"
+	facility.Address = "Test Rd."
+	facility.NumberOfCourts = 2
+	facilityV, err := database.CreateOne(ctx, db, facility)
+	require.NoError(t, err)
+
+	season := model.NewSeason()
+	season.Name = "Test Season"
+	season.StartTime = model.NewStartTime(8, 30)
+	season.DraftId = draftV.ID
+	season.Facility = facilityV.ID
+	seasonV, err := database.CreateOne(ctx, db, season)
+	require.NoError(t, err)
+	require.NoError(t, seasonV.AddCommissioner(ctx, db, commissioner.ID))
+
+	captain := newStoredUser(t, db)
+	member := newStoredUser(t, db)
+	outsider := newStoredUser(t, db)
+	team := model.NewDefaultTeam(captain.ID, "Team A")
+	teamV, err := database.CreateOne(ctx, db, team)
+	require.NoError(t, err)
+	require.NoError(t, seasonV.AddTeam(ctx, db, teamV.ID))
+	addAssignment(t, db, teamV, member, model.TeamRoleMember)
+
+	// Assign the line's required ratings to the captain and member.
+	_, err = database.CreateOne(ctx, db, &model.TeamRating{TeamId: teamV.ID, UserId: captain.ID, RatingId: rating1})
+	require.NoError(t, err)
+	_, err = database.CreateOne(ctx, db, &model.TeamRating{TeamId: teamV.ID, UserId: member.ID, RatingId: rating2})
+	require.NoError(t, err)
+
+	week := model.NewWeek()
+	week.DraftId = draftV.ID
+	week.Date = time.Date(2025, 3, 1, 8, 0, 0, 0, time.UTC)
+	week.Note = "week 1"
+	weekV, err := database.CreateOne(ctx, db, week)
+	require.NoError(t, err)
+
+	return &lineupFixture{
+		season:       seasonV,
+		week:         weekV,
+		team:         teamV,
+		line:         line,
+		captain:      captain.ID,
+		member:       member.ID,
+		commissioner: commissioner.ID,
+		outsider:     outsider.ID,
+	}
+}
+
+func newStoredRating(t *testing.T, db database.Provider, owner database.UserId) model.RatingId {
+	t.Helper()
+	r := model.NewRating()
+	r.UserId = owner
+	r.Name = fmt.Sprintf("rating %d", rand.Uint64())
+	r.Description = "test rating"
+	v, err := database.CreateOne(context.Background(), db, r)
+	require.NoError(t, err)
+	return v.ID
+}
+
+func addAssignment(t *testing.T, db database.Provider, team *model.Team, user *model.User, role model.TeamRole) {
+	t.Helper()
+	_, err := database.CreateOne(context.Background(), db, &model.TeamAssignment{TeamId: team.ID, UserId: user.ID, Role: role})
+	require.NoError(t, err)
+}
+
+func newTestRouter(t *testing.T, db database.Provider) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	api.UserType = &model.User{}
+	database.SysAdminCheck = model.IsUserSystemAdministrator
+
+	router := gin.New()
+	group := router.Group("/api")
+	RegisterRoutes(group, db)
+	return router
+}
+
+var (
+	lineupKeyOnce sync.Once
+	lineupPubKey  *ecdsa.PublicKey
+	lineupPrivKey *ecdsa.PrivateKey
+)
+
+func newToken(t *testing.T, userId database.UserId) string {
+	t.Helper()
+	lineupKeyOnce.Do(func() {
+		pub, priv, err := api.GenerateKeyPair()
+		require.NoError(t, err)
+		lineupPubKey = pub
+		lineupPrivKey = priv
+	})
+	api.JwtPublicKey = lineupPubKey
+	api.JwtPrivateKey = lineupPrivKey
+	token, err := api.GenerateToken(userId.RecordId())
+	require.NoError(t, err)
+	return token
+}
+
+func doJSON(t *testing.T, router *gin.Engine, method, path string, body any, token string) *httptest.ResponseRecorder {
+	t.Helper()
+	var reader io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		require.NoError(t, err)
+		reader = bytes.NewReader(b)
+	}
+	req, err := http.NewRequest(method, path, reader)
+	require.NoError(t, err)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if token != "" {
+		req.Header.Set(api.AuthTokenHeaderValue, token)
+	}
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+// ---------------------------------------------------------------------------
+// tests
+// ---------------------------------------------------------------------------
+
+func TestSetLineupAsCaptain(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	fx := newLineupFixture(t, db)
+
+	// A non-captain (regular member) cannot build the lineup.
+	w := doJSON(t, router, http.MethodPost, "/api/lineup/set",
+		map[string]any{
+			"team_id": fx.team.ID.String(),
+			"week_id": fx.week.ID.String(),
+			"pairings": []map[string]any{{
+				"player1": fx.captain.String(),
+				"player2": fx.member.String(),
+				"format_line_index": 0,
+			}},
+		}, newToken(t, fx.member))
+	require.Equal(t, http.StatusForbidden, w.Code, "member set: %s", w.Body.String())
+
+	// The captain builds the lineup with one valid pairing.
+	w = doJSON(t, router, http.MethodPost, "/api/lineup/set",
+		map[string]any{
+			"team_id": fx.team.ID.String(),
+			"week_id": fx.week.ID.String(),
+			"pairings": []map[string]any{{
+				"player1": fx.captain.String(),
+				"player2": fx.member.String(),
+				"format_line_index": 0,
+			}},
+		}, newToken(t, fx.captain))
+	require.Equal(t, http.StatusOK, w.Code, "captain set: %s", w.Body.String())
+
+	var created struct {
+		Resource *LineupDetail `json:"resource"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &created))
+	require.NotNil(t, created.Resource)
+	require.NotNil(t, created.Resource.Lineup)
+	require.Equal(t, fx.team.ID, created.Resource.TeamId)
+	require.Equal(t, fx.week.ID, created.Resource.WeekId)
+	require.False(t, created.Resource.Lineup.Confirmed)
+	require.Len(t, created.Resource.Pairings, 1)
+	require.Equal(t, fx.captain, created.Resource.Pairings[0].Player1)
+	require.Equal(t, fx.member, created.Resource.Pairings[0].Player2)
+	require.Equal(t, 0, created.Resource.Pairings[0].FormatLineIndex)
+
+	lineupID := created.Resource.Lineup.ID
+	lineupIDStr := lineupID.String()
+
+	// Confirm as the captain.
+	w = doJSON(t, router, http.MethodPost, "/api/lineup/"+lineupIDStr+"/confirm", nil, newToken(t, fx.captain))
+	require.Equal(t, http.StatusOK, w.Code, "confirm: %s", w.Body.String())
+	var confirmed struct {
+		Resource *model.Lineup `json:"resource"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &confirmed))
+	require.True(t, confirmed.Resource.Confirmed)
+	require.False(t, confirmed.Resource.Official)
+
+	// A non-commissioner (the captain) cannot mark the lineup official.
+	w = doJSON(t, router, http.MethodPost, "/api/lineup/"+lineupIDStr+"/official", nil, newToken(t, fx.captain))
+	require.Equal(t, http.StatusForbidden, w.Code, "captain official: %s", w.Body.String())
+
+	// The commissioner marks the confirmed lineup official.
+	w = doJSON(t, router, http.MethodPost, "/api/lineup/"+lineupIDStr+"/official", nil, newToken(t, fx.commissioner))
+	require.Equal(t, http.StatusOK, w.Code, "official: %s", w.Body.String())
+	var official struct {
+		Resource *model.Lineup `json:"resource"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &official))
+	require.True(t, official.Resource.Confirmed)
+	require.True(t, official.Resource.Official)
+
+	// GetLineupDetail reflects the saved state.
+	w = doJSON(t, router, http.MethodGet,
+		"/api/lineup/detail?team_id="+fx.team.ID.String()+"&week_id="+fx.week.ID.String(),
+		nil, newToken(t, fx.member))
+	require.Equal(t, http.StatusOK, w.Code, "detail: %s", w.Body.String())
+	var detail struct {
+		Resource *LineupDetail `json:"resource"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &detail))
+	require.Len(t, detail.Resource.Lines, 1)
+	require.Len(t, detail.Resource.Pairings, 1)
+	require.True(t, detail.Resource.Lineup.Official)
+}
+
+func TestSetLineupRejectsMismatchedRatings(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	fx := newLineupFixture(t, db)
+
+	// Swap the players so neither matches the line's required ratings.
+	w := doJSON(t, router, http.MethodPost, "/api/lineup/set",
+		map[string]any{
+			"team_id": fx.team.ID.String(),
+			"week_id": fx.week.ID.String(),
+			"pairings": []map[string]any{{
+				"player1": fx.member.String(),
+				"player2": fx.captain.String(),
+				"format_line_index": 0,
+			}},
+		}, newToken(t, fx.captain))
+	require.Equal(t, http.StatusBadRequest, w.Code, "mismatch: %s", w.Body.String())
+}
+
+func TestConfirmRequiresCaptain(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	fx := newLineupFixture(t, db)
+
+	// Build a lineup as the captain.
+	w := doJSON(t, router, http.MethodPost, "/api/lineup/set",
+		map[string]any{
+			"team_id": fx.team.ID.String(),
+			"week_id": fx.week.ID.String(),
+			"pairings": []map[string]any{{
+				"player1": fx.captain.String(),
+				"player2": fx.member.String(),
+				"format_line_index": 0,
+			}},
+		}, newToken(t, fx.captain))
+	require.Equal(t, http.StatusOK, w.Code, "set: %s", w.Body.String())
+	var created struct {
+		Resource *LineupDetail `json:"resource"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &created))
+
+	// An outsider (not on the team) cannot confirm.
+	w = doJSON(t, router, http.MethodPost, "/api/lineup/"+created.Resource.Lineup.ID.String()+"/confirm", nil, newToken(t, fx.outsider))
+	require.Equal(t, http.StatusForbidden, w.Code, "outsider confirm: %s", w.Body.String())
+
+	// A non-confirmed lineup cannot be marked official by the commissioner.
+	w = doJSON(t, router, http.MethodPost, "/api/lineup/"+created.Resource.Lineup.ID.String()+"/official", nil, newToken(t, fx.commissioner))
+	require.Equal(t, http.StatusBadRequest, w.Code, "official before confirm: %s", w.Body.String())
+}

--- a/route/lineup/routes.go
+++ b/route/lineup/routes.go
@@ -1,0 +1,41 @@
+package lineup
+
+import (
+	"intraclub/api"
+	"intraclub/database"
+	"intraclub/model"
+
+	"github.com/gin-gonic/gin"
+)
+
+// RegisterRoutes wires up the Lineup and LineupPairing REST surface.
+//
+// Generic CRUD is registered for both models: the models enforce that only a
+// team's captain/co-captains can create/update/delete their lineup and its
+// pairings (via EditableBy), and that pairings validate team membership and
+// format ratings (via DynamicallyValid). Custom routes add the
+// builder/confirm/official flow the season page uses:
+//
+//	GET  /lineup/detail?team_id=&week_id=   -> LineupDetail (lines, pairings)
+//	POST /lineup/set                        -> build/replace a weekly lineup
+//	POST /lineup/:id/confirm                -> captain confirms the lineup
+//	POST /lineup/:id/official               -> commissioner marks it official
+func RegisterRoutes(e *gin.RouterGroup, db database.Provider) {
+	lineups := api.NewCrudCommon(model.NewLineup, false, db)
+	lineups.HandleRouteTypes(e, api.CrudWrapperFunctionAll...)
+
+	pairings := api.NewCrudCommon(model.NewLineupPairing, false, db)
+	pairings.HandleRouteTypes(e, api.CrudWrapperFunctionAll...)
+
+	detail := api.RouteFamily[*LineupQuery]{DatabaseProvider: db}
+	detail.Handle(e, GetLineupDetail{})
+
+	set := api.RouteFamily[*SetLineupBody]{DatabaseProvider: db}
+	set.Handle(e, SetLineup{})
+
+	confirm := api.RouteFamily[*EmptyBody]{DatabaseProvider: db}
+	confirm.Handle(e, ConfirmLineup{})
+
+	official := api.RouteFamily[*EmptyBody]{DatabaseProvider: db}
+	official.Handle(e, MarkOfficial{})
+}

--- a/ui/e2e/lineup.spec.ts
+++ b/ui/e2e/lineup.spec.ts
@@ -1,0 +1,199 @@
+import { expect, test, type Page } from '@playwright/test';
+import { waitForHydration } from './helpers';
+
+const API = 'http://127.0.0.1:8080/api';
+
+// Log in through the UI (dev mode returns the magic-link token in the
+// one_time_password response, rendered as a clickable link on the login page).
+async function login(page: Page, email: string) {
+	await page.goto('/login');
+	await page.waitForLoadState('networkidle');
+	await page.getByLabel('Email').fill(email);
+	await page.getByRole('button', { name: 'Send login link' }).click();
+	const link = page.getByRole('main').getByRole('link', { name: 'Log in' });
+	await expect(link).toBeVisible();
+	await link.click();
+	await expect(page).toHaveURL('/');
+}
+
+test('captain builds a weekly lineup, confirms it, and the commissioner marks it official', async ({
+	page
+}) => {
+	await login(page, 'jdarthur@gatech.edu');
+	const token = await page.evaluate(() => localStorage.getItem('intraclub_jwt') ?? '');
+	expect(token).toBeTruthy();
+
+	const unique = Date.now();
+
+	// Two captains + four roster players (two per team) is enough to field a
+	// rated pairing on each team: team A ends up with a Men's 1 player and a
+	// Men's 2 player, which exactly matches format line index 1.
+	const people = [
+		{ first: `CapA${unique}`, last: 'One' },
+		{ first: `CapB${unique}`, last: 'Two' },
+		{ first: `PlayA${unique}`, last: 'One' },
+		{ first: `PlayB${unique}`, last: 'Two' },
+		{ first: `PlayC${unique}`, last: 'Three' },
+		{ first: `PlayD${unique}`, last: 'Four' }
+	];
+	const csv = [
+		'First Name, Last Name, Email',
+		...people.map((p) => `${p.first}, ${p.last}, ${p.first.toLowerCase()}@example.com`)
+	].join('\n');
+	const importRes = await page.request.post(`${API}/import_users_from_csv`, {
+		form: { file: csv }
+	});
+	expect(importRes.ok()).toBeTruthy();
+	const importBody = await importRes.json();
+	const imported = [...importBody.Created, ...importBody.AlreadyExisting] as {
+		id: string;
+		email: string;
+	}[];
+	const idFor = (email: string) => imported.find((u) => u.email === email)!.id;
+	const captainAId = idFor(`${people[0].first.toLowerCase()}@example.com`);
+	const captainBId = idFor(`${people[1].first.toLowerCase()}@example.com`);
+	const playerAId = idFor(`${people[2].first.toLowerCase()}@example.com`);
+	const playerBId = idFor(`${people[3].first.toLowerCase()}@example.com`);
+	const playerCId = idFor(`${people[4].first.toLowerCase()}@example.com`);
+	const playerDId = idFor(`${people[5].first.toLowerCase()}@example.com`);
+	const captainAEmail = `${people[0].first.toLowerCase()}@example.com`;
+
+	const facilityRes = await page.request.post(`${API}/facility`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { name: `Lineup Facility ${unique}`, address: `${unique} Main St`, courts: 4 }
+	});
+	expect(facilityRes.ok()).toBeTruthy();
+	const facilityId = (await facilityRes.json()).resource.id as string;
+
+	const formats = (await (await page.request.get(`${API}/format`)).json()).resource as {
+		id: string;
+		name: string;
+	}[];
+	const format = formats.find((f) => f.name === "Men's Intraclub");
+	expect(format).toBeTruthy();
+
+	const draftRes = await page.request.post(`${API}/draft`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { name: `Lineup Draft ${unique}`, format: format!.id }
+	});
+	expect(draftRes.ok()).toBeTruthy();
+	const draftId = (await draftRes.json()).resource.id as string;
+
+	const initRes = await page.request.post(`${API}/draft/${draftId}/initialize`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { captains: [captainAId, captainBId] }
+	});
+	expect(initRes.ok(), `initialize failed: ${await initRes.text()}`).toBeTruthy();
+	await page.request.post(`${API}/draft/${draftId}/assign_draftable_players`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { players: [playerAId, playerBId, playerCId, playerDId] }
+	});
+
+	const ratings = (
+		await (
+			await page.request.get(`${API}/format/${format!.id}/possible_ratings`, {
+				headers: { 'X-INTRACLUB-TOKEN': token }
+			})
+		).json()
+	).resource as { id: string }[];
+	expect(ratings.length).toBeGreaterThanOrEqual(2);
+	await page.request.post(`${API}/draft/${draftId}/assign_rating_cutoff`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { rating: ratings[0].id, cutoff: 1 }
+	});
+	await page.request.post(`${API}/draft/${draftId}/assign_rating_cutoff`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { rating: ratings[1].id, cutoff: 5 }
+	});
+
+	const tokenFor = async (email: string) => {
+		const res = await page.request.post(`${API}/one_time_password`, { data: { email } });
+		expect(res.ok()).toBeTruthy();
+		const { token: otp } = await res.json();
+		const jwtRes = await page.request.post(`${API}/token`, { data: { token: otp } });
+		expect(jwtRes.ok()).toBeTruthy();
+		return (await jwtRes.json()).jwt as string;
+	};
+	const captainAToken = await tokenFor(captainAEmail);
+	const captainBToken = await tokenFor(`${people[1].first.toLowerCase()}@example.com`);
+
+	// Complete the draft: A, B, B, A, A, B snake order. Team A gets picks 1, 4
+	// and 5 (playerA with Men's 1, playerD with Men's 2, and the captain), so the
+	// two rated non-captains on team A match format line index 1.
+	const pickPlan = [
+		{ player: playerAId, token: captainAToken },
+		{ player: playerBId, token: captainBToken },
+		{ player: playerCId, token: captainBToken },
+		{ player: playerDId, token: captainAToken },
+		{ player: captainAId, token: captainAToken },
+		{ player: captainBId, token: captainBToken }
+	];
+	for (const { player, token: pickToken } of pickPlan) {
+		const res = await page.request.post(`${API}/draft/${draftId}/select`, {
+			headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': pickToken },
+			data: { player_id: player }
+		});
+		expect(res.ok(), `pick failed: ${await res.text()}`).toBeTruthy();
+	}
+
+	// Finalize the draft so drafted players get team_rating rows with their
+	// assigned ratings (the captain is pre-assigned and appears via draft_captain).
+	const assignRes = await page.request.post(`${API}/draft/${draftId}/assign_drafted_players_to_teams`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token }
+	});
+	expect(assignRes.ok(), `assign failed: ${await assignRes.text()}`).toBeTruthy();
+
+	const seasonName = `Lineup ${unique}`;
+	const seasonRes = await page.request.post(`${API}/draft/${draftId}/create_season`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { name: seasonName, facility: facilityId, start_time: '08:30' }
+	});
+	expect(seasonRes.ok()).toBeTruthy();
+	const season = (await seasonRes.json()).resource as { id: string };
+
+	const weekRes = await page.request.post(`${API}/week`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { draft_id: draftId, date: '2026-01-05T08:00:00Z', note: 'Week 1' }
+	});
+	expect(weekRes.ok()).toBeTruthy();
+	const week = (await weekRes.json()).resource as { id: string };
+
+	// --- log in as the team captain and build a lineup ---
+	await login(page, captainAEmail);
+	await page.goto(`/seasons/${season.id}`);
+	await waitForHydration(page);
+	await expect(page.getByRole('heading', { name: seasonName })).toBeVisible();
+
+	const lineupCard = page.getByText('Weekly lineups', { exact: true });
+	await expect(lineupCard).toBeVisible();
+
+	// Build the captain's team's lineup for Week 1.
+	await page.getByRole('button', { name: 'Build' }).click();
+
+	// Team A's rated non-captains are playerA (Men's 1) and playerD (Men's 2),
+	// which match format line index 1 (Men's 1 / Men's 2).
+	const playerALabel = `${people[2].first} ${people[2].last}`;
+	const playerDLabel = `${people[5].first} ${people[5].last}`;
+	await page.locator(`[id="${week.id}-lineup-p1-1"]`).selectOption({ label: playerALabel });
+	await page.locator(`[id="${week.id}-lineup-p2-1"]`).selectOption({ label: playerDLabel });
+
+	await page.getByRole('button', { name: 'Save' }).click();
+	await page.getByRole('button', { name: 'Confirm' }).click();
+	await expect(page.getByText('Confirmed', { exact: true })).toBeVisible();
+
+	// --- log in as the commissioner and mark the lineup official ---
+	await login(page, 'jdarthur@gatech.edu');
+	await page.goto(`/seasons/${season.id}`);
+	await waitForHydration(page);
+
+	// The confirmed lineup for Team A shows a "Mark official" button.
+	await page.getByRole('button', { name: 'Mark official' }).first().click();
+	// Once marked official, the button disappears (no more confirmed lineups).
+	await expect(page.getByRole('button', { name: 'Mark official' })).toHaveCount(0);
+
+	// Clean up the draft so the table doesn't accumulate rows across runs.
+	const cleanup = await page.request.delete(`${API}/draft/${draftId}`, {
+		headers: { 'X-INTRACLUB-TOKEN': token }
+	});
+	expect(cleanup.ok()).toBeTruthy();
+});

--- a/ui/src/lib/lineup.ts
+++ b/ui/src/lib/lineup.ts
@@ -1,0 +1,104 @@
+// Lineup API client. Weekly lineups are exposed via the REST surface
+// registered in route/lineup (see main.go):
+//
+//	GET  /api/lineup/detail?team_id=&week_id=  -> { resource: LineupDetail }
+//	POST /api/lineup/set                       body: { team_id, week_id, pairings }
+//	POST /api/lineup/:id/confirm               -> mark lineup confirmed (captain)
+//	POST /api/lineup/:id/official              -> mark lineup official (commissioner)
+//
+// Generic CRUD is also available at /api/lineup and /api/lineup_pairing. A
+// lineup is built by a team's captain/co-captain, confirmed, and then marked
+// official by the season commissioner. Record IDs are 16-char hex strings.
+import { authFetch } from '$lib/auth';
+
+export interface Lineup {
+	id: string;
+	team_id: string;
+	week_id: string;
+	confirmed: boolean;
+	official: boolean;
+}
+
+export interface LineupPairing {
+	id: string;
+	lineup_id: string;
+	team_id: string;
+	player1: string;
+	player2: string;
+	format_line_index: number;
+}
+
+export interface FormatLine {
+	id: string;
+	format_id: string;
+	player_1_rating: string;
+	player_2_rating: string;
+	format_index: number;
+}
+
+export interface LineupDetail {
+	team_id: string;
+	week_id: string;
+	lineup: Lineup | null;
+	lines: FormatLine[];
+	pairings: LineupPairing[];
+}
+
+export interface PairingInput {
+	player1: string;
+	player2: string;
+	format_line_index: number;
+}
+
+const BASE = '/api/lineup';
+
+async function unwrap(res: Response): Promise<any> {
+	if (!res.ok) {
+		let message = `Request failed (${res.status})`;
+		try {
+			const body = await res.json();
+			if (body?.error) message = body.error;
+		} catch {
+			// non-JSON error body; fall back to the status message
+		}
+		throw new Error(message);
+	}
+	const body = await res.json();
+	return body?.resource;
+}
+
+export async function getLineupDetail(teamId: string, weekId: string): Promise<LineupDetail> {
+	return unwrap(await authFetch(`${BASE}/detail?team_id=${teamId}&week_id=${weekId}`));
+}
+
+export async function setLineup(
+	teamId: string,
+	weekId: string,
+	pairings: PairingInput[]
+): Promise<LineupDetail> {
+	return unwrap(
+		await authFetch(`${BASE}/set`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ team_id: teamId, week_id: weekId, pairings })
+		})
+	);
+}
+
+export async function confirmLineup(lineupId: string): Promise<Lineup> {
+	return unwrap(
+		await authFetch(`${BASE}/${lineupId}/confirm`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' }
+		})
+	);
+}
+
+export async function markOfficial(lineupId: string): Promise<Lineup> {
+	return unwrap(
+		await authFetch(`${BASE}/${lineupId}/official`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' }
+		})
+	);
+}

--- a/ui/src/routes/seasons/[id]/+page.svelte
+++ b/ui/src/routes/seasons/[id]/+page.svelte
@@ -30,6 +30,13 @@
 		assignWeeklyMatchup
 	} from '$lib/schedule';
 	import type { ScheduleDetail, WeeklyMatchup } from '$lib/schedule';
+	import {
+		getLineupDetail,
+		setLineup,
+		confirmLineup,
+		markOfficial
+	} from '$lib/lineup';
+	import type { LineupDetail, PairingInput } from '$lib/lineup';
 	import { Badge } from '$lib/components/ui/badge/index.js';
 	import {
 		Card,
@@ -63,6 +70,13 @@
 	let teamAvailability = $state<Record<string, Record<string, AvailabilityOption>>>({});
 	let availabilityError = $state('');
 	let savingWeek = $state<string | null>(null);
+
+	// weekly lineup state
+	let lineupDetails = $state<Record<string, Record<string, LineupDetail>>>({});
+	let lineupDrafts = $state<Record<string, PairingInput[]>>({});
+	let editingLineupWeek = $state<string | null>(null);
+	let lineupError = $state('');
+	let savingLineup = $state(false);
 
 	let loading = $state(true);
 	let loadError = $state('');
@@ -121,6 +135,7 @@
 			scheduleDetail = scheduleData;
 			rosters = rosterList;
 			await loadAvailability();
+			await loadLineups();
 		} catch (e) {
 			loadError = e instanceof Error ? e.message : 'Failed to load season';
 		} finally {
@@ -262,6 +277,95 @@
 			availabilityError = e instanceof Error ? e.message : 'Failed to save availability';
 		} finally {
 			savingWeek = null;
+		}
+	}
+
+	// --- weekly lineup actions -----------------------------------------------
+
+	// loadLineups fetches the LineupDetail for every team x week combination the
+	// current user can act on: their own team (if captain/co-captain) and all
+	// teams (if commissioner, so they can mark lineups official).
+	async function loadLineups() {
+		const teamsToLoad = isCommissioner ? teams : captainTeam ? [captainTeam] : [];
+		const details: Record<string, Record<string, LineupDetail>> = {};
+		for (const team of teamsToLoad) {
+			details[team.teamId] = {};
+			for (const week of weeks) {
+				try {
+					details[team.teamId][week.id] = await getLineupDetail(team.teamId, week.id);
+				} catch {
+					// ignore individual failures; the row just stays empty
+				}
+			}
+		}
+		lineupDetails = details;
+	}
+
+	// members eligible to play a slot in a line, filtered by the required rating.
+	function lineupPlayerOptions(ratingId: string) {
+		return sortedMembers(captainTeam!.members.filter((m) => m.rating_id === ratingId));
+	}
+
+	function setLineupPlayer(weekId: string, idx: number, slot: 'player1' | 'player2', value: string) {
+		lineupDrafts[weekId][idx][slot] = value;
+	}
+
+	// startEditLineup seeds the draft rows from the existing pairings (if any),
+	// one row per format line.
+	function startEditLineup(weekId: string) {
+		const detail = lineupDetails[captainTeam!.teamId]?.[weekId];
+		const pairings = detail?.pairings ?? [];
+		lineupDrafts[weekId] =
+			detail?.lines.map((line, idx) => {
+				const p = pairings.find((x) => x.format_line_index === idx);
+				return {
+					player1: p?.player1 ?? '',
+					player2: p?.player2 ?? '',
+					format_line_index: idx
+				};
+			}) ?? [];
+		editingLineupWeek = weekId;
+		lineupError = '';
+	}
+
+	async function saveLineup(weekId: string) {
+		if (!captainTeam) return;
+		const pairings = (lineupDrafts[weekId] ?? []).filter((p) => p.player1 && p.player2);
+		savingLineup = true;
+		lineupError = '';
+		try {
+			await setLineup(captainTeam.teamId, weekId, pairings);
+			editingLineupWeek = null;
+			await loadLineups();
+		} catch (e) {
+			lineupError = e instanceof Error ? e.message : 'Failed to save lineup';
+		} finally {
+			savingLineup = false;
+		}
+	}
+
+	async function confirmWeekLineup(weekId: string) {
+		if (!captainTeam) return;
+		const detail = lineupDetails[captainTeam.teamId]?.[weekId];
+		if (!detail?.lineup) return;
+		lineupError = '';
+		try {
+			await confirmLineup(detail.lineup.id);
+			await loadLineups();
+		} catch (e) {
+			lineupError = e instanceof Error ? e.message : 'Failed to confirm lineup';
+		}
+	}
+
+	async function markWeekOfficial(teamId: string, weekId: string) {
+		const detail = lineupDetails[teamId]?.[weekId];
+		if (!detail?.lineup) return;
+		lineupError = '';
+		try {
+			await markOfficial(detail.lineup.id);
+			await loadLineups();
+		} catch (e) {
+			lineupError = e instanceof Error ? e.message : 'Failed to mark lineup official';
 		}
 	}
 
@@ -624,6 +728,184 @@
 						</table>
 					</div>
 				</div>
+			{/if}
+		</CardContent>
+	</Card>
+
+	<!-- Weekly lineups -->
+	<Card class="mt-6">
+		<CardHeader>
+			<CardTitle class="text-base">Weekly lineups</CardTitle>
+		</CardHeader>
+		<CardContent>
+			{#if lineupError}
+				<p class="mb-4 text-sm font-medium text-destructive">{lineupError}</p>
+			{/if}
+
+			{#if weeks.length === 0}
+				<p class="text-sm text-muted-foreground">
+					No weeks have been added to this season yet.
+				</p>
+			{:else if isCommissioner}
+				<p class="mb-4 text-sm text-muted-foreground">
+					Mark confirmed lineups official. A lineup must be confirmed by the team captain
+					before it can be marked official.
+				</p>
+				<ul class="flex flex-col gap-4">
+					{#each weeks as week (week.id)}
+						<li class="rounded-lg border p-4">
+							<span class="text-sm font-medium">{weekLabel(week)}</span>
+							<ul class="mt-2 flex flex-col gap-2 text-sm">
+								{#each teams as team}
+									{@const d = lineupDetails[team.teamId]?.[week.id]}
+									<li class="flex items-center justify-between gap-3">
+										<span>
+											{team.name}
+											{#if d?.lineup?.confirmed}
+												<span class="text-xs text-muted-foreground"> — confirmed</span>
+											{/if}
+											{#if d?.lineup?.official}
+												<span class="text-xs text-muted-foreground"> — official</span>
+											{/if}
+										</span>
+										{#if d?.lineup?.confirmed && !d.lineup.official}
+											<Button
+												type="button"
+												size="sm"
+												onclick={() => markWeekOfficial(team.teamId, week.id)}
+											>
+												Mark official
+											</Button>
+										{/if}
+									</li>
+								{/each}
+							</ul>
+						</li>
+					{/each}
+				</ul>
+			{:else if captainTeam}
+				<p class="mb-4 text-sm text-muted-foreground">
+					Build and confirm {captainTeam.name}'s weekly lineup from the team's rated players.
+				</p>
+				<ul class="flex flex-col gap-4">
+					{#each weeks as week (week.id)}
+						{@const detail = lineupDetails[captainTeam.teamId]?.[week.id]}
+						{@const confirmed = detail?.lineup?.confirmed}
+						{@const official = detail?.lineup?.official}
+						<li class="rounded-lg border p-4">
+							<div class="mb-2 flex items-center justify-between">
+								<span class="text-sm font-medium">{weekLabel(week)}</span>
+								{#if official}
+									<Badge variant="secondary">Official</Badge>
+								{:else if confirmed}
+									<Badge variant="secondary">Confirmed</Badge>
+								{/if}
+							</div>
+
+							{#if editingLineupWeek === week.id}
+								{#each lineupDrafts[week.id] ?? [] as row, idx (idx)}
+									{@const line = detail?.lines[idx]}
+									<div class="mb-3 flex flex-wrap items-end gap-3">
+										<div class="flex flex-col gap-1">
+											<Label for={`${week.id}-lineup-p1-${idx}`} class="text-xs">Player 1</Label>
+											<NativeSelect
+												id={`${week.id}-lineup-p1-${idx}`}
+												value={row.player1}
+												oninput={(e) =>
+													setLineupPlayer(
+														week.id,
+														idx,
+														'player1',
+														(e.currentTarget as HTMLSelectElement).value
+													)
+												}
+											>
+												<NativeSelectOption value="" disabled>Select…</NativeSelectOption>
+												{#each lineupPlayerOptions(line?.player_1_rating ?? '') as m}
+													<NativeSelectOption value={m.user_id}>
+														{userName(m.user_id)}
+													</NativeSelectOption>
+												{/each}
+											</NativeSelect>
+										</div>
+										<div class="flex flex-col gap-1">
+											<Label for={`${week.id}-lineup-p2-${idx}`} class="text-xs">Player 2</Label>
+											<NativeSelect
+												id={`${week.id}-lineup-p2-${idx}`}
+												value={row.player2}
+												oninput={(e) =>
+													setLineupPlayer(
+														week.id,
+														idx,
+														'player2',
+														(e.currentTarget as HTMLSelectElement).value
+													)
+												}
+											>
+												<NativeSelectOption value="" disabled>Select…</NativeSelectOption>
+												{#each lineupPlayerOptions(line?.player_2_rating ?? '') as m}
+													<NativeSelectOption value={m.user_id}>
+														{userName(m.user_id)}
+													</NativeSelectOption>
+												{/each}
+											</NativeSelect>
+										</div>
+										{#if line}
+											<span class="pb-1 text-xs text-muted-foreground">
+												{ratingName(line.player_1_rating)} / {ratingName(line.player_2_rating)}
+											</span>
+										{/if}
+									</div>
+								{/each}
+								<div class="mt-2 flex items-center gap-3">
+									<Button type="button" size="sm" onclick={() => saveLineup(week.id)} disabled={savingLineup}>
+										{savingLineup ? 'Saving…' : 'Save'}
+									</Button>
+									<Button
+										type="button"
+										variant="ghost"
+										size="sm"
+										onclick={() => (editingLineupWeek = null)}
+									>
+										Cancel
+									</Button>
+								</div>
+							{:else}
+								<div class="flex items-center justify-between gap-3">
+									<span class="text-sm text-muted-foreground">
+										{#if (detail?.pairings.length ?? 0) > 0}
+											{detail!.pairings.length} line(s) assigned
+										{:else}
+											No lineup set.
+										{/if}
+									</span>
+									<div class="flex items-center gap-2">
+										{#if !confirmed && !official}
+											<Button
+												type="button"
+												variant="outline"
+												size="sm"
+												onclick={() => startEditLineup(week.id)}
+											>
+												Build
+											</Button>
+											{#if detail?.lineup}
+												<Button type="button" size="sm" onclick={() => confirmWeekLineup(week.id)}>
+													Confirm
+												</Button>
+											{/if}
+										{/if}
+									</div>
+								</div>
+							{/if}
+						</li>
+					{/each}
+				</ul>
+			{:else}
+				<p class="text-sm text-muted-foreground">
+					You are not a captain or co-captain on a team in this season, and you are not a
+					commissioner.
+				</p>
 			{/if}
 		</CardContent>
 	</Card>


### PR DESCRIPTION
Closes #157

## Scope
- Register CRUD for `Lineup` and `LineupPairing` in `main.go`.
- Season-page UI: a per-week lineup builder for a team (assign rated players to format lines), with a confirm flow before the commissioner marks it official.
- e2e coverage.

## Backend
- `model/lineup.go`: add `confirmed` / `official` flags to `Lineup`, plus JSON marshal/unmarshal on `LineupId`.
- `model/lineup_pairing.go`: enforce rating validation in `DynamicallyValid`, add JSON tags + marshal/unmarshal on `LineupPairingId`.
- `database/migrations/0052`: add the `confirmed` / `official` columns.
- `route/lineup`: generic CRUD for both models plus custom routes for the builder/confirm/official flow:
  - `GET /lineup/detail?team_id=&week_id=`
  - `POST /lineup/set`
  - `POST /lineup/:id/confirm` (captain/co-captain)
  - `POST /lineup/:id/official` (commissioner, requires confirmed)
- Tests: `route/lineup/lineup_test.go`.

## UI
- `ui/src/lib/lineup.ts` API client.
- `seasons/[id]/+page.svelte`: captains build/confirm their team's weekly lineup; commissioners mark confirmed lineups official.

## Verification
- `go build ./...`, `go vet ./...`, `go test ./...` all pass.
- `cd ui && npm run check`: 0 errors / 0 warnings.
- `make e2e`: all 30 tests pass (including the new lineup spec).
