### PR TITLE
UI: weekly standings component

### DIFF
--- a/ui/src/lib/components/Standings.svelte
+++ b/ui/src/lib/components/Standings.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+	import type { StandingsEntry } from '$lib/match';
+	import {
+		Card,
+		CardContent,
+		CardHeader,
+		CardTitle
+	} from '$lib/components/ui/card/index.js';
+
+	let { standings, teamName }: {
+		/** Weekly standings entries (fetched from GET /match/standings?season_id=). */
+		standings: StandingsEntry[];
+		/** Resolves a team id to its display name. */
+		teamName: (teamId: string) => string;
+	} = $props();
+</script>
+
+<Card class="mt-6">
+	<CardHeader>
+		<CardTitle class="text-base">Standings</CardTitle>
+	</CardHeader>
+	<CardContent>
+		{#if standings.length === 0}
+			<p class="text-sm text-muted-foreground">
+				No completed matches yet. Standings update as team matches are completed.
+			</p>
+		{:else}
+			<div class="overflow-x-auto">
+				<table class="w-full text-sm">
+					<thead>
+						<tr class="border-b text-left text-muted-foreground">
+							<th class="py-1 pr-4 font-medium">Team</th>
+							<th class="py-1 pr-4 font-medium">Wins</th>
+							<th class="py-1 pr-4 font-medium">Losses</th>
+							<th class="py-1 pr-4 font-medium">Ties</th>
+						</tr>
+					</thead>
+					<tbody>
+						{#each standings as entry}
+							<tr class="border-b">
+								<td class="py-1 pr-4 font-medium">{teamName(entry.team_id)}</td>
+								<td class="py-1 pr-4">{entry.wins}</td>
+								<td class="py-1 pr-4">{entry.losses}</td>
+								<td class="py-1 pr-4">{entry.ties}</td>
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+			</div>
+		{/if}
+	</CardContent>
+</Card>

--- a/ui/src/routes/seasons/[id]/+page.svelte
+++ b/ui/src/routes/seasons/[id]/+page.svelte
@@ -62,6 +62,7 @@
 	} from '$lib/components/ui/native-select/index.js';
 	import { Checkbox } from '$lib/components/ui/checkbox/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
+	import Standings from '$lib/components/Standings.svelte';
 
 	const id = () => page.params.id as string;
 
@@ -1194,41 +1195,8 @@
 	</Card>
 
 	<!-- Standings -->
-	<Card class="mt-6">
-		<CardHeader>
-			<CardTitle class="text-base">Standings</CardTitle>
-		</CardHeader>
-		<CardContent>
-			{#if standings.length === 0}
-				<p class="text-sm text-muted-foreground">
-					No completed matches yet. Standings update as team matches are completed.
-				</p>
-			{:else}
-				<div class="overflow-x-auto">
-					<table class="w-full text-sm">
-						<thead>
-							<tr class="border-b text-left text-muted-foreground">
-								<th class="py-1 pr-4 font-medium">Team</th>
-								<th class="py-1 pr-4 font-medium">Wins</th>
-								<th class="py-1 pr-4 font-medium">Losses</th>
-								<th class="py-1 pr-4 font-medium">Ties</th>
-							</tr>
-						</thead>
-						<tbody>
-							{#each standings as entry}
-								<tr class="border-b">
-									<td class="py-1 pr-4 font-medium">{teamName(entry.team_id)}</td>
-									<td class="py-1 pr-4">{entry.wins}</td>
-									<td class="py-1 pr-4">{entry.losses}</td>
-									<td class="py-1 pr-4">{entry.ties}</td>
-								</tr>
-							{/each}
-						</tbody>
-					</table>
-				</div>
-			{/if}
-		</CardContent>
-	</Card>
+	<Standings {standings} {teamName} />
+
 
 	{#if teams.length === 0}
 		<p class="mt-6 text-sm text-muted-foreground">No teams have been added to this season yet.</p>


### PR DESCRIPTION
Extract the inline standings table on the season page into a dedicated, reusable `Standings` component.

## Scope
- Standings component on the season page (closes #178).
- Wired to `GET /match/standings?season_id=`.

## Behavior
- The season page still fetches standings via the match API and refreshes them when a match is completed or a week closes, passing the entries into the component as a prop — so standings stay live without re-fetching in the child.
- Empty-state message and table markup preserved.

## Acceptance
- Weekly standings reflect scores per the rules in the UI ✓ (existing backend + e2e)
- Standings update as matches complete and weeks close ✓

## Verification
- `npm run check`: 0 errors / 0 warnings
- `make e2e`: 31 passed (incl. matches standings test)

Closes #178