### PR TITLE
API + UI: Commissioner proposals & votes

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ import (
 	"intraclub/route/lineup"
 	"intraclub/route/match"
 	"intraclub/route/organization"
+	"intraclub/route/proposal"
 	"intraclub/route/ruleset"
 	"intraclub/route/schedule"
 	"intraclub/route/team"
@@ -106,6 +107,19 @@ func main() {
 
 	amendRuleset := api.RouteFamily[*ruleset.AmendNameBody]{DatabaseProvider: db}
 	amendRuleset.Handle(rg, ruleset.AmendRulesetName{})
+
+	// Commissioner proposals are the "manage club rules" feature: a season
+	// commissioner proposes a rule change / administrative action and the
+	// season's participants (commissioners + team captains) ratify it by
+	// majority or unanimous consent. Generic CRUD covers create / list / read /
+	// update / delete of proposals; writes to votes go exclusively through the
+	// custom cast-vote endpoint in route/proposal (which validates the voter is
+	// a season participant), so the vote records are exposed read-only here.
+	proposals := api.NewCrudCommon(model.NewCommissionerProposal, false, db)
+	proposals.HandleRouteTypes(rg, api.CrudWrapperFunctionAll...)
+	proposalVotes := api.NewCrudCommon(func() *model.CommissionerProposalVote { return &model.CommissionerProposalVote{} }, false, db)
+	proposalVotes.HandleRouteTypes(rg, api.CrudWrapperFunctionGetOne, api.CrudWrapperFunctionGetMany)
+	proposal.RegisterRoutes(rg, db)
 
 	rg.GET("/draft_order_patterns", model.GetDraftOrderPatterns)
 

--- a/model/commissioner_proposal.go
+++ b/model/commissioner_proposal.go
@@ -22,10 +22,10 @@ import (
 // field is not a breaking wire change; in-process reads can reassemble the
 // relationship rows into the old map shape via `CommissionerProposal.GetVotes`.
 type CommissionerProposal struct {
-	ID              database.RecordId `json:"id"` // unique ID for this proposal
-	Description     string            // description of the change or action
-	SeasonId        SeasonId          // season that this pertains to
-	MustBeUnanimous bool              // true if this proposal must get unanimous consent to pass
+	ID              database.RecordId `json:"id"`               // unique ID for this proposal
+	Description     string            `json:"description"`      // description of the change or action
+	SeasonId        SeasonId          `json:"season_id"`        // season that this pertains to
+	MustBeUnanimous bool              `json:"must_be_unanimous"` // true if this proposal must get unanimous consent to pass
 }
 
 func (c *CommissionerProposal) GetOwner() database.UserId {
@@ -285,9 +285,9 @@ func (c *CommissionerProposal) NewRecord() database.CrudRecord {
 // migration/backfill.
 type CommissionerProposalVote struct {
 	ID         database.RecordId `json:"id"`
-	ProposalId database.RecordId
-	UserId     database.UserId
-	Vote       bool
+	ProposalId database.RecordId `json:"proposal_id"`
+	UserId     database.UserId   `json:"user_id"`
+	Vote       bool              `json:"vote"`
 }
 
 func (v *CommissionerProposalVote) GetOwner() database.UserId {

--- a/route/proposal/proposal.go
+++ b/route/proposal/proposal.go
@@ -1,0 +1,175 @@
+// Package proposal implements the custom REST surface for
+// model.CommissionerProposal: casting a vote (validating the voter is a season
+// participant) and fetching a proposal's detail/tally. The generic CRUD create
+// / list / update / delete endpoints are registered in main.go.
+package proposal
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"intraclub/api"
+	"intraclub/database"
+	"intraclub/model"
+
+	"github.com/gin-gonic/gin"
+)
+
+// BaseRoute is the base API route for CommissionerProposal records. It matches
+// the model's Type() ("commissioner_proposal").
+var BaseRoute = "/commissioner_proposal"
+
+// ProposalDetail is the read shape returned for a single proposal: the record
+// itself plus its vote tally, the set of eligible voters, the pass/fail status,
+// and (when the requester is eligible) their own vote.
+type ProposalDetail struct {
+	Proposal     *model.CommissionerProposal `json:"proposal"`
+	VotesFor     int                         `json:"votes_for"`
+	VotesAgainst int                         `json:"votes_against"`
+	Voters       []database.UserId           `json:"voters"`
+	Accepted     bool                        `json:"accepted"`
+	Rejected     bool                        `json:"rejected"`
+	// MyVote is the requesting user's vote, if they have cast one yet.
+	MyVote *bool `json:"my_vote,omitempty"`
+}
+
+// RegisterRoutes wires up the custom proposal endpoints.
+func RegisterRoutes(e *gin.RouterGroup, db database.Provider) {
+	voteFamily := api.RouteFamily[*CastVoteBody]{DatabaseProvider: db}
+	voteFamily.Handle(e, CastVote{})
+
+	detailFamily := api.RouteFamily[*EmptyBody]{DatabaseProvider: db}
+	detailFamily.Handle(e, GetProposalDetail{})
+}
+
+// EmptyBody is used by the detail route, which accepts no request body.
+type EmptyBody struct{}
+
+func (b *EmptyBody) StaticallyValid() error {
+	return nil
+}
+
+// CastVoteBody is the request body for CastVote.
+type CastVoteBody struct {
+	// Vote is true for "in favor", false for "against".
+	Vote bool `json:"vote"`
+}
+
+func (b *CastVoteBody) StaticallyValid() error {
+	return nil
+}
+
+// CastVote records the authenticated user's vote on a proposal. The model's
+// Vote method enforces that the voter is a season participant (commissioner or
+// team captain) and that each voter casts at most one vote (subsequent votes
+// update the existing row).
+type CastVote struct{}
+
+func (c CastVote) Path() (api.HttpMethod, string) {
+	return api.HttpMethodPost, api.AppendPathId(BaseRoute) + "/vote"
+}
+
+func (c CastVote) RequestBody() (*CastVoteBody, bool) {
+	return &CastVoteBody{}, true
+}
+
+func (c CastVote) Handler(req api.Request[*CastVoteBody]) (any, int, error) {
+	if req.Token == nil {
+		return nil, http.StatusUnauthorized, errors.New("token is required")
+	}
+
+	proposal, err := database.GetExistingRecordById(req.Context, req.DatabaseProvider, &model.CommissionerProposal{}, req.PathId)
+	if err != nil {
+		return nil, http.StatusNotFound, err
+	}
+
+	if err := proposal.Vote(req.Context, req.DatabaseProvider, req.Token.UserId, req.Body.Vote); err != nil {
+		return nil, http.StatusForbidden, err
+	}
+
+	detail, status, err := buildDetail(req.Context, req.DatabaseProvider, proposal, req.Token.UserId)
+	if err != nil {
+		return nil, status, err
+	}
+	return gin.H{api.ResourceKey: detail}, http.StatusOK, nil
+}
+
+// GetProposalDetail returns a proposal's detail and vote tally to any eligible
+// voter (a commissioner or team captain of the proposal's season).
+type GetProposalDetail struct{}
+
+func (c GetProposalDetail) Path() (api.HttpMethod, string) {
+	return api.HttpMethodGet, api.AppendPathId(BaseRoute) + "/detail"
+}
+
+func (c GetProposalDetail) RequestBody() (*EmptyBody, bool) {
+	return &EmptyBody{}, false
+}
+
+func (c GetProposalDetail) Handler(req api.Request[*EmptyBody]) (any, int, error) {
+	if req.Token == nil {
+		return nil, http.StatusUnauthorized, errors.New("token is required")
+	}
+
+	proposal, err := database.GetExistingRecordById(req.Context, req.DatabaseProvider, &model.CommissionerProposal{}, req.PathId)
+	if err != nil {
+		return nil, http.StatusNotFound, err
+	}
+
+	// Only eligible voters may view the detail/tally.
+	wac := database.NewWithAccessControl[*model.CommissionerProposal](req.Context, req.DatabaseProvider, req.Token.UserId)
+	if !wac.CanUserAccess(proposal) {
+		return nil, http.StatusNotFound, errors.New("proposal not found")
+	}
+
+	detail, status, err := buildDetail(req.Context, req.DatabaseProvider, proposal, req.Token.UserId)
+	if err != nil {
+		return nil, status, err
+	}
+	return gin.H{api.ResourceKey: detail}, http.StatusOK, nil
+}
+
+// buildDetail assembles the ProposalDetail response for a proposal.
+func buildDetail(ctx context.Context, db database.Provider, proposal *model.CommissionerProposal, userId database.UserId) (*ProposalDetail, int, error) {
+	voters, err := proposal.GetAllVoterIds(ctx, db)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+
+	accepted, rejected, err := proposal.Status(ctx, db)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+
+	votes, err := proposal.GetVotes(ctx, db)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+
+	var myVote *bool
+	if v, ok := votes[userId]; ok {
+		vv := v
+		myVote = &vv
+	}
+
+	votesFor := 0
+	votesAgainst := 0
+	for _, v := range votes {
+		if v {
+			votesFor++
+		} else {
+			votesAgainst++
+		}
+	}
+
+	return &ProposalDetail{
+		Proposal:     proposal,
+		VotesFor:     votesFor,
+		VotesAgainst: votesAgainst,
+		Voters:       voters,
+		Accepted:     accepted,
+		Rejected:     rejected,
+		MyVote:       myVote,
+	}, http.StatusOK, nil
+}

--- a/ui/e2e/proposals.spec.ts
+++ b/ui/e2e/proposals.spec.ts
@@ -1,0 +1,165 @@
+import { expect, test, type Page } from '@playwright/test';
+import { waitForHydration } from './helpers';
+
+// The Go backend runs with --dev-token from the repo root (see
+// playwright.config.ts), so POST /api/one_time_password returns the magic-link
+// token in the response body. Login with the user seeded by SeedDevData. This
+// user owns the drafts it creates, and draft owners become the season
+// commissioner (and therefore an eligible voter) on finalize.
+async function login(page: Page) {
+	await page.goto('/login');
+	await page.waitForLoadState('networkidle');
+	await page.getByLabel('Email').fill('jdarthur@gatech.edu');
+	await page.getByRole('button', { name: 'Send login link' }).click();
+	const link = page.getByRole('main').getByRole('link', { name: 'Log in' });
+	await expect(link).toBeVisible();
+	await link.click();
+	await expect(page).toHaveURL('/');
+}
+
+// SeedDevData creates a format named "Men's Intraclub".
+const SEED_FORMAT = "Men's Intraclub";
+const API = 'http://127.0.0.1:8080/api';
+
+test('commissioner can create a proposal, cast a vote, and view the tally', async ({ page }) => {
+	await login(page);
+	const token = await page.evaluate(() => localStorage.getItem('intraclub_jwt') ?? '');
+	expect(token).toBeTruthy();
+
+	const unique = Date.now();
+
+	// One captain plus one roster player is enough to complete a draft.
+	const people = [
+		{ first: `Cap${unique}`, last: 'One' },
+		{ first: `Play${unique}`, last: 'One' }
+	];
+	const csv = [
+		'First Name, Last Name, Email',
+		...people.map((p) => `${p.first}, ${p.last}, ${p.first.toLowerCase()}@example.com`)
+	].join('\n');
+	const importRes = await page.request.post(`${API}/import_users_from_csv`, {
+		form: { file: csv }
+	});
+	expect(importRes.ok()).toBeTruthy();
+	const importBody = await importRes.json();
+	const [captainId, playerId] = [...importBody.Created, ...importBody.AlreadyExisting].map(
+		(u: { id: string }) => u.id
+	);
+
+	const facilityRes = await page.request.post(`${API}/facility`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { name: `Proposal Facility ${unique}`, address: `${unique} Main St`, courts: 4 }
+	});
+	expect(facilityRes.ok()).toBeTruthy();
+	const facilityId = (await facilityRes.json()).resource.id as string;
+
+	const formats = (await (await page.request.get(`${API}/format`)).json()).resource as {
+		id: string;
+		name: string;
+	}[];
+	const format = formats.find((f) => f.name === SEED_FORMAT);
+	expect(format).toBeTruthy();
+
+	const draftRes = await page.request.post(`${API}/draft`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { name: `Proposal Draft ${unique}`, format: format!.id }
+	});
+	expect(draftRes.ok()).toBeTruthy();
+	const draftId = (await draftRes.json()).resource.id as string;
+
+	await page.request.post(`${API}/draft/${draftId}/initialize`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { captains: [captainId] }
+	});
+	await page.request.post(`${API}/draft/${draftId}/assign_draftable_players`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { players: [playerId] }
+	});
+
+	const ratings = (
+		await (
+			await page.request.get(`${API}/format/${format!.id}/possible_ratings`, {
+				headers: { 'X-INTRACLUB-TOKEN': token }
+			})
+		).json()
+	).resource as { id: string }[];
+	// Cutoffs are required for every rating except the last (lowest-skill) one.
+	expect(ratings.length).toBeGreaterThanOrEqual(2);
+	await page.request.post(`${API}/draft/${draftId}/assign_rating_cutoff`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { rating: ratings[0].id, cutoff: 1 }
+	});
+	await page.request.post(`${API}/draft/${draftId}/assign_rating_cutoff`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { rating: ratings[1].id, cutoff: 5 }
+	});
+
+	const captainToken = await tokenFor(page, `${people[0].first.toLowerCase()}@example.com`);
+
+	// The captain drafts the roster player, then themselves -> 2 picks = complete.
+	for (const player of [playerId, captainId]) {
+		const res = await page.request.post(`${API}/draft/${draftId}/select`, {
+			headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': captainToken },
+			data: { player_id: player }
+		});
+		expect(res.ok(), `pick failed: ${await res.text()}`).toBeTruthy();
+	}
+
+	const seasonName = `Season ${unique}`;
+	const seasonRes = await page.request.post(`${API}/draft/${draftId}/create_season`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { name: seasonName, facility: facilityId, start_time: '08:30' }
+	});
+	expect(seasonRes.ok()).toBeTruthy();
+	const seasonId = ((await seasonRes.json()).resource as { id: string }).id;
+
+	// --- commissioner creates a proposal --------------------------------
+	await page.goto(`/seasons/${seasonId}/proposals`);
+	await waitForHydration(page);
+	await expect(
+		page.getByRole('heading', { name: 'Commissioner proposals' })
+	).toBeVisible();
+
+	// The commissioner sees the "New proposal" button.
+	await expect(page.getByRole('button', { name: 'New proposal' })).toBeVisible();
+	await page.getByRole('button', { name: 'New proposal' }).click();
+
+	const description = `Change the scoring format ${unique}`;
+	await page.getByLabel('Description').fill(description);
+	await page.getByRole('button', { name: 'Create proposal' }).click();
+
+	// The new proposal appears in the list.
+	await expect(page.getByText(description)).toBeVisible();
+	await expect(page.getByText('Pending')).toBeVisible();
+
+	// --- cast a vote + view the tally ------------------------------------
+	await page.getByRole('link', { name: 'View' }).click();
+	await page.waitForURL(`/seasons/${seasonId}/proposals/*`);
+	await waitForHydration(page);
+
+	// The commissioner is an eligible voter and can cast a vote.
+	await expect(page.getByRole('button', { name: 'Vote for' })).toBeVisible();
+	await page.getByRole('button', { name: 'Vote for' }).click();
+
+	await expect(page.getByText('Your vote:')).toBeVisible();
+	await expect(page.getByText('For', { exact: true })).toBeVisible();
+	await expect(page.getByText('1 for')).toBeVisible();
+	await expect(page.getByText('0 against')).toBeVisible();
+	await expect(page.getByText('2 eligible voters')).toBeVisible();
+
+	// Clean up the draft so the table doesn't accumulate rows across runs.
+	const cleanup = await page.request.delete(`${API}/draft/${draftId}`, {
+		headers: { 'X-INTRACLUB-TOKEN': token }
+	});
+	expect(cleanup.ok()).toBeTruthy();
+});
+
+async function tokenFor(page: Page, email: string): Promise<string> {
+	const res = await page.request.post(`${API}/one_time_password`, { data: { email } });
+	expect(res.ok()).toBeTruthy();
+	const { token } = await res.json();
+	const jwtRes = await page.request.post(`${API}/token`, { data: { token } });
+	expect(jwtRes.ok()).toBeTruthy();
+	const { jwt } = await jwtRes.json();
+	return jwt;
+}

--- a/ui/src/lib/commissionerProposal.ts
+++ b/ui/src/lib/commissionerProposal.ts
@@ -1,0 +1,85 @@
+// Commissioner proposal API client. Backed by the CRUD routes registered in
+// main.go plus the custom detail / vote endpoints in route/proposal:
+//
+//	GET    /api/commissioner_proposal        -> { resource: CommissionerProposal[] }
+//	POST   /api/commissioner_proposal        -> { resource: CommissionerProposal }
+//	GET    /api/commissioner_proposal/:id    -> { resource: CommissionerProposal }
+//	PUT    /api/commissioner_proposal/:id    -> { resource: CommissionerProposal }
+//	DELETE /api/commissioner_proposal/:id    -> { resource: CommissionerProposal }
+//	GET    /api/commissioner_proposal/:id/detail -> { resource: ProposalDetail }
+//	POST   /api/commissioner_proposal/:id/vote   -> { resource: ProposalDetail }
+//
+// Proposals are season-scoped; a commissioner creates them and the season's
+// participants (commissioners + team captains) ratify them. Record IDs are
+// 16-char hex strings.
+import { authFetch } from '$lib/auth';
+
+export interface CommissionerProposal {
+	id: string;
+	description: string;
+	season_id: string;
+	must_be_unanimous: boolean;
+}
+
+export interface ProposalDetail {
+	proposal: CommissionerProposal;
+	votes_for: number;
+	votes_against: number;
+	voters: string[];
+	accepted: boolean;
+	rejected: boolean;
+	my_vote?: boolean;
+}
+
+export interface ProposalInput {
+	description: string;
+	season_id: string;
+	must_be_unanimous: boolean;
+}
+
+const BASE = '/api/commissioner_proposal';
+
+// unwrap parses a CrudCommon response (`{ resource: ... }`) and throws the
+// backend error message on non-2xx responses so callers can surface it.
+async function unwrap(res: Response): Promise<any> {
+	if (!res.ok) {
+		let message = `Request failed (${res.status})`;
+		try {
+			const body = await res.json();
+			if (body?.error) message = body.error;
+		} catch {
+			// non-JSON error body; fall back to the status message
+		}
+		throw new Error(message);
+	}
+	const body = await res.json();
+	return body?.resource;
+}
+
+export async function listProposals(): Promise<CommissionerProposal[]> {
+	return unwrap(await authFetch(BASE));
+}
+
+export async function createProposal(input: ProposalInput): Promise<CommissionerProposal> {
+	return unwrap(
+		await authFetch(BASE, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(input)
+		})
+	);
+}
+
+export async function getProposalDetail(id: string): Promise<ProposalDetail> {
+	return unwrap(await authFetch(`${BASE}/${id}/detail`));
+}
+
+export async function castVote(id: string, vote: boolean): Promise<ProposalDetail> {
+	return unwrap(
+		await authFetch(`${BASE}/${id}/vote`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ vote })
+		})
+	);
+}

--- a/ui/src/routes/seasons/[id]/+page.svelte
+++ b/ui/src/routes/seasons/[id]/+page.svelte
@@ -583,6 +583,12 @@
 	<h1 class="text-2xl font-semibold tracking-tight">{season?.name ?? 'Season'}</h1>
 	<div class="ml-auto flex items-center gap-3">
 		{#if season}
+			<a
+				href={`/seasons/${season.id}/proposals`}
+				class="text-sm text-muted-foreground hover:text-foreground"
+			>
+				Commissioner proposals
+			</a>
 			<a href={`/drafts/${season.draft_id}`} class="text-sm text-muted-foreground hover:text-foreground">
 				&larr; View draft
 			</a>

--- a/ui/src/routes/seasons/[id]/proposals/+page.svelte
+++ b/ui/src/routes/seasons/[id]/proposals/+page.svelte
@@ -1,0 +1,200 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { page } from '$app/state';
+	import { getSeason } from '$lib/season';
+	import type { Season } from '$lib/season';
+	import { getScheduleForSeason } from '$lib/schedule';
+	import type { ScheduleDetail } from '$lib/schedule';
+	import {
+		listProposals,
+		createProposal,
+		getProposalDetail
+	} from '$lib/commissionerProposal';
+	import type { CommissionerProposal, ProposalDetail } from '$lib/commissionerProposal';
+	import { getCurrentUserId } from '$lib/auth';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import {
+		Card,
+		CardContent,
+		CardHeader,
+		CardTitle
+	} from '$lib/components/ui/card/index.js';
+	import { Badge } from '$lib/components/ui/badge/index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
+	import { Textarea } from '$lib/components/ui/textarea/index.js';
+	import { Checkbox } from '$lib/components/ui/checkbox/index.js';
+
+	const id = () => page.params.id as string;
+
+	let season = $state<Season | null>(null);
+	let schedule = $state<ScheduleDetail | null>(null);
+	let details = $state<Record<string, ProposalDetail>>({});
+	let loading = $state(true);
+	let loadError = $state('');
+
+	// create-proposal form state
+	let showCreate = $state(false);
+	let description = $state('');
+	let mustBeUnanimous = $state(false);
+	let creating = $state(false);
+	let createError = $state('');
+
+	const isCommissioner = $derived(
+		schedule !== null && schedule.commissioners.includes(getCurrentUserId() ?? '')
+	);
+
+	async function load() {
+		loading = true;
+		loadError = '';
+		try {
+			const [seasonData, scheduleData, proposals] = await Promise.all([
+				getSeason(id()),
+				getScheduleForSeason(id()),
+				listProposals()
+			]);
+			season = seasonData;
+			schedule = scheduleData;
+			const seasonProposals = proposals.filter((p) => p.season_id === seasonData.id);
+			const detailMap: Record<string, ProposalDetail> = {};
+			for (const p of seasonProposals) {
+				try {
+					detailMap[p.id] = await getProposalDetail(p.id);
+				} catch {
+					// an eligible user can always fetch detail; skip on transient error
+				}
+			}
+			details = detailMap;
+		} catch (e) {
+			loadError = e instanceof Error ? e.message : 'Failed to load proposals';
+		} finally {
+			loading = false;
+		}
+	}
+
+	onMount(load);
+
+	async function submitCreate() {
+		createError = '';
+		creating = true;
+		try {
+			await createProposal({
+				description,
+				season_id: id(),
+				must_be_unanimous: mustBeUnanimous
+			});
+			description = '';
+			mustBeUnanimous = false;
+			showCreate = false;
+			await load();
+		} catch (e) {
+			createError = e instanceof Error ? e.message : 'Failed to create proposal';
+		} finally {
+			creating = false;
+		}
+	}
+
+	function statusLabel(d: ProposalDetail): { text: string; variant: 'default' | 'destructive' | 'secondary' } {
+		if (d.accepted) return { text: 'Accepted', variant: 'default' };
+		if (d.rejected) return { text: 'Rejected', variant: 'destructive' };
+		return { text: 'Pending', variant: 'secondary' };
+	}
+</script>
+
+<svelte:head>
+	<title>Intraclub | {season?.name ?? 'Season'} proposals</title>
+</svelte:head>
+
+<div class="flex items-center justify-between gap-4">
+	<div>
+		<h1 class="text-2xl font-semibold tracking-tight">Commissioner proposals</h1>
+		{#if season}
+			<p class="text-sm text-muted-foreground">{season.name}</p>
+		{/if}
+	</div>
+	{#if isCommissioner}
+		<Button type="button" onclick={() => (showCreate = !showCreate)}>
+			{showCreate ? 'Cancel' : 'New proposal'}
+		</Button>
+	{/if}
+</div>
+
+{#if loading}
+	<p class="text-muted-foreground">Loading...</p>
+{:else if loadError}
+	<p class="text-sm font-medium text-destructive">{loadError}</p>
+{:else}
+	{#if showCreate}
+		<Card class="mt-6">
+			<CardHeader>
+				<CardTitle class="text-base">New proposal</CardTitle>
+			</CardHeader>
+			<CardContent>
+				{#if createError}
+					<p class="mb-4 text-sm font-medium text-destructive">{createError}</p>
+				{/if}
+				<div class="flex flex-col gap-4">
+					<div class="flex flex-col gap-1">
+						<Label for="proposal-description">Description</Label>
+						<Textarea
+							id="proposal-description"
+							placeholder="Describe the rule change or administrative action…"
+							bind:value={description}
+							required
+						/>
+					</div>
+					<div class="flex items-center gap-2">
+						<Checkbox checked={mustBeUnanimous} onCheckedChange={(c) => (mustBeUnanimous = !!c)} />
+						<Label class="text-sm">Require unanimous consent</Label>
+					</div>
+					<div>
+						<Button
+							type="button"
+							disabled={creating || description.trim().length === 0}
+							onclick={submitCreate}
+						>
+							{creating ? 'Creating…' : 'Create proposal'}
+						</Button>
+					</div>
+				</div>
+			</CardContent>
+		</Card>
+	{/if}
+
+	{#if Object.keys(details).length === 0}
+		<p class="mt-6 text-muted-foreground">No proposals for this season yet.</p>
+	{:else}
+		<div class="mt-6 flex flex-col gap-4">
+			{#each Object.values(details) as detail (detail.proposal.id)}
+				{@const st = statusLabel(detail)}
+				<Card>
+					<CardContent class="pt-6">
+						<div class="flex items-start justify-between gap-4">
+							<div class="flex-1">
+								<p class="font-medium">{detail.proposal.description}</p>
+								<div class="mt-1 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+									<Badge variant={st.variant}>{st.text}</Badge>
+									<span>
+										{detail.votes_for} for · {detail.votes_against} against
+									</span>
+									{#if detail.proposal.must_be_unanimous}
+										<span>· unanimous</span>
+									{:else}
+										<span>· majority</span>
+									{/if}
+								</div>
+							</div>
+							<Button
+								type="button"
+								variant="outline"
+								size="sm"
+								href={`/seasons/${id()}/proposals/${detail.proposal.id}`}
+							>
+								View
+							</Button>
+						</div>
+					</CardContent>
+				</Card>
+			{/each}
+		</div>
+	{/if}
+{/if}

--- a/ui/src/routes/seasons/[id]/proposals/[proposalId]/+page.svelte
+++ b/ui/src/routes/seasons/[id]/proposals/[proposalId]/+page.svelte
@@ -1,0 +1,162 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { page } from '$app/state';
+	import { getSeason } from '$lib/season';
+	import type { Season } from '$lib/season';
+	import { getProposalDetail, castVote } from '$lib/commissionerProposal';
+	import type { ProposalDetail } from '$lib/commissionerProposal';
+	import { getCurrentUserId } from '$lib/auth';
+	import {
+		Card,
+		CardContent,
+		CardHeader,
+		CardTitle
+	} from '$lib/components/ui/card/index.js';
+	import { Badge } from '$lib/components/ui/badge/index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
+
+	const seasonId = () => page.params.id as string;
+	const proposalId = () => page.params.proposalId as string;
+
+	let season = $state<Season | null>(null);
+	let detail = $state<ProposalDetail | null>(null);
+	let loading = $state(true);
+	let loadError = $state('');
+	let voting = $state<'for' | 'against' | null>(null);
+	let voteError = $state('');
+
+	const currentUserId = $derived(getCurrentUserId() ?? '');
+	const isVoter = $derived(detail !== null && detail.voters.includes(currentUserId));
+
+	async function load() {
+		loading = true;
+		loadError = '';
+		try {
+			const [seasonData, d] = await Promise.all([
+				getSeason(seasonId()),
+				getProposalDetail(proposalId())
+			]);
+			season = seasonData;
+			detail = d;
+		} catch (e) {
+			loadError = e instanceof Error ? e.message : 'Failed to load proposal';
+		} finally {
+			loading = false;
+		}
+	}
+
+	onMount(load);
+
+	async function submitVote(vote: boolean) {
+		voteError = '';
+		voting = vote ? 'for' : 'against';
+		try {
+			detail = await castVote(proposalId(), vote);
+		} catch (e) {
+			voteError = e instanceof Error ? e.message : 'Failed to cast vote';
+		} finally {
+			voting = null;
+		}
+	}
+
+	function statusLabel(): { text: string; variant: 'default' | 'destructive' | 'secondary' } {
+		if (!detail) return { text: 'Pending', variant: 'secondary' };
+		if (detail.accepted) return { text: 'Accepted', variant: 'default' };
+		if (detail.rejected) return { text: 'Rejected', variant: 'destructive' };
+		return { text: 'Pending', variant: 'secondary' };
+	}
+</script>
+
+<svelte:head>
+	<title>Intraclub | Proposal</title>
+</svelte:head>
+
+{#if loading}
+	<p class="text-muted-foreground">Loading...</p>
+{:else if loadError}
+	<p class="text-sm font-medium text-destructive">{loadError}</p>
+{:else if detail}
+	<div class="flex items-center justify-between gap-4">
+		<div>
+			<h1 class="text-2xl font-semibold tracking-tight">Commissioner proposal</h1>
+			{#if season}
+				<p class="text-sm text-muted-foreground">{season.name}</p>
+			{/if}
+		</div>
+		<Button type="button" variant="outline" href={`/seasons/${seasonId()}/proposals`}>
+			Back to proposals
+		</Button>
+	</div>
+
+	<Card class="mt-6">
+		<CardHeader>
+			<CardTitle class="text-base">Proposal</CardTitle>
+		</CardHeader>
+		<CardContent>
+			{@const st = statusLabel()}
+			<p class="text-sm">{detail.proposal.description}</p>
+			<div class="mt-3 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+				<Badge variant={st.variant}>{st.text}</Badge>
+				{#if detail.proposal.must_be_unanimous}
+					<Badge variant="outline">Unanimous consent</Badge>
+				{:else}
+					<Badge variant="outline">Majority consent</Badge>
+				{/if}
+			</div>
+		</CardContent>
+	</Card>
+
+	<Card class="mt-6">
+		<CardHeader>
+			<CardTitle class="text-base">Vote tally</CardTitle>
+		</CardHeader>
+		<CardContent>
+			<div class="flex items-center gap-6 text-sm">
+				<span class="font-medium text-emerald-600">{detail.votes_for} for</span>
+				<span class="font-medium text-destructive">{detail.votes_against} against</span>
+				<span class="text-muted-foreground">{detail.voters.length} eligible voters</span>
+			</div>
+
+			{#if voteError}
+				<p class="mt-4 text-sm font-medium text-destructive">{voteError}</p>
+			{/if}
+
+			{#if isVoter}
+				<div class="mt-4 flex flex-wrap items-center gap-2">
+					<span class="text-sm text-muted-foreground">Your vote:</span>
+					{#if detail.my_vote === undefined}
+						<span class="text-sm">Not cast yet</span>
+					{:else}
+						<span class="text-sm font-medium">
+							{detail.my_vote ? 'For' : 'Against'}
+						</span>
+					{/if}
+					<div class="ml-2 flex items-center gap-2">
+						<Button
+							type="button"
+							size="sm"
+							variant={detail.my_vote === true ? 'default' : 'outline'}
+							disabled={voting !== null}
+							onclick={() => submitVote(true)}
+						>
+							{voting === 'for' ? 'Voting…' : 'Vote for'}
+						</Button>
+						<Button
+							type="button"
+							size="sm"
+							variant={detail.my_vote === false ? 'default' : 'outline'}
+							disabled={voting !== null}
+							onclick={() => submitVote(false)}
+						>
+							{voting === 'against' ? 'Voting…' : 'Vote against'}
+						</Button>
+					</div>
+				</div>
+			{:else}
+				<p class="mt-4 text-sm text-muted-foreground">
+					Only commissioners and team captains of this season can vote.
+				</p>
+			{/if}
+		</CardContent>
+	</Card>
+{/if}


### PR DESCRIPTION
Closes #159

Implements the commissioner-proposal feature (manage club rules via season-scoped proposals):

## API
- Registered full CRUD for `CommissionerProposal` (`/api/commissioner_proposal`) and read-only CRUD for `CommissionerProposalVote`.
- New custom endpoints in `route/proposal`:
  - `POST /api/commissioner_proposal/:id/vote` — casts the authenticated user's vote, validating (via `model.CommissionerProposal.Vote`) that the voter is a season participant (commissioner or team captain).
  - `GET /api/commissioner_proposal/:id/detail` — returns the proposal plus vote tally, eligible voters, pass/fail status, and the requester's vote.
- Added snake_case JSON tags to `CommissionerProposal` and `CommissionerProposalVote` so responses follow the project's wire convention.

## UI
- `/seasons/[id]/proposals` — season-scoped proposals list with a commissioner-only create form.
- `/seasons/[id]/proposals/[proposalId]` — proposal detail with status, vote tally, and cast-vote buttons for eligible voters.
- Added a `Commissioner proposals` link on the season detail page.

## Tests
- Added `ui/e2e/proposals.spec.ts` covering: commissioner creates a proposal, casts a vote, and views the updated tally.
- `make tests` (go vet + go test) green; `make e2e` green (32/32).