### PR TITLE
API + UI: manage ruleset sections & amendments (#160)

### DIFF
--- a/main.go
+++ b/main.go
@@ -108,6 +108,21 @@ func main() {
 	amendRuleset := api.RouteFamily[*ruleset.AmendNameBody]{DatabaseProvider: db}
 	amendRuleset.Handle(rg, ruleset.AmendRulesetName{})
 
+	// RuleSections are the individual rule blocks (title + markdown) that make
+	// up a ruleset; RulesetSections are the join-table records that order them
+	// within a ruleset via SectionIndex. Both are exposed via generic CRUD for
+	// read/admin access, but section edits from the UI go through the
+	// amend_sections route below (which applies a RuleAmendment through the
+	// Ruleset.Amend flow, producing new revisions and preserving ordering).
+	ruleSections := api.NewCrudCommon(func() *model.RuleSection { return &model.RuleSection{} }, false, db)
+	ruleSections.HandleRouteTypes(rg, api.CrudWrapperFunctionAll...)
+
+	rulesetSections := api.NewCrudCommon(func() *model.RulesetSection { return &model.RulesetSection{} }, false, db)
+	rulesetSections.HandleRouteTypes(rg, api.CrudWrapperFunctionAll...)
+
+	amendRulesetSections := api.RouteFamily[*model.RuleAmendment]{DatabaseProvider: db}
+	amendRulesetSections.Handle(rg, ruleset.AmendSections{})
+
 	// Commissioner proposals are the "manage club rules" feature: a season
 	// commissioner proposes a rule change / administrative action and the
 	// season's participants (commissioners + team captains) ratify it by

--- a/model/rule_amendment.go
+++ b/model/rule_amendment.go
@@ -216,19 +216,24 @@ func (r *Ruleset) HandleReorderSection(ctx context.Context, db database.Provider
 		}
 	}
 
-	// Build new ordered list by inserting target after the "After" section
+	// Build new ordered list by inserting target after the "After" section.
+	// An empty After moves the target to the front of the list.
 	var newRelations []*RulesetSection
-	found := false
-	for _, sr := range otherRelations {
-		newRelations = append(newRelations, sr)
-		if sr.SectionId == a.After {
-			newRelations = append(newRelations, targetRelation)
-			found = true
+	if a.After.Empty() {
+		newRelations = append(newRelations, targetRelation)
+		newRelations = append(newRelations, otherRelations...)
+	} else {
+		found := false
+		for _, sr := range otherRelations {
+			newRelations = append(newRelations, sr)
+			if sr.SectionId == a.After {
+				newRelations = append(newRelations, targetRelation)
+				found = true
+			}
 		}
-	}
-
-	if !found {
-		return nil, fmt.Errorf("after section ID %s was not found in ruleset %s", a.After, r.ID)
+		if !found {
+			return nil, fmt.Errorf("after section ID %s was not found in ruleset %s", a.After, r.ID)
+		}
 	}
 
 	// Update section indices for all relations

--- a/model/ruleset.go
+++ b/model/ruleset.go
@@ -14,9 +14,13 @@ import (
 // RulesetId is a unique identifier for the Ruleset type
 type RulesetId database.RecordId
 
-func (id RulesetId) UnmarshalJSON(bytes []byte) error {
+func (id *RulesetId) UnmarshalJSON(bytes []byte) error {
 	rid := id.RecordId()
-	return (*database.RecordId)(&rid).UnmarshalJSON(bytes)
+	if err := (*database.RecordId)(&rid).UnmarshalJSON(bytes); err != nil {
+		return err
+	}
+	*id = RulesetId(rid)
+	return nil
 }
 
 func (id RulesetId) MarshalJSON() ([]byte, error) {
@@ -385,9 +389,13 @@ func (r *Ruleset) EditName(ctx context.Context, db database.Provider, newName st
 
 type RuleSectionId database.RecordId
 
-func (id RuleSectionId) UnmarshalJSON(bytes []byte) error {
+func (id *RuleSectionId) UnmarshalJSON(bytes []byte) error {
 	rid := id.RecordId()
-	return (*database.RecordId)(&rid).UnmarshalJSON(bytes)
+	if err := (*database.RecordId)(&rid).UnmarshalJSON(bytes); err != nil {
+		return err
+	}
+	*id = RuleSectionId(rid)
+	return nil
 }
 
 func (id RuleSectionId) MarshalJSON() ([]byte, error) {

--- a/model/ruleset_test.go
+++ b/model/ruleset_test.go
@@ -226,8 +226,115 @@ func TestSupersededByOwnerMustBeIdentical(t *testing.T) {
 
 }
 
-func TestRulesetPostDeleteCascadesChildren(t *testing.T) {
+func TestRuleSectionIdJSONRoundTrip(t *testing.T) {
+	// RuleSectionId / RulesetId must be parsed back from JSON bodies (used by
+	// the RuleAmendment request). A value-receiver UnmarshalJSON silently
+	// discards the parsed value, so this guards the pointer-receiver fix.
+	rid, err := database.RecordIdFromString("1234567890abcdef")
+	if err != nil {
+		t.Fatal(err)
+	}
+	id := RuleSectionId(rid)
+	raw, err := id.MarshalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var parsed RuleSectionId
+	if err := parsed.UnmarshalJSON(raw); err != nil {
+		t.Fatal(err)
+	}
+	if parsed != id {
+		t.Fatalf("expected %s after round trip, got %s", id, parsed)
+	}
+}
+
+func TestRulesetIdJSONRoundTrip(t *testing.T) {
+	rid, err := database.RecordIdFromString("fedcba9876543210")
+	if err != nil {
+		t.Fatal(err)
+	}
+	id := RulesetId(rid)
+	raw, err := id.MarshalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var parsed RulesetId
+	if err := parsed.UnmarshalJSON(raw); err != nil {
+		t.Fatal(err)
+	}
+	if parsed != id {
+		t.Fatalf("expected %s after round trip, got %s", id, parsed)
+	}
+}
+
+func TestRulesetReorderSectionToFront(t *testing.T) {
 	db := database.NewUnitTestDBProvider()
+	ruleset := newValidStoredRulesetWithXSections(t, db, 3)
+
+	sections, err := ruleset.GetSections(context.Background(), db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sections) != 3 {
+		t.Fatalf("expected 3 sections, got %d", len(sections))
+	}
+	first, second := sections[0], sections[1]
+
+	// Move the second section to the front (empty After).
+	amended, err := ruleset.Amend(context.Background(), db, &RuleAmendment{
+		Type:          RuleAmendmentTypeReorderSection,
+		TargetSection: second,
+		After:         RuleSectionId(database.InvalidRecordId),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error reordering section to front: %s", err)
+	}
+
+	got, err := amended.GetSections(context.Background(), db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 sections after reorder, got %d", len(got))
+	}
+	if got[0] != second || got[1] != first {
+		t.Fatalf("expected [%s %s ...] after reorder, got [%s %s ...]", second, first, got[0], got[1])
+	}
+}
+
+func TestRulesetReorderSectionAfter(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	ruleset := newValidStoredRulesetWithXSections(t, db, 3)
+
+	sections, err := ruleset.GetSections(context.Background(), db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, third := sections[0], sections[2]
+
+	// Move the first section after the third (to the end).
+	amended, err := ruleset.Amend(context.Background(), db, &RuleAmendment{
+		Type:          RuleAmendmentTypeReorderSection,
+		TargetSection: first,
+		After:         third,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error reordering section: %s", err)
+	}
+
+	got, err := amended.GetSections(context.Background(), db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 sections after reorder, got %d", len(got))
+	}
+	if got[2] != first {
+		t.Fatalf("expected first section to move to end, got last %s", got[2])
+	}
+}
+
+func TestRulesetPostDeleteCascadesChildren(t *testing.T) {	db := database.NewUnitTestDBProvider()
 	ruleset := newValidStoredRuleset(t, db)
 
 	section := &RuleSection{Parent: ruleset.ID, Title: "title", Markdown: "contents", Owner: ruleset.Owner}

--- a/route/ruleset/amend_sections.go
+++ b/route/ruleset/amend_sections.go
@@ -1,0 +1,52 @@
+package ruleset
+
+import (
+	"errors"
+	"net/http"
+
+	"intraclub/api"
+	"intraclub/database"
+	"intraclub/model"
+
+	"github.com/gin-gonic/gin"
+)
+
+// AmendSections applies a RuleAmendment (add / remove / modify / reorder a
+// section) to a Ruleset. Rulesets may not be directly modified
+// (Ruleset.PreUpdate forbids it), so section edits go through the
+// Ruleset.Amend flow: add/remove/reorder produce a new superseding revision,
+// while a pure content edit updates the section in place. Returns the (possibly
+// new) Ruleset revision.
+type AmendSections struct{}
+
+func (c AmendSections) Path() (api.HttpMethod, string) {
+	return api.HttpMethodPut, api.AppendPathId(BaseRoute) + "/amend_sections"
+}
+
+func (c AmendSections) RequestBody() (*model.RuleAmendment, bool) {
+	return &model.RuleAmendment{}, true
+}
+
+func (c AmendSections) Handler(req api.Request[*model.RuleAmendment]) (any, int, error) {
+	if req.Token == nil {
+		return nil, http.StatusUnauthorized, errors.New("token is required to amend a ruleset")
+	}
+
+	ruleset, err := database.GetExistingRecordById(req.Context, req.DatabaseProvider, &model.Ruleset{}, req.PathId)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+
+	// enforce per-record edit authorization (owner / sysadmin)
+	wac := database.NewWithAccessControl[*model.Ruleset](req.Context, req.DatabaseProvider, req.Token.UserId)
+	if !wac.CanUserEdit(ruleset) {
+		return nil, http.StatusForbidden, errors.New("not authorized to amend this ruleset")
+	}
+
+	newRuleset, err := ruleset.Amend(req.Context, req.DatabaseProvider, req.Body)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+
+	return gin.H{api.ResourceKey: newRuleset}, http.StatusOK, nil
+}

--- a/ui/e2e/ruleset.spec.ts
+++ b/ui/e2e/ruleset.spec.ts
@@ -62,3 +62,48 @@ test('ruleset CRUD: create, view, amend (update), delete', async ({ page }) => {
 	await expect(page).toHaveURL('/rulesets');
 	await expect(page.getByRole('link', { name: `Test Ruleset ${unique} Amended` })).toHaveCount(0);
 });
+
+test('ruleset sections: add, edit, reorder', async ({ page }) => {
+	await login(page);
+
+	const unique = Date.now();
+
+	// Create a ruleset
+	await page.goto('/rulesets');
+	await page.getByRole('link', { name: 'New ruleset' }).click();
+	await expect(page).toHaveURL(/\/rulesets\/new$/);
+	await waitForHydration(page);
+	await page.getByLabel('Name').fill(`Section Test ${unique}`);
+	await page.getByRole('button', { name: 'Create ruleset' }).click();
+	await expect(page.getByRole('heading', { name: `Section Test ${unique}` })).toBeVisible();
+
+	// Add two sections
+	await page.getByLabel('Title').fill('First Section');
+	await page.getByLabel('Contents').fill('First contents');
+	await page.getByRole('button', { name: 'Add section' }).click();
+	await expect(page.getByText('1. First Section')).toBeVisible();
+	await expect(page.getByText('First contents')).toBeVisible();
+	// Adding a section amends the ruleset into a new revision and navigates to
+	// it; wait for that revision's data fetches to settle so the next add reads
+	// the current section list.
+	await waitForHydration(page);
+
+	await page.getByLabel('Title').fill('Second Section');
+	await page.getByLabel('Contents').fill('Second contents');
+	await page.getByRole('button', { name: 'Add section' }).click();
+	await expect(page.getByText('2. Second Section')).toBeVisible();
+
+	// Edit the first section (rename it)
+	const firstRow = page.locator('li', { hasText: 'First Section' });
+	await firstRow.getByRole('button', { name: 'Edit' }).click();
+	await page.locator('input[id^="edit-title-"]').fill('Renamed Section');
+	await page.getByRole('button', { name: 'Save section' }).click();
+	await expect(page.getByText('1. Renamed Section')).toBeVisible();
+
+	// Reorder: move the second section up so it becomes the first
+	const secondRow = page.locator('li', { hasText: 'Second Section' });
+	await secondRow.getByRole('button', { name: '↑' }).click();
+	await expect(page.getByText('1. Second Section')).toBeVisible();
+	await expect(page.getByText('2. Renamed Section')).toBeVisible();
+});
+

--- a/ui/src/lib/ruleset.ts
+++ b/ui/src/lib/ruleset.ts
@@ -84,3 +84,72 @@ export async function deleteRuleset(id: string): Promise<void> {
 		throw new Error(message);
 	}
 }
+
+// A RuleSection is a single rule block (title + markdown) belonging to a
+// ruleset. Sections are exposed via generic CRUD (see main.go).
+export interface RuleSection {
+	section_id: string;
+	parent: string;
+	title: string;
+	markdown: string;
+	owner: string;
+}
+
+// A RulesetSection is the join-table record that orders a RuleSection within a
+// ruleset. SectionIndex preserves the ordering.
+export interface RulesetSection {
+	id: string;
+	ruleset_id: string;
+	section_id: string;
+	section_index: number;
+}
+
+// RuleAmendmentType values mirror the Go enum in model/rule_amendment.go.
+export const RULE_AMENDMENT_ADD = 0;
+export const RULE_AMENDMENT_REMOVE = 1;
+export const RULE_AMENDMENT_MODIFY = 2;
+export const RULE_AMENDMENT_REORDER = 3;
+
+export interface RuleAmendment {
+	type: number;
+	target_section?: string;
+	new_section?: Partial<RuleSection>;
+	after?: string;
+}
+
+const RULE_SECTION_BASE = '/api/rule_section';
+const RULESET_SECTION_BASE = '/api/ruleset_section';
+
+export async function listRuleSections(): Promise<RuleSection[]> {
+	return unwrap(await authFetch(RULE_SECTION_BASE));
+}
+
+export async function listRulesetSections(): Promise<RulesetSection[]> {
+	return unwrap(await authFetch(RULESET_SECTION_BASE));
+}
+
+// getRulesetSections returns the sections of a ruleset, in order (as enforced
+// by SectionIndex in the RulesetSection join table).
+export async function getRulesetSections(rulesetId: string): Promise<RuleSection[]> {
+	const [sections, relations] = await Promise.all([listRuleSections(), listRulesetSections()]);
+	const ordered = relations
+		.filter((r) => r.ruleset_id === rulesetId)
+		.sort((a, b) => a.section_index - b.section_index);
+	return ordered
+		.map((r) => sections.find((s) => s.section_id === r.section_id))
+		.filter((s): s is RuleSection => !!s);
+}
+
+// amendSections applies a RuleAmendment (add / remove / modify / reorder
+// section) to a ruleset and returns the resulting Ruleset. Add/remove/reorder
+// may produce a new superseding revision; a pure content edit updates the
+// section in place.
+export async function amendSections(id: string, amendment: RuleAmendment): Promise<Ruleset> {
+	return unwrap(
+		await authFetch(`${BASE}/${id}/amend_sections`, {
+			method: 'PUT',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(amendment)
+		})
+	);
+}

--- a/ui/src/routes/rulesets/[id]/+page.svelte
+++ b/ui/src/routes/rulesets/[id]/+page.svelte
@@ -1,12 +1,24 @@
 <script lang="ts">
 	import { page } from '$app/state';
 	import { goto } from '$app/navigation';
-	import { getRuleset, amendRulesetName, deleteRuleset } from '$lib/ruleset';
-	import type { Ruleset } from '$lib/ruleset';
+	import {
+		getRuleset,
+		amendRulesetName,
+		deleteRuleset,
+		getRulesetSections,
+		amendSections,
+		type Ruleset,
+		type RuleSection,
+		RULE_AMENDMENT_ADD,
+		RULE_AMENDMENT_REMOVE,
+		RULE_AMENDMENT_MODIFY,
+		RULE_AMENDMENT_REORDER
+	} from '$lib/ruleset';
 	import { Button, buttonVariants } from '$lib/components/ui/button/index.js';
 	import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
 	import { Label } from '$lib/components/ui/label/index.js';
+	import { Textarea } from '$lib/components/ui/textarea/index.js';
 	import {
 		Popover,
 		PopoverClose,
@@ -28,6 +40,16 @@
 	let deleting = $state(false);
 	let deleteOpen = $state(false);
 
+	// Section management state.
+	let sections = $state<RuleSection[]>([]);
+	let sectionError = $state('');
+	let sectionSaving = $state(false);
+	let addTitle = $state('');
+	let addMarkdown = $state('');
+	let editingId = $state<string | null>(null);
+	let editTitle = $state('');
+	let editMarkdown = $state('');
+
 	$effect(() => {
 		load(currentId);
 	});
@@ -39,8 +61,29 @@
 			const r = await getRuleset(idToLoad);
 			ruleset = r;
 			name = r.name;
+			await loadSections(idToLoad);
 		} catch (e) {
 			loadError = e instanceof Error ? e.message : 'Failed to load ruleset';
+		}
+	}
+
+	async function loadSections(idToLoad: string) {
+		sectionError = '';
+		try {
+			sections = await getRulesetSections(idToLoad);
+		} catch (e) {
+			sectionError = e instanceof Error ? e.message : 'Failed to load sections';
+		}
+	}
+
+	// After an amend, the ruleset may have been superseded by a new revision
+	// (add/remove/reorder) or updated in place (content edit). Navigate to a
+	// new revision when the ID changed, otherwise just reload the sections.
+	async function afterAmend(amended: Ruleset) {
+		if (amended.id !== currentId) {
+			await goto(`/rulesets/${amended.id}`);
+		} else {
+			await loadSections(currentId);
 		}
 	}
 
@@ -71,6 +114,108 @@
 			error = err instanceof Error ? err.message : 'Failed to delete ruleset';
 			deleting = false;
 		}
+	}
+
+	async function handleAdd(e: Event) {
+		e.preventDefault();
+		sectionError = '';
+		sectionSaving = true;
+		try {
+			// Fetch the current sections so we append after the authoritative
+			// last section rather than a possibly-stale in-memory list: the
+			// previous add amends the ruleset into a new revision and navigates,
+			// and `sections` may not have caught up to the new revision yet.
+			const current = await getRulesetSections(currentId);
+			const lastId = current.length ? current[current.length - 1].section_id : '';
+			const amended = await amendSections(currentId, {
+				type: RULE_AMENDMENT_ADD,
+				new_section: { title: addTitle, markdown: addMarkdown },
+				after: lastId
+			});
+			addTitle = '';
+			addMarkdown = '';
+			await afterAmend(amended);
+		} catch (err) {
+			sectionError = err instanceof Error ? err.message : 'Failed to add section';
+		} finally {
+			sectionSaving = false;
+		}
+	}
+
+	function startEdit(section: RuleSection) {
+		editingId = section.section_id;
+		editTitle = section.title;
+		editMarkdown = section.markdown;
+	}
+
+	function cancelEdit() {
+		editingId = null;
+	}
+
+	async function handleEditSave() {
+		if (editingId === null) return;
+		sectionError = '';
+		sectionSaving = true;
+		try {
+			const amended = await amendSections(currentId, {
+				type: RULE_AMENDMENT_MODIFY,
+				target_section: editingId,
+				new_section: { title: editTitle, markdown: editMarkdown }
+			});
+			editingId = null;
+			await afterAmend(amended);
+		} catch (err) {
+			sectionError = err instanceof Error ? err.message : 'Failed to update section';
+		} finally {
+			sectionSaving = false;
+		}
+	}
+
+	async function handleRemove(section: RuleSection) {
+		sectionError = '';
+		sectionSaving = true;
+		try {
+			const amended = await amendSections(currentId, {
+				type: RULE_AMENDMENT_REMOVE,
+				target_section: section.section_id
+			});
+			await afterAmend(amended);
+		} catch (err) {
+			sectionError = err instanceof Error ? err.message : 'Failed to remove section';
+		} finally {
+			sectionSaving = false;
+		}
+	}
+
+	async function doReorder(section: RuleSection, after: string) {
+		sectionError = '';
+		sectionSaving = true;
+		try {
+			const amended = await amendSections(currentId, {
+				type: RULE_AMENDMENT_REORDER,
+				target_section: section.section_id,
+				after
+			});
+			await afterAmend(amended);
+		} catch (err) {
+			sectionError = err instanceof Error ? err.message : 'Failed to reorder section';
+		} finally {
+			sectionSaving = false;
+		}
+	}
+
+	// Move a section up one position. Moving to the front uses an empty "after".
+	function moveUp(section: RuleSection) {
+		const i = sections.findIndex((s) => s.section_id === section.section_id);
+		if (i <= 0) return;
+		const after = i - 1 === 0 ? '' : sections[i - 2].section_id;
+		return doReorder(section, after);
+	}
+
+	function moveDown(section: RuleSection) {
+		const i = sections.findIndex((s) => s.section_id === section.section_id);
+		if (i < 0 || i >= sections.length - 1) return;
+		return doReorder(section, sections[i + 1].section_id);
 	}
 </script>
 
@@ -132,6 +277,122 @@
 		</CardContent>
 	</Card>
 
+	<Card class="mt-6">
+		<CardHeader>
+			<CardTitle class="text-base">Sections</CardTitle>
+		</CardHeader>
+		<CardContent class="flex flex-col gap-4">
+			{#if sections.length === 0}
+				<p class="text-sm text-muted-foreground">This ruleset has no sections yet.</p>
+			{:else}
+				<ol class="flex flex-col gap-3">
+					{#each sections as section, i (section.section_id)}
+						<li class="section-card">
+							<div class="flex items-center justify-between gap-2">
+								<span class="font-medium">
+									{i + 1}. {section.title || '(untitled)'}
+								</span>
+								<div class="flex items-center gap-1">
+									<Button
+										variant="outline"
+										size="sm"
+										disabled={sectionSaving || i === 0}
+										onclick={() => moveUp(section)}
+									>
+										&uarr;
+									</Button>
+									<Button
+										variant="outline"
+										size="sm"
+										disabled={sectionSaving || i === sections.length - 1}
+										onclick={() => moveDown(section)}
+									>
+										&darr;
+									</Button>
+									<Button variant="outline" size="sm" onclick={() => startEdit(section)}>
+										Edit
+									</Button>
+									<Button
+										variant="destructive"
+										size="sm"
+										disabled={sectionSaving}
+										onclick={() => handleRemove(section)}
+									>
+										Remove
+									</Button>
+								</div>
+							</div>
+
+							{#if editingId === section.section_id}
+								<form
+									onsubmit={(e) => {
+										e.preventDefault();
+										handleEditSave();
+									}}
+									class="mt-3 flex flex-col gap-3"
+								>
+									<div class="flex flex-col gap-2">
+										<Label for={`edit-title-${section.section_id}`}>Title</Label>
+										<Input
+											id={`edit-title-${section.section_id}`}
+											type="text"
+											bind:value={editTitle}
+										/>
+									</div>
+									<div class="flex flex-col gap-2">
+										<Label for={`edit-markdown-${section.section_id}`}>Contents</Label>
+										<Textarea
+											id={`edit-markdown-${section.section_id}`}
+											bind:value={editMarkdown}
+											rows={4}
+										/>
+									</div>
+									<div class="flex gap-2">
+										<Button type="submit" size="sm" disabled={sectionSaving}>
+											Save section
+										</Button>
+										<Button variant="outline" size="sm" type="button" onclick={cancelEdit}>
+											Cancel
+										</Button>
+									</div>
+								</form>
+							{:else}
+								{#if section.markdown}
+									<p class="section-contents">{section.markdown}</p>
+								{/if}
+							{/if}
+						</li>
+					{/each}
+				</ol>
+			{/if}
+
+			<form onsubmit={handleAdd} class="flex flex-col gap-3 border-t pt-4">
+				<p class="text-sm font-medium">Add a section</p>
+				<div class="flex flex-col gap-2">
+					<Label for="add-title">Title</Label>
+					<Input id="add-title" type="text" bind:value={addTitle} placeholder="e.g. Eligibility" />
+				</div>
+				<div class="flex flex-col gap-2">
+					<Label for="add-markdown">Contents</Label>
+					<Textarea
+						id="add-markdown"
+						bind:value={addMarkdown}
+						rows={4}
+						placeholder="Rule text"
+						required
+					/>
+				</div>
+				<Button type="submit" class="w-fit" disabled={sectionSaving}>
+					{sectionSaving ? 'Saving...' : 'Add section'}
+				</Button>
+			</form>
+
+			{#if sectionError}
+				<p class="text-sm font-medium text-destructive">{sectionError}</p>
+			{/if}
+		</CardContent>
+	</Card>
+
 	<div class="mt-4">
 		<Popover bind:open={deleteOpen}>
 			<PopoverTrigger disabled={deleting} class={buttonVariants({ variant: 'destructive' })}>
@@ -169,5 +430,16 @@
 	}
 	.meta dd {
 		margin: 0;
+	}
+	.section-card {
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		padding: 0.75rem;
+	}
+	.section-contents {
+		margin-top: 0.5rem;
+		white-space: pre-wrap;
+		font-size: 0.875rem;
+		color: #555;
 	}
 </style>


### PR DESCRIPTION
Closes #160

Implements club-rule section management for a ruleset.

- Register CRUD for `RuleSection` and `RulesetSection` in `main.go`.
- Add `PUT /api/ruleset/:id/amend_sections` which applies a `RuleAmendment` (add / remove / modify / reorder) through the existing `Ruleset.Amend` flow, authorized to the ruleset owner / sysadmin.
- Section management UI on `/rulesets/[id]`: list, add, edit, reorder (up/down), remove.
- e2e coverage for add / edit / reorder.

Also fixes two latent model bugs surfaced by this feature:
- `RuleSectionId`/\`RulesetId\` `UnmarshalJSON` used value receivers, silently discarding the parsed value (so the `after` field in the request body was ignored and sections were always added to the front).
- `HandleReorderSection` did not handle an empty `After` (move to front), which the amend validation already permits.

Verified: `make tests` green; `make e2e` green (33 passed; one unrelated `matches.spec` flake observed once, green on re-run).