### PR TITLE
Matches: match scoring, close week & weekly standings API

### DIFF
--- a/database/migrations/0053_add_week_closed.sql
+++ b/database/migrations/0053_add_week_closed.sql
@@ -1,0 +1,6 @@
+-- 0053_add_week_closed.sql
+-- Add the commissioner-closed flag to the week table. The Week model
+-- (model/week.go) tracks this so a week is marked final once every team match
+-- in it is complete. Stored as INTEGER (0/1), matching the provider's bool
+-- mapping.
+ALTER TABLE week ADD COLUMN closed INTEGER NOT NULL DEFAULT 0;

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ import (
 	"intraclub/route/draft"
 	"intraclub/route/format"
 	"intraclub/route/lineup"
+	"intraclub/route/match"
 	"intraclub/route/organization"
 	"intraclub/route/ruleset"
 	"intraclub/route/schedule"
@@ -136,6 +137,26 @@ func main() {
 	schedule.RegisterRoutes(rg, db)
 
 	lineup.RegisterRoutes(rg, db)
+
+	// Match scoring is driven through the custom route/match surface (generate,
+	// score, complete, week score sheet, standings); the underlying records are
+	// also exposed read-only here so the season page can render a score sheet
+	// without the generic write surface (writes are gated by each model's
+	// EditableBy — team matches are sysadmin-only, individual matches are
+	// editable by their match_editor rows).
+	match.RegisterRoutes(rg, db)
+
+	individualMatches := api.NewCrudCommon(model.NewMatch, false, db)
+	individualMatches.HandleRouteTypes(rg, api.CrudWrapperFunctionGetOne, api.CrudWrapperFunctionGetMany)
+
+	teamMatches := api.NewCrudCommon(func() *model.TeamMatch { return &model.TeamMatch{} }, false, db)
+	teamMatches.HandleRouteTypes(rg, api.CrudWrapperFunctionGetOne, api.CrudWrapperFunctionGetMany)
+
+	teamMatchIndividualMatches := api.NewCrudCommon(func() *model.TeamMatchIndividualMatch { return &model.TeamMatchIndividualMatch{} }, false, db)
+	teamMatchIndividualMatches.HandleRouteTypes(rg, api.CrudWrapperFunctionGetOne, api.CrudWrapperFunctionGetMany)
+
+	matchEditors := api.NewCrudCommon(func() *model.MatchEditor { return &model.MatchEditor{} }, false, db)
+	matchEditors.HandleRouteTypes(rg, api.CrudWrapperFunctionGetOne, api.CrudWrapperFunctionGetMany)
 
 	playoffStructures := api.NewCrudCommon(model.NewPlayoffStructure, false, db)
 	playoffStructures.HandleRouteTypes(rg, api.CrudWrapperFunctionAll...)

--- a/model/week.go
+++ b/model/week.go
@@ -38,6 +38,10 @@ type Week struct {
 	DraftId DraftId   `json:"draft_id"`
 	Date    time.Time `json:"date"`
 	Note    string    `json:"note"`
+	// Closed is set by the season commissioner once every team match in the
+	// week is complete. A closed week is final; standings are computed from
+	// closed (and completed) weeks' team matches.
+	Closed bool `json:"closed"`
 }
 
 func (w *Week) GetOwner() database.UserId {

--- a/route/match/match.go
+++ b/route/match/match.go
@@ -1,0 +1,727 @@
+package match
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"sort"
+
+	"intraclub/api"
+	"intraclub/database"
+	"intraclub/model"
+
+	"github.com/gin-gonic/gin"
+)
+
+// BaseRoute is the base path for the Match REST surface.
+const BaseRoute = "/match"
+
+// isSeasonCommissioner reports whether the requesting user is one of the
+// season's commissioners (the only role allowed to generate matches and close
+// a week).
+func isSeasonCommissioner(ctx context.Context, db database.Provider, userId database.UserId, seasonId model.SeasonId) bool {
+	if userId == database.InvalidUserId {
+		return false
+	}
+	for _, uid := range model.EditableBySeason(ctx, db, seasonId) {
+		if uid == userId {
+			return true
+		}
+	}
+	return false
+}
+
+// canEditMatch reports whether the requesting user may record/complete a score
+// on an individual match: they are a listed match editor (the season
+// commissioners are added as editors when matches are generated), or a
+// sysadmin.
+func canEditMatch(ctx context.Context, db database.Provider, userId database.UserId, matchId model.IndividualMatchId) bool {
+	if userId == database.InvalidUserId {
+		return false
+	}
+	editors, err := database.GetAllWhere[*model.MatchEditor](ctx, db, func(_ context.Context, e *model.MatchEditor) bool {
+		return e.MatchId == matchId && e.EditorUserId == userId
+	})
+	if err == nil && len(editors) > 0 {
+		return true
+	}
+	if isAdmin, err := model.IsUserSystemAdministrator(ctx, db, userId); err == nil && isAdmin {
+		return true
+	}
+	return false
+}
+
+// weekSeason resolves the season a week belongs to via its draft.
+func weekSeason(ctx context.Context, db database.Provider, week *model.Week) (*model.Season, error) {
+	draft, err := database.GetExistingRecordById(ctx, db, &model.Draft{}, week.DraftId.RecordId())
+	if err != nil {
+		return nil, err
+	}
+	return draft.GetSeason(ctx, db)
+}
+
+// officialLineupForTeamWeek returns the team's official lineup for the week, or
+// nil if the team has not yet had one marked official.
+func officialLineupForTeamWeek(ctx context.Context, db database.Provider, teamId model.TeamId, weekId model.WeekId) (*model.Lineup, error) {
+	lineups, err := database.GetAllWhere[*model.Lineup](ctx, db, func(_ context.Context, l *model.Lineup) bool {
+		return l.TeamId == teamId && l.WeekId == weekId && l.Official
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(lineups) == 0 {
+		return nil, nil
+	}
+	return lineups[0], nil
+}
+
+// pairingsForLineup returns a lineup's pairings sorted by format line index.
+func pairingsForLineup(ctx context.Context, db database.Provider, lineupId model.LineupId) ([]*model.LineupPairing, error) {
+	pairings, err := database.GetAllWhere[*model.LineupPairing](ctx, db, func(_ context.Context, p *model.LineupPairing) bool {
+		return p.LineupId == lineupId
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(pairings, func(i, j int) bool {
+		return pairings[i].FormatLineIndex < pairings[j].FormatLineIndex
+	})
+	return pairings, nil
+}
+
+// hasScore reports whether a side of an individual match has been scored yet.
+func hasScore(m *model.IndividualMatch) bool {
+	return m.WinOverride || m.MainValue > 0 || m.SecondaryValue > 0
+}
+
+// IndividualMatchDTO is the wire representation of one scored line in a team
+// match, including which team/pairing it belongs to and the opponent's status.
+type IndividualMatchDTO struct {
+	ID              string `json:"id"`
+	Structure       string `json:"structure"`
+	MainValue       int    `json:"main_value"`
+	SecondaryValue  int    `json:"secondary_value"`
+	WinOverride     bool   `json:"win_override"`
+	Status          int    `json:"status"`
+	TeamId          string `json:"team_id"`
+	Player1         string `json:"player1"`
+	Player2         string `json:"player2"`
+	FormatLineIndex int    `json:"format_line_index"`
+	Opponent        string `json:"opponent"`
+	OpponentStatus  int    `json:"opponent_status"`
+}
+
+// TeamMatchDTO is the wire representation of one head-to-head team match with
+// its individual matches and a running win tally.
+type TeamMatchDTO struct {
+	ID       string              `json:"id"`
+	WeekId   string              `json:"week_id"`
+	HomeTeam string              `json:"home_team_id"`
+	AwayTeam string              `json:"away_team_id"`
+	Complete bool                `json:"complete"`
+	HomeWins int                 `json:"home_wins"`
+	AwayWins int                 `json:"away_wins"`
+	Winner   string              `json:"winner_team_id"`
+	Matches  []*IndividualMatchDTO `json:"matches"`
+}
+
+// WeekMatchDetail is the wire representation of a week's score sheet.
+type WeekMatchDetail struct {
+	WeekId      string          `json:"week_id"`
+	SeasonId    string          `json:"season_id"`
+	Closed      bool            `json:"closed"`
+	TeamMatches []*TeamMatchDTO `json:"team_matches"`
+}
+
+// buildIndividualMatchDTO converts a stored individual match plus its pairing
+// into its wire form.
+func buildIndividualMatchDTO(ctx context.Context, db database.Provider, im *model.IndividualMatch, pairing *model.LineupPairing) (*IndividualMatchDTO, error) {
+	dto := &IndividualMatchDTO{
+		ID:              im.ID.RecordId().String(),
+		Structure:       im.Structure.RecordId().String(),
+		MainValue:       im.MainValue,
+		SecondaryValue:  im.SecondaryValue,
+		WinOverride:     im.WinOverride,
+		Status:          int(im.Status),
+		TeamId:          pairing.TeamId.RecordId().String(),
+		Player1:         database.RecordId(pairing.Player1).String(),
+		Player2:         database.RecordId(pairing.Player2).String(),
+		FormatLineIndex: pairing.FormatLineIndex,
+		Opponent:        im.Opponent.RecordId().String(),
+	}
+	if im.Opponent != model.IndividualMatchId(database.InvalidRecordId) {
+		opp, err := database.GetExistingRecordById(ctx, db, &model.IndividualMatch{}, im.Opponent.RecordId())
+		if err != nil {
+			return nil, err
+		}
+		dto.OpponentStatus = int(opp.Status)
+	}
+	return dto, nil
+}
+
+// buildTeamMatchDTO assembles a TeamMatch with its individual matches and win
+// tally from the join table and each assigned lineup pairing.
+func buildTeamMatchDTO(ctx context.Context, db database.Provider, tm *model.TeamMatch) (*TeamMatchDTO, error) {
+	rows, err := database.GetAllWhere[*model.TeamMatchIndividualMatch](ctx, db, func(_ context.Context, r *model.TeamMatchIndividualMatch) bool {
+		return r.TeamMatchId == tm.ID
+	})
+	if err != nil {
+		return nil, err
+	}
+	dto := &TeamMatchDTO{
+		ID:       tm.ID.RecordId().String(),
+		WeekId:   tm.WeekId.RecordId().String(),
+		HomeTeam: tm.HomeTeam.RecordId().String(),
+		AwayTeam: tm.AwayTeam.RecordId().String(),
+		Matches:  []*IndividualMatchDTO{},
+	}
+	complete := true
+	for _, row := range rows {
+		pairing, err := database.GetExistingRecordById(ctx, db, &model.LineupPairing{}, row.LineupPairingId.RecordId())
+		if err != nil {
+			return nil, err
+		}
+		im, err := database.GetExistingRecordById(ctx, db, &model.IndividualMatch{}, row.IndividualMatchId.RecordId())
+		if err != nil {
+			return nil, err
+		}
+		matchDTO, err := buildIndividualMatchDTO(ctx, db, im, pairing)
+		if err != nil {
+			return nil, err
+		}
+		dto.Matches = append(dto.Matches, matchDTO)
+		if im.Status == model.MatchWon {
+			if pairing.TeamId == tm.HomeTeam {
+				dto.HomeWins++
+			} else if pairing.TeamId == tm.AwayTeam {
+				dto.AwayWins++
+			}
+		}
+		if im.Status != model.MatchWon && im.Status != model.MatchLost {
+			complete = false
+		}
+	}
+	dto.Complete = complete
+	if complete && dto.HomeWins > dto.AwayWins {
+		dto.Winner = tm.HomeTeam.RecordId().String()
+	} else if complete && dto.AwayWins > dto.HomeWins {
+		dto.Winner = tm.AwayTeam.RecordId().String()
+	}
+	return dto, nil
+}
+
+// weekDetailForWeek assembles the WeekMatchDetail for a week.
+func weekDetailForWeek(ctx context.Context, db database.Provider, week *model.Week) (*WeekMatchDetail, error) {
+	season, err := weekSeason(ctx, db, week)
+	if err != nil {
+		return nil, err
+	}
+	detail := &WeekMatchDetail{WeekId: week.ID.RecordId().String(), SeasonId: season.ID.RecordId().String(), Closed: week.Closed, TeamMatches: []*TeamMatchDTO{}}
+	teamMatches, err := database.GetAllWhere[*model.TeamMatch](ctx, db, func(_ context.Context, tm *model.TeamMatch) bool {
+		return tm.WeekId == week.ID
+	})
+	if err != nil {
+		return nil, err
+	}
+	for _, tm := range teamMatches {
+		dto, err := buildTeamMatchDTO(ctx, db, tm)
+		if err != nil {
+			return nil, err
+		}
+		detail.TeamMatches = append(detail.TeamMatches, dto)
+	}
+	return detail, nil
+}
+
+// ---- request/response types ----
+
+// EmptyBody is a placeholder for routes that carry no request body.
+type EmptyBody struct{}
+
+// StaticallyValid has no static constraints.
+func (b *EmptyBody) StaticallyValid() error { return nil }
+
+// GenerateBody is the request body for GenerateMatches.
+type GenerateBody struct {
+	WeekId             string `json:"week_id"`
+	ScoringStructureId string `json:"scoring_structure_id"`
+}
+
+// StaticallyValid ensures a week and a scoring structure are specified.
+func (b *GenerateBody) StaticallyValid() error {
+	if b.WeekId == "" {
+		return errors.New("week_id must be set")
+	}
+	if b.ScoringStructureId == "" {
+		return errors.New("scoring_structure_id must be set")
+	}
+	return nil
+}
+
+// GenerateMatches creates the week's TeamMatches (and their individual matches)
+// from the scheduled weekly matchups and both teams' official lineups. Only a
+// season commissioner may generate matches.
+type GenerateMatches struct{}
+
+func (c GenerateMatches) Path() (api.HttpMethod, string) {
+	return api.HttpMethodPost, BaseRoute + "/generate"
+}
+
+func (c GenerateMatches) RequestBody() (*GenerateBody, bool) {
+	return &GenerateBody{}, true
+}
+
+func (c GenerateMatches) Handler(req api.Request[*GenerateBody]) (any, int, error) {
+	if req.Token == nil {
+		return nil, http.StatusUnauthorized, errors.New("token is required")
+	}
+	weekRid, err := database.RecordIdFromString(req.Body.WeekId)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	ssRid, err := database.RecordIdFromString(req.Body.ScoringStructureId)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	week, err := database.GetExistingRecordById(req.Context, req.DatabaseProvider, &model.Week{}, weekRid)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	season, err := weekSeason(req.Context, req.DatabaseProvider, week)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	if !isSeasonCommissioner(req.Context, req.DatabaseProvider, req.Token.UserId, season.ID) {
+		return nil, http.StatusForbidden, errors.New("only a season commissioner may generate matches")
+	}
+	if _, err := database.GetExistingRecordById(req.Context, req.DatabaseProvider, &model.ScoringStructure{}, ssRid); err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	detail, err := generateWeekMatches(req.Context, req.DatabaseProvider, week, season, model.ScoringStructureId(ssRid))
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	return gin.H{api.ResourceKey: detail}, http.StatusOK, nil
+}
+
+// generateWeekMatches creates team + individual matches for a week from the
+// scheduled weekly matchup entries and both teams' official lineups, pairing
+// home and away lineup slots by format line index.
+func generateWeekMatches(ctx context.Context, db database.Provider, week *model.Week, season *model.Season, scoringStructureId model.ScoringStructureId) (*WeekMatchDetail, error) {
+	if season.ScheduleID.RecordId() == database.InvalidRecordId {
+		return nil, errors.New("season has no schedule")
+	}
+	schedule, err := database.GetExistingRecordById(ctx, db, &model.Schedule{}, season.ScheduleID.RecordId())
+	if err != nil {
+		return nil, err
+	}
+	weeklyMatchups, err := schedule.GetMatchups(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+	var wm *model.WeeklyMatchup
+	for _, m := range weeklyMatchups {
+		if m.WeekId == week.ID {
+			wm = m
+			break
+		}
+	}
+	if wm == nil {
+		return nil, errors.New("week has no assigned weekly matchup")
+	}
+	entries, err := wm.GetMatchups(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+	commissioners, err := season.GetCommissioners(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+
+	detail := &WeekMatchDetail{WeekId: week.ID.RecordId().String(), SeasonId: season.ID.RecordId().String(), Closed: week.Closed, TeamMatches: []*TeamMatchDTO{}}
+	for _, entry := range entries {
+		if entry.Bye {
+			continue
+		}
+		homeLineup, err := officialLineupForTeamWeek(ctx, db, entry.HomeTeam, week.ID)
+		if err != nil {
+			return nil, err
+		}
+		awayLineup, err := officialLineupForTeamWeek(ctx, db, entry.AwayTeam, week.ID)
+		if err != nil {
+			return nil, err
+		}
+		if homeLineup == nil {
+			return nil, errors.New("home team has no official lineup for this week")
+		}
+		if awayLineup == nil {
+			return nil, errors.New("away team has no official lineup for this week")
+		}
+
+		tm := &model.TeamMatch{WeekId: week.ID, HomeTeam: entry.HomeTeam, AwayTeam: entry.AwayTeam, Lineup: homeLineup.ID}
+		tmCreated, err := database.CreateOne(ctx, db, tm)
+		if err != nil {
+			return nil, err
+		}
+
+		homePairings, err := pairingsForLineup(ctx, db, homeLineup.ID)
+		if err != nil {
+			return nil, err
+		}
+		awayPairings, err := pairingsForLineup(ctx, db, awayLineup.ID)
+		if err != nil {
+			return nil, err
+		}
+		awayByIndex := make(map[int]*model.LineupPairing, len(awayPairings))
+		for _, p := range awayPairings {
+			awayByIndex[p.FormatLineIndex] = p
+		}
+
+		for _, hp := range homePairings {
+			ap := awayByIndex[hp.FormatLineIndex]
+			if ap == nil {
+				continue
+			}
+			homeIM := &model.IndividualMatch{Structure: scoringStructureId, Status: model.MatchUnstarted}
+			homeIMCreated, err := database.CreateOne(ctx, db, homeIM)
+			if err != nil {
+				return nil, err
+			}
+			awayIM := &model.IndividualMatch{Structure: scoringStructureId, Opponent: homeIMCreated.ID, Status: model.MatchUnstarted}
+			awayIMCreated, err := database.CreateOne(ctx, db, awayIM)
+			if err != nil {
+				return nil, err
+			}
+			homeIMCreated.Opponent = awayIMCreated.ID
+			if err := database.UpdateOne(ctx, db, homeIMCreated); err != nil {
+				return nil, err
+			}
+			for _, c := range commissioners {
+				if _, err := homeIMCreated.AssignEditor(ctx, db, c); err != nil {
+					return nil, err
+				}
+				if _, err := awayIMCreated.AssignEditor(ctx, db, c); err != nil {
+					return nil, err
+				}
+			}
+			if _, err := database.CreateOne(ctx, db, &model.TeamMatchIndividualMatch{
+				TeamMatchId:       tmCreated.ID,
+				LineupPairingId:   hp.ID,
+				IndividualMatchId: homeIMCreated.ID,
+			}); err != nil {
+				return nil, err
+			}
+			if _, err := database.CreateOne(ctx, db, &model.TeamMatchIndividualMatch{
+				TeamMatchId:       tmCreated.ID,
+				LineupPairingId:   ap.ID,
+				IndividualMatchId: awayIMCreated.ID,
+			}); err != nil {
+				return nil, err
+			}
+		}
+
+		tmDTO, err := buildTeamMatchDTO(ctx, db, tmCreated)
+		if err != nil {
+			return nil, err
+		}
+		detail.TeamMatches = append(detail.TeamMatches, tmDTO)
+	}
+	return detail, nil
+}
+
+// MatchQuery holds the query parameter for GetWeekMatches.
+type MatchQuery struct {
+	WeekId model.WeekId `json:"week_id"`
+}
+
+// StaticallyValid ensures a week is specified.
+func (q *MatchQuery) StaticallyValid() error {
+	if q.WeekId.RecordId() == database.InvalidRecordId {
+		return errors.New("week_id must be set")
+	}
+	return nil
+}
+
+// GetWeekMatches returns the week's score sheet. It is viewable by everyone.
+type GetWeekMatches struct{}
+
+func (c GetWeekMatches) Path() (api.HttpMethod, string) {
+	return api.HttpMethodGet, BaseRoute + "/week"
+}
+
+func (c GetWeekMatches) RequestBody() (*MatchQuery, bool) {
+	return &MatchQuery{}, false
+}
+
+func (c GetWeekMatches) Handler(req api.Request[*MatchQuery]) (any, int, error) {
+	query := req.HTTPRequest().URL.Query()
+	weekStr := query.Get("week_id")
+	if weekStr == "" {
+		return nil, http.StatusBadRequest, errors.New("week_id must be set")
+	}
+	rid, err := database.RecordIdFromString(weekStr)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	week, err := database.GetExistingRecordById(req.Context, req.DatabaseProvider, &model.Week{}, rid)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	detail, err := weekDetailForWeek(req.Context, req.DatabaseProvider, week)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	return gin.H{api.ResourceKey: detail}, http.StatusOK, nil
+}
+
+// ScoreBody is the request body for RecordScore.
+type ScoreBody struct {
+	IndividualMatchId string `json:"individual_match_id"`
+	MainValue         int    `json:"main_value"`
+	SecondaryValue    int    `json:"secondary_value"`
+	WinOverride       bool   `json:"win_override"`
+}
+
+// StaticallyValid ensures an individual match is specified and scores are
+// non-negative.
+func (b *ScoreBody) StaticallyValid() error {
+	if b.IndividualMatchId == "" {
+		return errors.New("individual_match_id must be set")
+	}
+	if b.MainValue < 0 || b.SecondaryValue < 0 {
+		return errors.New("scores cannot be negative")
+	}
+	return nil
+}
+
+// RecordScore updates the score on one side of an individual match. It does not
+// complete the match; use CompleteMatch to determine the winner once both sides
+// have been scored.
+type RecordScore struct{}
+
+func (c RecordScore) Path() (api.HttpMethod, string) {
+	return api.HttpMethodPost, BaseRoute + "/score"
+}
+
+func (c RecordScore) RequestBody() (*ScoreBody, bool) {
+	return &ScoreBody{}, true
+}
+
+func (c RecordScore) Handler(req api.Request[*ScoreBody]) (any, int, error) {
+	if req.Token == nil {
+		return nil, http.StatusUnauthorized, errors.New("token is required")
+	}
+	matchRid, err := database.RecordIdFromString(req.Body.IndividualMatchId)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	matchId := model.IndividualMatchId(matchRid)
+	if !canEditMatch(req.Context, req.DatabaseProvider, req.Token.UserId, matchId) {
+		return nil, http.StatusForbidden, errors.New("you are not an editor of this match")
+	}
+	im, err := database.GetExistingRecordById(req.Context, req.DatabaseProvider, &model.IndividualMatch{}, matchId.RecordId())
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	im.MainValue = req.Body.MainValue
+	im.SecondaryValue = req.Body.SecondaryValue
+	im.WinOverride = req.Body.WinOverride
+	if err := database.UpdateOne(req.Context, req.DatabaseProvider, im); err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	return gin.H{api.ResourceKey: im}, http.StatusOK, nil
+}
+
+// CompleteMatch marks an individual match complete, determining the winner
+// against its opponent by the scoring structure once both sides have scores. A
+// match with no opponent is recorded as won once it has a score.
+type CompleteMatch struct{}
+
+func (c CompleteMatch) Path() (api.HttpMethod, string) {
+	return api.HttpMethodPost, api.AppendPathId(BaseRoute) + "/complete"
+}
+
+func (c CompleteMatch) RequestBody() (*EmptyBody, bool) {
+	return &EmptyBody{}, false
+}
+
+func (c CompleteMatch) Handler(req api.Request[*EmptyBody]) (any, int, error) {
+	if req.Token == nil {
+		return nil, http.StatusUnauthorized, errors.New("token is required")
+	}
+	matchId := model.IndividualMatchId(req.PathId)
+	if !canEditMatch(req.Context, req.DatabaseProvider, req.Token.UserId, matchId) {
+		return nil, http.StatusForbidden, errors.New("you are not an editor of this match")
+	}
+	im, err := database.GetExistingRecordById(req.Context, req.DatabaseProvider, &model.IndividualMatch{}, matchId.RecordId())
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	if err := determineWinnerAndMark(req.Context, req.DatabaseProvider, im); err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	return gin.H{api.ResourceKey: im}, http.StatusOK, nil
+}
+
+// determineWinnerAndMark completes an individual match: when it has an
+// opponent, both sides must be scored and the scoring structure decides the
+// winner; the winner is marked Won and the loser Lost. A lone match (no
+// opponent) is marked Won once it has a score.
+func determineWinnerAndMark(ctx context.Context, db database.Provider, im *model.IndividualMatch) error {
+	if im.Opponent == model.IndividualMatchId(database.InvalidRecordId) {
+		if !hasScore(im) {
+			return errors.New("match must be scored before completing")
+		}
+		im.Status = model.MatchWon
+		return database.UpdateOne(ctx, db, im)
+	}
+	opp, err := database.GetExistingRecordById(ctx, db, &model.IndividualMatch{}, im.Opponent.RecordId())
+	if err != nil {
+		return err
+	}
+	if !hasScore(im) || !hasScore(opp) {
+		return errors.New("both sides must be scored before completing the match")
+	}
+	if err := im.Initialize(ctx, db); err != nil {
+		return err
+	}
+	if err := opp.Initialize(ctx, db); err != nil {
+		return err
+	}
+	if im.Victorious(opp) {
+		im.Status = model.MatchWon
+		opp.Status = model.MatchLost
+	} else if opp.Victorious(im) {
+		opp.Status = model.MatchWon
+		im.Status = model.MatchLost
+	} else {
+		return errors.New("match is not decided by the current scores")
+	}
+	if err := database.UpdateOne(ctx, db, opp); err != nil {
+		return err
+	}
+	return database.UpdateOne(ctx, db, im)
+}
+
+// StandingsQuery holds the query parameter for GetStandings.
+type StandingsQuery struct {
+	SeasonId model.SeasonId `json:"season_id"`
+}
+
+// StaticallyValid ensures a season is specified.
+func (q *StandingsQuery) StaticallyValid() error {
+	if q.SeasonId.RecordId() == database.InvalidRecordId {
+		return errors.New("season_id must be set")
+	}
+	return nil
+}
+
+// StandingsEntry is a team's cumulative win/loss/tie record across the season's
+// completed team matches.
+type StandingsEntry struct {
+	TeamId string `json:"team_id"`
+	Wins   int    `json:"wins"`
+	Losses int    `json:"losses"`
+	Ties   int    `json:"ties"`
+}
+
+// GetStandings computes the season's weekly standings from completed team
+// matches, sorted by wins (then ties). It is viewable by everyone.
+type GetStandings struct{}
+
+func (c GetStandings) Path() (api.HttpMethod, string) {
+	return api.HttpMethodGet, BaseRoute + "/standings"
+}
+
+func (c GetStandings) RequestBody() (*StandingsQuery, bool) {
+	return &StandingsQuery{}, false
+}
+
+func (c GetStandings) Handler(req api.Request[*StandingsQuery]) (any, int, error) {
+	query := req.HTTPRequest().URL.Query()
+	seasonStr := query.Get("season_id")
+	if seasonStr == "" {
+		return nil, http.StatusBadRequest, errors.New("season_id must be set")
+	}
+	rid, err := database.RecordIdFromString(seasonStr)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	season, err := database.GetExistingRecordById(req.Context, req.DatabaseProvider, &model.Season{}, rid)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	entries, err := computeStandings(req.Context, req.DatabaseProvider, season)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	return gin.H{api.ResourceKey: entries}, http.StatusOK, nil
+}
+
+// computeStandings tallies each team's record across every completed team match
+// in the season's weeks, sorted by wins then ties.
+func computeStandings(ctx context.Context, db database.Provider, season *model.Season) ([]*StandingsEntry, error) {
+	weeks, err := model.GetWeeksForDraft(ctx, db, season.DraftId)
+	if err != nil {
+		return nil, err
+	}
+	records := make(map[model.TeamId]*StandingsEntry)
+	for _, week := range weeks {
+		teamMatches, err := database.GetAllWhere[*model.TeamMatch](ctx, db, func(_ context.Context, tm *model.TeamMatch) bool {
+			return tm.WeekId == week.ID
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, tm := range teamMatches {
+			dto, err := buildTeamMatchDTO(ctx, db, tm)
+			if err != nil {
+				return nil, err
+			}
+			if !dto.Complete {
+				continue
+			}
+			if dto.Winner == tm.HomeTeam.RecordId().String() {
+				bump(records, tm.HomeTeam, boolPtr(true))
+				bump(records, tm.AwayTeam, boolPtr(false))
+			} else if dto.Winner == tm.AwayTeam.RecordId().String() {
+				bump(records, tm.AwayTeam, boolPtr(true))
+				bump(records, tm.HomeTeam, boolPtr(false))
+			} else {
+				bump(records, tm.HomeTeam, nil)
+				bump(records, tm.AwayTeam, nil)
+			}
+		}
+	}
+	out := make([]*StandingsEntry, 0, len(records))
+	for _, e := range records {
+		out = append(out, e)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Wins != out[j].Wins {
+			return out[i].Wins > out[j].Wins
+		}
+		return out[i].Ties > out[j].Ties
+	})
+	return out, nil
+}
+
+// boolPtr returns a pointer to a bool literal (Go has no &true syntax).
+func boolPtr(v bool) *bool { return &v }
+
+// bump updates a team's win/loss/tie record. won is true for a win, false for a
+// loss, and nil for a tie.
+func bump(records map[model.TeamId]*StandingsEntry, teamId model.TeamId, won *bool) {
+	e := records[teamId]
+	if e == nil {
+		e = &StandingsEntry{TeamId: teamId.RecordId().String()}
+		records[teamId] = e
+	}
+	if won == nil {
+		e.Ties++
+	} else if *won {
+		e.Wins++
+	} else {
+		e.Losses++
+	}
+}

--- a/route/match/match_test.go
+++ b/route/match/match_test.go
@@ -1,0 +1,501 @@
+package match
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/rand/v2"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"intraclub/api"
+	"intraclub/database"
+	"intraclub/model"
+	"intraclub/route/week"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// test setup helpers (mirror route/lineup)
+// ---------------------------------------------------------------------------
+
+func newStoredUser(t *testing.T, db database.Provider) *model.User {
+	t.Helper()
+	user := model.NewUser()
+	user.Email = model.EmailAddress(fmt.Sprintf("user%d@email.com", rand.Uint64()))
+	user.FirstName = fmt.Sprintf("Test %d", rand.Uint64())
+	user.LastName = "User"
+	user.PhoneNumber = model.PhoneNumber(fmt.Sprintf("%d", 100_000_0000+rand.Uint32N(999_999_999)))
+	v, err := database.CreateOne(context.Background(), db, user)
+	require.NoError(t, err)
+	return v
+}
+
+func newStoredRating(t *testing.T, db database.Provider, owner database.UserId) model.RatingId {
+	t.Helper()
+	r := model.NewRating()
+	r.UserId = owner
+	r.Name = fmt.Sprintf("rating %d", rand.Uint64())
+	r.Description = "test rating"
+	v, err := database.CreateOne(context.Background(), db, r)
+	require.NoError(t, err)
+	return v.ID
+}
+
+func addAssignment(t *testing.T, db database.Provider, team *model.Team, user *model.User, role model.TeamRole) {
+	t.Helper()
+	_, err := database.CreateOne(context.Background(), db, &model.TeamAssignment{TeamId: team.ID, UserId: user.ID, Role: role})
+	require.NoError(t, err)
+}
+
+// newScoringStructure builds a simple set-scoring structure (win at 6 games,
+// by 2) that Victorious can decide on.
+func newScoringStructure(t *testing.T, db database.Provider, owner database.UserId) *model.ScoringStructure {
+	t.Helper()
+	s := model.NewScoringStructure()
+	s.Owner = owner
+	s.Name = fmt.Sprintf("scoring %d", rand.Uint64())
+	s.WinConditionCountingType = model.Game
+	s.WinCondition = model.WinCondition{WinThreshold: 6, MustWinBy: 2, InstantWinThreshold: 7}
+	v, err := database.CreateOne(context.Background(), db, s)
+	require.NoError(t, err)
+	return v
+}
+
+// newRatedTeam creates a team with a captain (rating1) and a member (rating2)
+// and assigns it to the season, so a format-line pairing (rating1/rating2) can
+// be built for it.
+func newRatedTeam(t *testing.T, db database.Provider, season *model.Season, rating1, rating2 model.RatingId, name string) (*model.Team, database.UserId, database.UserId) {
+	t.Helper()
+	ctx := context.Background()
+	captain := newStoredUser(t, db)
+	member := newStoredUser(t, db)
+	team := model.NewDefaultTeam(captain.ID, name)
+	teamV, err := database.CreateOne(ctx, db, team)
+	require.NoError(t, err)
+	require.NoError(t, season.AddTeam(ctx, db, teamV.ID))
+	addAssignment(t, db, teamV, member, model.TeamRoleMember)
+	_, err = database.CreateOne(ctx, db, &model.TeamRating{TeamId: teamV.ID, UserId: captain.ID, RatingId: rating1})
+	require.NoError(t, err)
+	_, err = database.CreateOne(ctx, db, &model.TeamRating{TeamId: teamV.ID, UserId: member.ID, RatingId: rating2})
+	require.NoError(t, err)
+	return teamV, captain.ID, member.ID
+}
+
+// matchFixture builds the full chain required to generate matches: a season
+// with a schedule and a weekly matchup between two rated teams, a week, a
+// scoring structure, and official lineups for both teams.
+type matchFixture struct {
+	season       *model.Season
+	week         *model.Week
+	homeTeam     *model.Team
+	awayTeam     *model.Team
+	homeCaptain  database.UserId
+	awayCaptain  database.UserId
+	scoring      *model.ScoringStructure
+	commissioner database.UserId
+	outsider     database.UserId
+}
+
+func newMatchFixture(t *testing.T, db database.Provider) *matchFixture {
+	t.Helper()
+	ctx := context.Background()
+	commissioner := newStoredUser(t, db)
+	outsider := newStoredUser(t, db)
+
+	rating1 := newStoredRating(t, db, commissioner.ID)
+	rating2 := newStoredRating(t, db, commissioner.ID)
+	format := model.NewFormat()
+	format.UserId = commissioner.ID
+	format.Name = fmt.Sprintf("format %d", rand.Uint64())
+	formatV, err := database.CreateOne(ctx, db, format)
+	require.NoError(t, err)
+	line := model.FormatLine{Player1Rating: rating1, Player2Rating: rating2}
+	require.NoError(t, formatV.SetPossibleRatings(ctx, db, model.RatingList{rating1, rating2}))
+	require.NoError(t, formatV.SetLines(ctx, db, []model.FormatLine{line}))
+
+	draft := model.NewDraft()
+	draft.Owner = commissioner.ID
+	draft.Format = formatV.ID
+	draftV, err := database.CreateOne(ctx, db, draft)
+	require.NoError(t, err)
+
+	facility := model.NewFacility()
+	facility.UserId = commissioner.ID
+	facility.Name = "Test facility"
+	facility.Address = "Test Rd."
+	facility.NumberOfCourts = 2
+	facilityV, err := database.CreateOne(ctx, db, facility)
+	require.NoError(t, err)
+
+	season := model.NewSeason()
+	season.Name = "Test Season"
+	season.StartTime = model.NewStartTime(8, 30)
+	season.DraftId = draftV.ID
+	season.Facility = facilityV.ID
+	seasonV, err := database.CreateOne(ctx, db, season)
+	require.NoError(t, err)
+	require.NoError(t, seasonV.AddCommissioner(ctx, db, commissioner.ID))
+
+	homeTeam, homeCaptain, _ := newRatedTeam(t, db, seasonV, rating1, rating2, "Home Team")
+	awayTeam, awayCaptain, _ := newRatedTeam(t, db, seasonV, rating1, rating2, "Away Team")
+
+	week := model.NewWeek()
+	week.DraftId = draftV.ID
+	week.Date = time.Date(2025, 3, 1, 8, 0, 0, 0, time.UTC)
+	weekV, err := database.CreateOne(ctx, db, week)
+	require.NoError(t, err)
+
+	scoring := newScoringStructure(t, db, commissioner.ID)
+
+	schedule := model.NewSchedule()
+	schedule.SeasonId = seasonV.ID
+	scheduleV, err := database.CreateOne(ctx, db, schedule)
+	require.NoError(t, err)
+
+	wm := model.NewWeeklyMatchup()
+	wm.WeekId = weekV.ID
+	wm.SeasonId = seasonV.ID
+	wmV, err := database.CreateOne(ctx, db, wm)
+	require.NoError(t, err)
+
+	_, err = database.CreateOne(ctx, db, &model.ScheduleMatchup{ScheduleId: scheduleV.ID, WeeklyMatchupId: wmV.ID, Position: 0})
+	require.NoError(t, err)
+	_, err = database.CreateOne(ctx, db, model.NewWeeklyMatchupTeamMatchup(wmV.ID, homeTeam.ID, awayTeam.ID, false, 0))
+	require.NoError(t, err)
+
+	// Build and mark official a one-line lineup for each team.
+	buildOfficialLineup(t, db, homeTeam.ID, weekV.ID, homeCaptain, rating1, rating2)
+	buildOfficialLineup(t, db, awayTeam.ID, weekV.ID, awayCaptain, rating1, rating2)
+
+	return &matchFixture{
+		season:       seasonV,
+		week:         weekV,
+		homeTeam:     homeTeam,
+		awayTeam:     awayTeam,
+		homeCaptain:  homeCaptain,
+		awayCaptain:  awayCaptain,
+		scoring:      scoring,
+		commissioner: commissioner.ID,
+		outsider:     outsider.ID,
+	}
+}
+
+// buildOfficialLineup creates a lineup (confirmed + official) with a single
+// pairing of the team's captain/member at format line index 0.
+func buildOfficialLineup(t *testing.T, db database.Provider, teamID model.TeamId, weekID model.WeekId, captain database.UserId, rating1, rating2 model.RatingId) {
+	t.Helper()
+	ctx := context.Background()
+	team, err := database.GetExistingRecordById(ctx, db, &model.Team{}, teamID.RecordId())
+	require.NoError(t, err)
+	var memberID database.UserId
+	assignments, err := database.GetAllWhere[*model.TeamAssignment](ctx, db, func(_ context.Context, a *model.TeamAssignment) bool {
+		return a.TeamId == teamID && a.Role == model.TeamRoleMember
+	})
+	require.NoError(t, err)
+	require.Len(t, assignments, 1)
+	memberID = assignments[0].UserId
+
+	lineup := &model.Lineup{TeamId: teamID, WeekId: weekID, Confirmed: true, Official: true}
+	lineupV, err := database.CreateOne(ctx, db, lineup)
+	require.NoError(t, err)
+
+	_, err = database.CreateOne(ctx, db, &model.LineupPairing{
+		LineupId:        lineupV.ID,
+		TeamId:          teamID,
+		Player1:         captain,
+		Player2:         memberID,
+		FormatLineIndex: 0,
+	})
+	require.NoError(t, err)
+	_ = team
+	_ = rating1
+	_ = rating2
+}
+
+func newTestRouter(t *testing.T, db database.Provider) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	api.UserType = &model.User{}
+	database.SysAdminCheck = model.IsUserSystemAdministrator
+
+	router := gin.New()
+	group := router.Group("/api")
+	RegisterRoutes(group, db)
+	week.RegisterRoutes(group, db)
+	return router
+}
+
+var (
+	testKeyOnce sync.Once
+	testPubKey  *ecdsa.PublicKey
+	testPrivKey *ecdsa.PrivateKey
+)
+
+func newToken(t *testing.T, userId database.UserId) string {
+	t.Helper()
+	testKeyOnce.Do(func() {
+		pub, priv, err := api.GenerateKeyPair()
+		require.NoError(t, err)
+		testPubKey = pub
+		testPrivKey = priv
+	})
+	api.JwtPublicKey = testPubKey
+	api.JwtPrivateKey = testPrivKey
+	token, err := api.GenerateToken(userId.RecordId())
+	require.NoError(t, err)
+	return token
+}
+
+func doJSON(t *testing.T, router *gin.Engine, method, path string, body any, token string) *httptest.ResponseRecorder {
+	t.Helper()
+	var reader io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		require.NoError(t, err)
+		reader = bytes.NewReader(b)
+	}
+	req, err := http.NewRequest(method, path, reader)
+	require.NoError(t, err)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if token != "" {
+		req.Header.Set(api.AuthTokenHeaderValue, token)
+	}
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+// weekMatchDetail mirrors the wire shape returned by GET /match/week.
+type weekMatchDetail struct {
+	WeekId      string          `json:"week_id"`
+	SeasonId    string          `json:"season_id"`
+	Closed      bool            `json:"closed"`
+	TeamMatches []*teamMatchDTO `json:"team_matches"`
+}
+
+type teamMatchDTO struct {
+	ID       string                `json:"id"`
+	HomeTeam string                `json:"home_team_id"`
+	AwayTeam string                `json:"away_team_id"`
+	Complete bool                  `json:"complete"`
+	HomeWins int                   `json:"home_wins"`
+	AwayWins int                   `json:"away_wins"`
+	Winner   string                `json:"winner_team_id"`
+	Matches  []*individualMatchDTO `json:"matches"`
+}
+
+type individualMatchDTO struct {
+	ID       string `json:"id"`
+	TeamId   string `json:"team_id"`
+	Status   int    `json:"status"`
+	Main     int    `json:"main_value"`
+	Opponent string `json:"opponent"`
+}
+
+func generateMatches(t *testing.T, router *gin.Engine, fx *matchFixture, token string) *httptest.ResponseRecorder {
+	t.Helper()
+	return doJSON(t, router, http.MethodPost, "/api/match/generate", map[string]any{
+		"week_id":              fx.week.ID.String(),
+		"scoring_structure_id": fx.scoring.ID.String(),
+	}, token)
+}
+
+func getWeekDetail(t *testing.T, router *gin.Engine, fx *matchFixture) *weekMatchDetail {
+	t.Helper()
+	w := doJSON(t, router, http.MethodGet, "/api/match/week?week_id="+fx.week.ID.String(), nil, "")
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var body struct {
+		Resource *weekMatchDetail `json:"resource"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	require.NotNil(t, body.Resource)
+	return body.Resource
+}
+
+// ---------------------------------------------------------------------------
+// tests
+// ---------------------------------------------------------------------------
+
+func TestGenerateMatchesCommissionerOnly(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	fx := newMatchFixture(t, db)
+
+	// No token -> unauthorized.
+	w := generateMatches(t, router, fx, "")
+	require.Equal(t, http.StatusUnauthorized, w.Code, w.Body.String())
+
+	// An unrelated user may NOT generate matches.
+	w = generateMatches(t, router, fx, newToken(t, fx.outsider))
+	require.Equal(t, http.StatusForbidden, w.Code, "outsider generate: %s", w.Body.String())
+
+	// The commissioner generates the week's matches.
+	w = generateMatches(t, router, fx, newToken(t, fx.commissioner))
+	require.Equal(t, http.StatusOK, w.Code, "commissioner generate: %s", w.Body.String())
+
+	// The week score sheet now has one team match with two individual matches
+	// (one per side).
+	detail := getWeekDetail(t, router, fx)
+	require.Len(t, detail.TeamMatches, 1)
+	tm := detail.TeamMatches[0]
+	require.Equal(t, fx.homeTeam.ID.String(), tm.HomeTeam)
+	require.Equal(t, fx.awayTeam.ID.String(), tm.AwayTeam)
+	require.Len(t, tm.Matches, 2)
+	require.False(t, tm.Complete)
+}
+
+func TestRecordScoreAndComplete(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	fx := newMatchFixture(t, db)
+
+	w := generateMatches(t, router, fx, newToken(t, fx.commissioner))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	detail := getWeekDetail(t, router, fx)
+	tm := detail.TeamMatches[0]
+	require.Len(t, tm.Matches, 2)
+
+	// Identify the home and away sides.
+	var homeMatch, awayMatch *individualMatchDTO
+	for _, m := range tm.Matches {
+		if m.TeamId == fx.homeTeam.ID.String() {
+			homeMatch = m
+		} else {
+			awayMatch = m
+		}
+	}
+	require.NotNil(t, homeMatch)
+	require.NotNil(t, awayMatch)
+
+	// An unrelated user cannot record a score.
+	w = doJSON(t, router, http.MethodPost, "/api/match/score", map[string]any{
+		"individual_match_id": homeMatch.ID,
+		"main_value":          6,
+	}, newToken(t, fx.outsider))
+	require.Equal(t, http.StatusForbidden, w.Code, "outsider score: %s", w.Body.String())
+
+	// The commissioner records 6-3 for the home side.
+	w = doJSON(t, router, http.MethodPost, "/api/match/score", map[string]any{
+		"individual_match_id": homeMatch.ID,
+		"main_value":          6,
+		"secondary_value":     3,
+	}, newToken(t, fx.commissioner))
+	require.Equal(t, http.StatusOK, w.Code, "home score: %s", w.Body.String())
+
+	// Completing before the away side is scored must fail.
+	w = doJSON(t, router, http.MethodPost, "/api/match/"+homeMatch.ID+"/complete", nil, newToken(t, fx.commissioner))
+	require.Equal(t, http.StatusBadRequest, w.Code, "complete early: %s", w.Body.String())
+
+	// Record the away score (3-6) then complete the home side -> home wins.
+	w = doJSON(t, router, http.MethodPost, "/api/match/score", map[string]any{
+		"individual_match_id": awayMatch.ID,
+		"main_value":          3,
+		"secondary_value":     6,
+	}, newToken(t, fx.commissioner))
+	require.Equal(t, http.StatusOK, w.Code, "away score: %s", w.Body.String())
+
+	w = doJSON(t, router, http.MethodPost, "/api/match/"+homeMatch.ID+"/complete", nil, newToken(t, fx.commissioner))
+	require.Equal(t, http.StatusOK, w.Code, "complete: %s", w.Body.String())
+
+	// The team match is now complete with a home win.
+	detail = getWeekDetail(t, router, fx)
+	tm = detail.TeamMatches[0]
+	require.True(t, tm.Complete)
+	require.Equal(t, 1, tm.HomeWins)
+	require.Equal(t, 0, tm.AwayWins)
+	require.Equal(t, fx.homeTeam.ID.String(), tm.Winner)
+}
+
+func TestCloseWeek(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	fx := newMatchFixture(t, db)
+
+	w := generateMatches(t, router, fx, newToken(t, fx.commissioner))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	detail := getWeekDetail(t, router, fx)
+	tm := detail.TeamMatches[0]
+
+	// A week with an incomplete match cannot be closed.
+	w = doJSON(t, router, http.MethodPost, "/api/week/"+fx.week.ID.String()+"/close", nil, newToken(t, fx.commissioner))
+	require.Equal(t, http.StatusBadRequest, w.Code, "close incomplete: %s", w.Body.String())
+
+	// Score both sides and complete.
+	homeMatch, awayMatch := tm.Matches[0], tm.Matches[1]
+	score := func(id string, main int) {
+		w := doJSON(t, router, http.MethodPost, "/api/match/score", map[string]any{
+			"individual_match_id": id,
+			"main_value":          main,
+		}, newToken(t, fx.commissioner))
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	}
+	score(homeMatch.ID, 6)
+	score(awayMatch.ID, 3)
+	w = doJSON(t, router, http.MethodPost, "/api/match/"+homeMatch.ID+"/complete", nil, newToken(t, fx.commissioner))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	// An unrelated user cannot close the week.
+	w = doJSON(t, router, http.MethodPost, "/api/week/"+fx.week.ID.String()+"/close", nil, newToken(t, fx.outsider))
+	require.Equal(t, http.StatusForbidden, w.Code, "outsider close: %s", w.Body.String())
+
+	// The commissioner closes the week.
+	w = doJSON(t, router, http.MethodPost, "/api/week/"+fx.week.ID.String()+"/close", nil, newToken(t, fx.commissioner))
+	require.Equal(t, http.StatusOK, w.Code, "close: %s", w.Body.String())
+
+	detail = getWeekDetail(t, router, fx)
+	require.True(t, detail.Closed)
+}
+
+func TestStandings(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	fx := newMatchFixture(t, db)
+
+	w := generateMatches(t, router, fx, newToken(t, fx.commissioner))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	detail := getWeekDetail(t, router, fx)
+	tm := detail.TeamMatches[0]
+	homeMatch, awayMatch := tm.Matches[0], tm.Matches[1]
+
+	// Home wins 6-3.
+	doJSON(t, router, http.MethodPost, "/api/match/score", map[string]any{"individual_match_id": homeMatch.ID, "main_value": 6}, newToken(t, fx.commissioner))
+	doJSON(t, router, http.MethodPost, "/api/match/score", map[string]any{"individual_match_id": awayMatch.ID, "main_value": 3}, newToken(t, fx.commissioner))
+	w = doJSON(t, router, http.MethodPost, "/api/match/"+homeMatch.ID+"/complete", nil, newToken(t, fx.commissioner))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	// Standings reflect the home team's win.
+	w = doJSON(t, router, http.MethodGet, "/api/match/standings?season_id="+fx.season.ID.String(), nil, "")
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var body struct {
+		Resource []*standingsEntry `json:"resource"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	require.Len(t, body.Resource, 2)
+	homeEntry, awayEntry := body.Resource[0], body.Resource[1]
+	if homeEntry.TeamId != fx.homeTeam.ID.String() {
+		homeEntry, awayEntry = awayEntry, homeEntry
+	}
+	require.Equal(t, fx.homeTeam.ID.String(), homeEntry.TeamId)
+	require.Equal(t, 1, homeEntry.Wins)
+	require.Equal(t, 0, homeEntry.Losses)
+	require.Equal(t, fx.awayTeam.ID.String(), awayEntry.TeamId)
+	require.Equal(t, 1, awayEntry.Losses)
+}
+
+type standingsEntry struct {
+	TeamId string `json:"team_id"`
+	Wins   int    `json:"wins"`
+	Losses int    `json:"losses"`
+	Ties   int    `json:"ties"`
+}

--- a/route/match/routes.go
+++ b/route/match/routes.go
@@ -1,0 +1,40 @@
+package match
+
+import (
+	"intraclub/api"
+	"intraclub/database"
+
+	"github.com/gin-gonic/gin"
+)
+
+// RegisterRoutes wires up the Match REST surface.
+//
+// Match scoring is a constrained flow layered on top of the schedule and
+// lineup builders: the season commissioner generates a week's TeamMatches from
+// the scheduled weekly matchups and both teams' official lineups, editors
+// record individual-match scores, and the commissioner closes the week once
+// every team match is complete. The underlying records (IndividualMatch,
+// TeamMatch, TeamMatchIndividualMatch, MatchEditor) are also exposed via
+// generic CRUD in main.go.
+//
+//	POST /match/generate     body: { week_id, scoring_structure_id }
+//	GET  /match/week?week_id=              -> WeekMatchDetail (score sheet)
+//	POST /match/score        body: { individual_match_id, main_value, secondary_value, win_override }
+//	POST /match/:id/complete -> mark an individual match complete (determines winner)
+//	GET  /match/standings?season_id=       -> Standings
+func RegisterRoutes(e *gin.RouterGroup, db database.Provider) {
+	generate := api.RouteFamily[*GenerateBody]{DatabaseProvider: db}
+	generate.Handle(e, GenerateMatches{})
+
+	week := api.RouteFamily[*MatchQuery]{DatabaseProvider: db}
+	week.Handle(e, GetWeekMatches{})
+
+	score := api.RouteFamily[*ScoreBody]{DatabaseProvider: db}
+	score.Handle(e, RecordScore{})
+
+	complete := api.RouteFamily[*EmptyBody]{DatabaseProvider: db}
+	complete.Handle(e, CompleteMatch{})
+
+	standings := api.RouteFamily[*StandingsQuery]{DatabaseProvider: db}
+	standings.Handle(e, GetStandings{})
+}

--- a/route/week/routes.go
+++ b/route/week/routes.go
@@ -28,4 +28,7 @@ func RegisterRoutes(e *gin.RouterGroup, db database.Provider) {
 
 	createFamily := api.RouteFamily[*CreateWeekBody]{DatabaseProvider: db}
 	createFamily.Handle(e, CreateWeek{})
+
+	closeFamily := api.RouteFamily[*CloseWeekBody]{DatabaseProvider: db}
+	closeFamily.Handle(e, CloseWeek{})
 }

--- a/route/week/week.go
+++ b/route/week/week.go
@@ -1,6 +1,7 @@
 package week
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"time"
@@ -142,4 +143,91 @@ func (c ListWeeks) Handler(req api.Request[*WeekQuery]) (any, int, error) {
 		return nil, http.StatusBadRequest, err
 	}
 	return gin.H{api.ResourceKey: weeks}, http.StatusOK, nil
+}
+
+// CloseWeekBody is a placeholder for the CloseWeek route, which carries no body.
+type CloseWeekBody struct{}
+
+// StaticallyValid has no static constraints.
+func (b *CloseWeekBody) StaticallyValid() error { return nil }
+
+// weekHasIncompleteMatch reports whether any team match in the week still has an
+// individual match that has not been decided (won or lost).
+func weekHasIncompleteMatch(ctx context.Context, db database.Provider, weekId model.WeekId) (bool, error) {
+	teamMatches, err := database.GetAllWhere[*model.TeamMatch](ctx, db, func(_ context.Context, tm *model.TeamMatch) bool {
+		return tm.WeekId == weekId
+	})
+	if err != nil {
+		return false, err
+	}
+	if len(teamMatches) == 0 {
+		return true, nil
+	}
+	for _, tm := range teamMatches {
+		rows, err := database.GetAllWhere[*model.TeamMatchIndividualMatch](ctx, db, func(_ context.Context, r *model.TeamMatchIndividualMatch) bool {
+			return r.TeamMatchId == tm.ID
+		})
+		if err != nil {
+			return false, err
+		}
+		for _, row := range rows {
+			im, err := database.GetExistingRecordById(ctx, db, &model.IndividualMatch{}, row.IndividualMatchId.RecordId())
+			if err != nil {
+				return false, err
+			}
+			if im.Status != model.MatchWon && im.Status != model.MatchLost {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+// CloseWeek marks a week closed once every team match in it is complete. Only a
+// season commissioner may close a week; closing is final.
+type CloseWeek struct{}
+
+func (c CloseWeek) Path() (api.HttpMethod, string) {
+	return api.HttpMethodPost, api.AppendPathId(BaseRoute) + "/close"
+}
+
+func (c CloseWeek) RequestBody() (*CloseWeekBody, bool) {
+	return &CloseWeekBody{}, false
+}
+
+func (c CloseWeek) Handler(req api.Request[*CloseWeekBody]) (any, int, error) {
+	if req.Token == nil {
+		return nil, http.StatusUnauthorized, errors.New("token is required")
+	}
+	week, err := database.GetExistingRecordById(req.Context, req.DatabaseProvider, &model.Week{}, req.PathId)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+
+	// Only a season commissioner may close the week; the week's EditableBy
+	// resolves the season's commissioners.
+	authorized := false
+	for _, uid := range week.EditableBy(req.Context, req.DatabaseProvider) {
+		if uid == req.Token.UserId {
+			authorized = true
+			break
+		}
+	}
+	if !authorized {
+		return nil, http.StatusForbidden, errors.New("only a season commissioner may close a week")
+	}
+
+	incomplete, err := weekHasIncompleteMatch(req.Context, req.DatabaseProvider, week.ID)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	if incomplete {
+		return nil, http.StatusBadRequest, errors.New("cannot close a week with incomplete matches")
+	}
+
+	week.Closed = true
+	if err := database.UpdateOne(req.Context, req.DatabaseProvider, week); err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	return gin.H{api.ResourceKey: week}, http.StatusOK, nil
 }


### PR DESCRIPTION
Implements the backend for the matches feature.

**Closes #175 · Closes #176**

## Scope
- **route/match** — generate a week's `TeamMatch`es from scheduled weekly matchups + official lineups, record individual-match scores, complete a match (determine the winner), fetch a week's score sheet, and compute season standings.
- **route/week** — `CloseWeek` endpoint (commissioner-only; requires every team match complete; sets `Week.Closed`).
- **model/week** — `Closed` flag + migration `0053_add_week_closed.sql`.
- **main.go** — register match routes + read-only CRUD for `IndividualMatch`, `TeamMatch`, `TeamMatchIndividualMatch`, `MatchEditor`.

## Fixes
- Standings `computeStandings`/`bump` type mismatches (string vs `TeamId`) so the package builds.
- Match test router now registers week routes so close-week tests hit the real `/api/week/:id/close` route.

## Verification
- `go build ./...` ✅
- `go test ./...` (incl. `route/match` generate/score/complete/close/standings) ✅
- `go vet ./...` ✅
- SQLite round-trips for match records + week `Closed` column ✅