### PR TITLE
API + UI: scoring structure secondary (tie-breakers)

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ import (
 	"intraclub/route/proposal"
 	"intraclub/route/ruleset"
 	"intraclub/route/schedule"
+	"intraclub/route/scoringstructure"
 	"intraclub/route/team"
 	"intraclub/route/user"
 	"intraclub/route/week"
@@ -92,6 +93,20 @@ func main() {
 	rg.GET("/score_counting_types", model.GetScoreCountingTypes)
 	scoringStructures := api.NewCrudCommon(model.NewScoringStructure, false, db)
 	scoringStructures.HandleRouteTypes(rg, api.CrudWrapperFunctionAll...)
+
+	// ScoringStructureSecondary records are the join table that links a
+	// (composite) ScoringStructure to its secondary (tie-breaker) scoring
+	// structures, ordered by SecondaryIndex. The raw collection is exposed via
+	// generic CRUD for read/admin access, but the ordered list is managed from
+	// the scoring structure detail page through the get/set routes below, which
+	// enforce the primary structure's edit authorization (owner / sysadmin) and
+	// replace the full ordered list atomically (preserving SecondaryIndex
+	// ordering).
+	scoringStructureSecondaries := api.NewCrudCommon(func() *model.ScoringStructureSecondary { return &model.ScoringStructureSecondary{} }, false, db)
+	scoringStructureSecondaries.HandleRouteTypes(rg, api.CrudWrapperFunctionAll...)
+
+	scoringStructureSecondaryRoutes := api.RouteFamily[*scoringstructure.SetSecondaryScoringStructuresBody]{DatabaseProvider: db}
+	scoringStructureSecondaryRoutes.Handle(rg, scoringstructure.GetSecondaryScoringStructures{}, scoringstructure.SetSecondaryScoringStructures{})
 
 	ratings := api.NewCrudCommon(model.NewRating, false, db)
 	ratings.HandleRouteTypes(rg, api.CrudWrapperFunctionAll...)

--- a/model/scoring_structure.go
+++ b/model/scoring_structure.go
@@ -88,9 +88,13 @@ func GetScoreCountingTypes(c *gin.Context) {
 
 type ScoringStructureId database.RecordId
 
-func (id ScoringStructureId) UnmarshalJSON(bytes []byte) error {
-	rid := id.RecordId()
-	return (*database.RecordId)(&rid).UnmarshalJSON(bytes)
+func (id *ScoringStructureId) UnmarshalJSON(bytes []byte) error {
+	var rid database.RecordId
+	if err := rid.UnmarshalJSON(bytes); err != nil {
+		return err
+	}
+	*id = ScoringStructureId(rid)
+	return nil
 }
 
 func (id ScoringStructureId) MarshalJSON() ([]byte, error) {

--- a/route/scoringstructure/set_secondary_scoring_structures.go
+++ b/route/scoringstructure/set_secondary_scoring_structures.go
@@ -1,0 +1,146 @@
+package scoringstructure
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"intraclub/api"
+	"intraclub/database"
+	"intraclub/model"
+
+	"github.com/gin-gonic/gin"
+)
+
+// BaseRoute is the base API route for ScoringStructure records.
+var BaseRoute = "/scoring_structure"
+
+// SetSecondaryScoringStructuresBody is the request body for setting a
+// ScoringStructure's secondary (tie-breaker) scoring structures. The
+// `secondary_scoring_structures` list replaces the structure's entire set of
+// assigned secondary references (as ScoringStructureSecondary join records),
+// preserving order as SecondaryIndex values. An empty list clears the
+// structure's secondaries (making it non-composite).
+type SetSecondaryScoringStructuresBody struct {
+	SecondaryScoringStructures model.ScoringStructureList `json:"secondary_scoring_structures"`
+}
+
+// StaticallyValid is a no-op: an empty list is legitimate (a non-composite
+// scoring structure). Count and counting-type validity are checked by the
+// handler and by the primary structure's DynamicallyValid on save.
+func (b *SetSecondaryScoringStructuresBody) StaticallyValid() error {
+	return nil
+}
+
+// GetSecondaryScoringStructures returns a ScoringStructure's currently-assigned
+// secondary scoring structures, ordered by SecondaryIndex (tie-breaker
+// position).
+type GetSecondaryScoringStructures struct{}
+
+func (c GetSecondaryScoringStructures) Path() (api.HttpMethod, string) {
+	return api.HttpMethodGet, api.AppendPathId(BaseRoute) + "/secondary_scoring_structures"
+}
+
+func (c GetSecondaryScoringStructures) RequestBody() (*SetSecondaryScoringStructuresBody, bool) {
+	return &SetSecondaryScoringStructuresBody{}, false
+}
+
+func (c GetSecondaryScoringStructures) Handler(req api.Request[*SetSecondaryScoringStructuresBody]) (any, int, error) {
+	if req.Token == nil {
+		return nil, http.StatusUnauthorized, errors.New("token is required to get secondary scoring structures")
+	}
+
+	structure, err := database.GetExistingRecordById(req.Context, req.DatabaseProvider, &model.ScoringStructure{}, req.PathId)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+
+	secondaries, err := resolveSecondaryScoringStructures(req.Context, req.DatabaseProvider, structure)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+
+	return gin.H{api.ResourceKey: secondaries}, http.StatusOK, nil
+}
+
+// SetSecondaryScoringStructures replaces a ScoringStructure's secondary
+// (tie-breaker) scoring structure references with the provided list,
+// preserving order. Only the structure's owner (or a SysAdmin) may do so.
+type SetSecondaryScoringStructures struct{}
+
+func (c SetSecondaryScoringStructures) Path() (api.HttpMethod, string) {
+	return api.HttpMethodPut, api.AppendPathId(BaseRoute) + "/secondary_scoring_structures"
+}
+
+func (c SetSecondaryScoringStructures) RequestBody() (*SetSecondaryScoringStructuresBody, bool) {
+	return &SetSecondaryScoringStructuresBody{}, true
+}
+
+func (c SetSecondaryScoringStructures) Handler(req api.Request[*SetSecondaryScoringStructuresBody]) (any, int, error) {
+	if req.Token == nil {
+		return nil, http.StatusUnauthorized, errors.New("token is required to set secondary scoring structures")
+	}
+
+	structure, err := database.GetExistingRecordById(req.Context, req.DatabaseProvider, &model.ScoringStructure{}, req.PathId)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+
+	// enforce per-record edit authorization (owner / sysadmin)
+	wac := database.NewWithAccessControl[*model.ScoringStructure](req.Context, req.DatabaseProvider, req.Token.UserId)
+	if !wac.CanUserEdit(structure) {
+		return nil, http.StatusForbidden, errors.New("not authorized to set secondary scoring structures for this scoring structure")
+	}
+
+	if err := validateSecondaryCountingTypes(req.Context, req.DatabaseProvider, structure, req.Body.SecondaryScoringStructures); err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+
+	if err := structure.SetSecondaryScoringStructures(req.Context, req.DatabaseProvider, req.Body.SecondaryScoringStructures); err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+
+	secondaries, err := resolveSecondaryScoringStructures(req.Context, req.DatabaseProvider, structure)
+	if err != nil {
+		return nil, http.StatusInternalServerError, err
+	}
+
+	return gin.H{api.ResourceKey: secondaries}, http.StatusOK, nil
+}
+
+// validateSecondaryCountingTypes checks that every secondary reference uses
+// the score-counting type expected for a secondary of this structure (the same
+// rule ScoringStructure.DynamicallyValid enforces when the primary is saved),
+// so mismatches are rejected here instead of blocking a later primary save.
+func validateSecondaryCountingTypes(ctx context.Context, db database.Provider, structure *model.ScoringStructure, ids model.ScoringStructureList) error {
+	for _, id := range ids {
+		secondary, err := database.GetExistingRecordById(ctx, db, &model.ScoringStructure{}, id.RecordId())
+		if err != nil {
+			return err
+		}
+		if secondary.WinConditionCountingType != structure.WinConditionCountingType.Secondary() {
+			return fmt.Errorf("cannot use %s-based secondary scoring structure in %s-based win condition", secondary.WinConditionCountingType, structure.WinConditionCountingType)
+		}
+	}
+	return nil
+}
+
+// resolveSecondaryScoringStructures fetches the full ScoringStructure records
+// for a structure's secondary references, preserving SecondaryIndex order.
+func resolveSecondaryScoringStructures(ctx context.Context, db database.Provider, structure *model.ScoringStructure) ([]model.ScoringStructure, error) {
+	ids, err := structure.GetSecondaryScoringStructures(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+
+	secondaries := make([]model.ScoringStructure, 0, len(ids))
+	for _, id := range ids {
+		s, err := database.GetExistingRecordById(ctx, db, &model.ScoringStructure{}, id.RecordId())
+		if err != nil {
+			return nil, err
+		}
+		secondaries = append(secondaries, *s)
+	}
+	return secondaries, nil
+}

--- a/route/scoringstructure/set_secondary_scoring_structures.go
+++ b/route/scoringstructure/set_secondary_scoring_structures.go
@@ -96,6 +96,9 @@ func (c SetSecondaryScoringStructures) Handler(req api.Request[*SetSecondaryScor
 	if err := validateSecondaryCountingTypes(req.Context, req.DatabaseProvider, structure, req.Body.SecondaryScoringStructures); err != nil {
 		return nil, http.StatusBadRequest, err
 	}
+	if err := validateSecondaryCount(structure, req.Body.SecondaryScoringStructures); err != nil {
+		return nil, http.StatusBadRequest, err
+	}
 
 	if err := structure.SetSecondaryScoringStructures(req.Context, req.DatabaseProvider, req.Body.SecondaryScoringStructures); err != nil {
 		return nil, http.StatusBadRequest, err
@@ -122,6 +125,30 @@ func validateSecondaryCountingTypes(ctx context.Context, db database.Provider, s
 		if secondary.WinConditionCountingType != structure.WinConditionCountingType.Secondary() {
 			return fmt.Errorf("cannot use %s-based secondary scoring structure in %s-based win condition", secondary.WinConditionCountingType, structure.WinConditionCountingType)
 		}
+	}
+	return nil
+}
+
+// validateSecondaryCount enforces the composite count rule that
+// ScoringStructure.DynamicallyValid applies when the primary is saved: a
+// composite structure must have exactly as many secondaries as the maximum
+// number of score-counting units playable under its win condition. An empty
+// list (a non-composite structure) is always valid. Rejecting a wrong count
+// here prevents persisting an invalid composite via this endpoint that would
+// only fail later when the primary is saved.
+func validateSecondaryCount(structure *model.ScoringStructure, ids model.ScoringStructureList) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	if structure.WinConditionCountingType == model.Point {
+		return fmt.Errorf("cannot use point-based win condition in a composite scoring structure")
+	}
+	maxUnits, err := structure.MaximumScoreCountingUnitsPlayed(len(ids))
+	if err != nil {
+		return err
+	}
+	if len(ids) != maxUnits {
+		return fmt.Errorf("secondary scoring structures length is %d, but we can play %d max %ss in this structure", len(ids), maxUnits, structure.WinConditionCountingType)
 	}
 	return nil
 }

--- a/route/scoringstructure/set_secondary_scoring_structures_test.go
+++ b/route/scoringstructure/set_secondary_scoring_structures_test.go
@@ -228,9 +228,9 @@ func TestSecondaryScoringStructuresAuthz(t *testing.T) {
 
 	// a sysadmin who is not the owner can set
 	sysadmin := newSysAdminUser(t, db)
-	w = setSecondaries(t, router, primary, []string{gameA}, newToken(t, sysadmin.ID))
+	w = setSecondaries(t, router, primary, []string{gameA, gameA, gameA}, newToken(t, sysadmin.ID))
 	require.Equal(t, http.StatusOK, w.Code, "sysadmin set secondaries: %s", w.Body.String())
-	require.Equal(t, []string{gameA}, getSecondaries(t, router, primary, newToken(t, owner.ID)))
+	require.Equal(t, []string{gameA, gameA, gameA}, getSecondaries(t, router, primary, newToken(t, owner.ID)))
 }
 
 func TestSecondaryScoringStructuresValidation(t *testing.T) {
@@ -251,10 +251,15 @@ func TestSecondaryScoringStructuresValidation(t *testing.T) {
 	require.Equal(t, http.StatusBadRequest, w.Code, "wrong counting type: %s", w.Body.String())
 	require.Empty(t, getSecondaries(t, router, primary, newToken(t, owner.ID)))
 
+	// wrong count rejected (a max-3 set primary needs exactly 3 game secondaries)
+	w = setSecondaries(t, router, primary, []string{gameA, gameA}, newToken(t, owner.ID))
+	require.Equal(t, http.StatusBadRequest, w.Code, "wrong count: %s", w.Body.String())
+	require.Empty(t, getSecondaries(t, router, primary, newToken(t, owner.ID)))
+
 	// a valid set still works afterwards
-	w = setSecondaries(t, router, primary, []string{gameA}, newToken(t, owner.ID))
+	w = setSecondaries(t, router, primary, []string{gameA, gameA, gameA}, newToken(t, owner.ID))
 	require.Equal(t, http.StatusOK, w.Code, "valid set: %s", w.Body.String())
-	require.Equal(t, []string{gameA}, getSecondaries(t, router, primary, newToken(t, owner.ID)))
+	require.Equal(t, []string{gameA, gameA, gameA}, getSecondaries(t, router, primary, newToken(t, owner.ID)))
 }
 
 // ---------------------------------------------------------------------------

--- a/route/scoringstructure/set_secondary_scoring_structures_test.go
+++ b/route/scoringstructure/set_secondary_scoring_structures_test.go
@@ -1,0 +1,337 @@
+package scoringstructure
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/rand/v2"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"intraclub/api"
+	"intraclub/database"
+	"intraclub/model"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// test setup helpers (mirror route/organization/membership_test.go)
+// ---------------------------------------------------------------------------
+
+func newStoredUser(t *testing.T, db database.Provider) *model.User {
+	t.Helper()
+	user := model.NewUser()
+	user.Email = model.EmailAddress(fmt.Sprintf("user%d@email.com", rand.Uint64()))
+	user.FirstName = fmt.Sprintf("Test %d", rand.Uint64())
+	user.LastName = "User"
+	user.PhoneNumber = model.PhoneNumber(fmt.Sprintf("%d", 100_000_0000+rand.Uint32N(999_999_999)))
+	v, err := database.CreateOne(context.Background(), db, user)
+	require.NoError(t, err)
+	return v
+}
+
+// newSysAdminUser creates a user and assigns them the SystemAdministrator
+// role directly (the raw scoring_structure_secondary CRUD surface is
+// sysadmin-only).
+func newSysAdminUser(t *testing.T, db database.Provider) *model.User {
+	t.Helper()
+	user := newStoredUser(t, db)
+	assignment := &model.UserRoleAssignment{
+		UserId: user.ID,
+		Role:   model.SystemAdministrator,
+	}
+	_, err := database.CreateOne(context.Background(), db, assignment)
+	require.NoError(t, err)
+	return user
+}
+
+// newTestRouter builds a gin engine with the scoring structure + secondary
+// CRUD surface and the get/set secondary routes registered (as in main.go)
+// with the auth globals wired up so real tokens validate.
+func newTestRouter(t *testing.T, db database.Provider) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	api.UserType = &model.User{}
+	database.SysAdminCheck = model.IsUserSystemAdministrator
+
+	router := gin.New()
+	group := router.Group("/api")
+
+	scoringStructures := api.NewCrudCommon(model.NewScoringStructure, false, db)
+	scoringStructures.HandleRouteTypes(group, api.CrudWrapperFunctionAll...)
+
+	scoringStructureSecondaries := api.NewCrudCommon(func() *model.ScoringStructureSecondary { return &model.ScoringStructureSecondary{} }, false, db)
+	scoringStructureSecondaries.HandleRouteTypes(group, api.CrudWrapperFunctionAll...)
+
+	family := api.RouteFamily[*SetSecondaryScoringStructuresBody]{DatabaseProvider: db}
+	family.Handle(group, GetSecondaryScoringStructures{}, SetSecondaryScoringStructures{})
+
+	return router
+}
+
+// testKeyOnce generates a single JWT keypair shared by every token minted in a
+// test process, so tokens issued by different helpers all verify.
+var (
+	testKeyOnce sync.Once
+	testPubKey  *ecdsa.PublicKey
+	testPrivKey *ecdsa.PrivateKey
+)
+
+// newToken returns a signed JWT for the given user ID without touching key
+// files on disk.
+func newToken(t *testing.T, userId database.UserId) string {
+	t.Helper()
+	testKeyOnce.Do(func() {
+		pub, priv, err := api.GenerateKeyPair()
+		require.NoError(t, err)
+		testPubKey = pub
+		testPrivKey = priv
+	})
+	api.JwtPublicKey = testPubKey
+	api.JwtPrivateKey = testPrivKey
+	token, err := api.GenerateToken(userId.RecordId())
+	require.NoError(t, err)
+	return token
+}
+
+// doJSON performs an authenticated HTTP request against the router.
+func doJSON(t *testing.T, router *gin.Engine, method, path string, body any, token string) *httptest.ResponseRecorder {
+	t.Helper()
+	var reader io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		require.NoError(t, err)
+		reader = bytes.NewReader(b)
+	}
+	req, err := http.NewRequest(method, path, reader)
+	require.NoError(t, err)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if token != "" {
+		req.Header.Set(api.AuthTokenHeaderValue, token)
+	}
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+// createScoringStructureViaHTTP creates a scoring structure through the CRUD
+// route as the given owner, returning its ID string.
+func createScoringStructureViaHTTP(t *testing.T, router *gin.Engine, owner database.UserId, name string, countingType model.ScoreCountingType, winThreshold, mustWinBy, instantWin int) string {
+	t.Helper()
+	w := doJSON(t, router, http.MethodPost, "/api/scoring_structure", map[string]any{
+		"name":                        name,
+		"win_condition_counting_type": countingType,
+		"win_condition": map[string]any{
+			"win_threshold":         winThreshold,
+			"must_win_by":           mustWinBy,
+			"instant_win_threshold": instantWin,
+		},
+	}, newToken(t, owner))
+	require.Equal(t, http.StatusOK, w.Code, "create scoring structure: %s", w.Body.String())
+
+	var resp struct {
+		Resource *model.ScoringStructure `json:"resource"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.NotNil(t, resp.Resource)
+	return resp.Resource.ID.String()
+}
+
+// getSecondaries performs GET /api/scoring_structure/:id/secondary_scoring_structures
+// and returns the ordered list of secondary IDs.
+func getSecondaries(t *testing.T, router *gin.Engine, structureID, token string) []string {
+	t.Helper()
+	w := doJSON(t, router, http.MethodGet, "/api/scoring_structure/"+structureID+"/secondary_scoring_structures", nil, token)
+	require.Equal(t, http.StatusOK, w.Code, "get secondaries: %s", w.Body.String())
+
+	var resp struct {
+		Resource []model.ScoringStructure `json:"resource"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	ids := make([]string, 0, len(resp.Resource))
+	for _, s := range resp.Resource {
+		ids = append(ids, s.ID.String())
+	}
+	return ids
+}
+
+func setSecondaries(t *testing.T, router *gin.Engine, structureID string, ids []string, token string) *httptest.ResponseRecorder {
+	t.Helper()
+	return doJSON(t, router, http.MethodPut, "/api/scoring_structure/"+structureID+"/secondary_scoring_structures",
+		map[string]any{"secondary_scoring_structures": ids}, token)
+}
+
+// ---------------------------------------------------------------------------
+// Get / set secondary scoring structures
+// ---------------------------------------------------------------------------
+
+func TestSecondaryScoringStructuresSetGetReorderClear(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	owner := newStoredUser(t, db)
+
+	// Set-based primary: best-of-3 sets (max 3 units) needs game-based secondaries.
+	primary := createScoringStructureViaHTTP(t, router, owner.ID, "Primary match", model.Set, 2, 1, 0)
+	gameA := createScoringStructureViaHTTP(t, router, owner.ID, "Game A", model.Game, 6, 2, 7)
+	gameB := createScoringStructureViaHTTP(t, router, owner.ID, "Game B", model.Game, 6, 2, 7)
+
+	// No secondaries yet.
+	require.Empty(t, getSecondaries(t, router, primary, newToken(t, owner.ID)))
+
+	// Set an ordered list (duplicates at different positions are allowed).
+	w := setSecondaries(t, router, primary, []string{gameA, gameB, gameA}, newToken(t, owner.ID))
+	require.Equal(t, http.StatusOK, w.Code, "set secondaries: %s", w.Body.String())
+	require.Equal(t, []string{gameA, gameB, gameA}, getSecondaries(t, router, primary, newToken(t, owner.ID)))
+
+	// Reorder: the list is replaced atomically and the new order is preserved.
+	w = setSecondaries(t, router, primary, []string{gameB, gameA, gameA}, newToken(t, owner.ID))
+	require.Equal(t, http.StatusOK, w.Code, "reorder secondaries: %s", w.Body.String())
+	require.Equal(t, []string{gameB, gameA, gameA}, getSecondaries(t, router, primary, newToken(t, owner.ID)))
+
+	// Clearing the list makes the structure non-composite again.
+	w = setSecondaries(t, router, primary, []string{}, newToken(t, owner.ID))
+	require.Equal(t, http.StatusOK, w.Code, "clear secondaries: %s", w.Body.String())
+	require.Empty(t, getSecondaries(t, router, primary, newToken(t, owner.ID)))
+}
+
+func TestSecondaryScoringStructuresAuthz(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	owner := newStoredUser(t, db)
+	nonOwner := newStoredUser(t, db)
+
+	primary := createScoringStructureViaHTTP(t, router, owner.ID, "Authz match", model.Set, 2, 1, 0)
+	gameA := createScoringStructureViaHTTP(t, router, owner.ID, "Authz game", model.Game, 6, 2, 7)
+
+	// non-owner cannot set
+	w := setSecondaries(t, router, primary, []string{gameA}, newToken(t, nonOwner.ID))
+	require.Equal(t, http.StatusForbidden, w.Code)
+
+	// non-owner can still read (scoring structures are accessible to everyone)
+	require.Equal(t, []string{}, getSecondaries(t, router, primary, newToken(t, nonOwner.ID)))
+
+	// unauthenticated cannot get or set
+	w = doJSON(t, router, http.MethodGet, "/api/scoring_structure/"+primary+"/secondary_scoring_structures", nil, "")
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+	w = setSecondaries(t, router, primary, []string{gameA}, "")
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+
+	// a sysadmin who is not the owner can set
+	sysadmin := newSysAdminUser(t, db)
+	w = setSecondaries(t, router, primary, []string{gameA}, newToken(t, sysadmin.ID))
+	require.Equal(t, http.StatusOK, w.Code, "sysadmin set secondaries: %s", w.Body.String())
+	require.Equal(t, []string{gameA}, getSecondaries(t, router, primary, newToken(t, owner.ID)))
+}
+
+func TestSecondaryScoringStructuresValidation(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	owner := newStoredUser(t, db)
+
+	primary := createScoringStructureViaHTTP(t, router, owner.ID, "Validation match", model.Set, 2, 1, 0)
+	gameA := createScoringStructureViaHTTP(t, router, owner.ID, "Validation game", model.Game, 6, 2, 7)
+	pointA := createScoringStructureViaHTTP(t, router, owner.ID, "Validation point", model.Point, 11, 1, 0)
+
+	// unknown secondary ID rejected
+	w := setSecondaries(t, router, primary, []string{database.NewRecordId().String()}, newToken(t, owner.ID))
+	require.Equal(t, http.StatusBadRequest, w.Code, "unknown secondary: %s", w.Body.String())
+
+	// wrong counting type rejected (point-based secondary on a set-based primary)
+	w = setSecondaries(t, router, primary, []string{pointA}, newToken(t, owner.ID))
+	require.Equal(t, http.StatusBadRequest, w.Code, "wrong counting type: %s", w.Body.String())
+	require.Empty(t, getSecondaries(t, router, primary, newToken(t, owner.ID)))
+
+	// a valid set still works afterwards
+	w = setSecondaries(t, router, primary, []string{gameA}, newToken(t, owner.ID))
+	require.Equal(t, http.StatusOK, w.Code, "valid set: %s", w.Body.String())
+	require.Equal(t, []string{gameA}, getSecondaries(t, router, primary, newToken(t, owner.ID)))
+}
+
+// ---------------------------------------------------------------------------
+// Raw scoring_structure_secondary CRUD (sysadmin-only writes)
+// ---------------------------------------------------------------------------
+
+func TestScoringStructureSecondaryCRUD(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	owner := newStoredUser(t, db)
+	sysadmin := newSysAdminUser(t, db)
+
+	primary := createScoringStructureViaHTTP(t, router, owner.ID, "CRUD match", model.Set, 2, 1, 0)
+	gameA := createScoringStructureViaHTTP(t, router, owner.ID, "CRUD game", model.Game, 6, 2, 7)
+
+	// generic CRUD create is open to any authenticated user (the record's own
+	// validation runs; EditableBy gates update / delete)
+	w := doJSON(t, router, http.MethodPost, "/api/scoring_structure_secondary", map[string]any{
+		"scoring_structure_id":           primary,
+		"secondary_scoring_structure_id": gameA,
+		"secondary_index":                0,
+	}, newToken(t, owner.ID))
+	require.Equal(t, http.StatusOK, w.Code, "create: %s", w.Body.String())
+
+	var created struct {
+		Resource *model.ScoringStructureSecondary `json:"resource"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &created))
+	require.NotNil(t, created.Resource)
+	rowID := created.Resource.ID.String()
+
+	// everyone can list the raw collection
+	w = doJSON(t, router, http.MethodGet, "/api/scoring_structure_secondary", nil, newToken(t, owner.ID))
+	require.Equal(t, http.StatusOK, w.Code)
+	var listed struct {
+		Resource []*model.ScoringStructureSecondary `json:"resource"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &listed))
+	require.Len(t, listed.Resource, 1)
+
+	// duplicate (primary, index) rejected
+	w = doJSON(t, router, http.MethodPost, "/api/scoring_structure_secondary", map[string]any{
+		"scoring_structure_id":           primary,
+		"secondary_scoring_structure_id": gameA,
+		"secondary_index":                0,
+	}, newToken(t, sysadmin.ID))
+	require.Equal(t, http.StatusBadRequest, w.Code, "duplicate index: %s", w.Body.String())
+
+	// unknown primary rejected
+	w = doJSON(t, router, http.MethodPost, "/api/scoring_structure_secondary", map[string]any{
+		"scoring_structure_id":           database.NewRecordId().String(),
+		"secondary_scoring_structure_id": gameA,
+		"secondary_index":                0,
+	}, newToken(t, sysadmin.ID))
+	require.Equal(t, http.StatusBadRequest, w.Code, "unknown primary: %s", w.Body.String())
+
+	// a non-sysadmin cannot update the raw join row
+	w = doJSON(t, router, http.MethodPut, "/api/scoring_structure_secondary/"+rowID, map[string]any{
+		"id":                             rowID,
+		"scoring_structure_id":           primary,
+		"secondary_scoring_structure_id": gameA,
+		"secondary_index":                1,
+	}, newToken(t, owner.ID))
+	require.Equal(t, http.StatusBadRequest, w.Code, "non-sysadmin update: %s", w.Body.String())
+
+	// the sysadmin can update and delete the raw join row
+	w = doJSON(t, router, http.MethodPut, "/api/scoring_structure_secondary/"+rowID, map[string]any{
+		"id":                             rowID,
+		"scoring_structure_id":           primary,
+		"secondary_scoring_structure_id": gameA,
+		"secondary_index":                1,
+	}, newToken(t, sysadmin.ID))
+	require.Equal(t, http.StatusOK, w.Code, "sysadmin update: %s", w.Body.String())
+
+	w = doJSON(t, router, http.MethodDelete, "/api/scoring_structure_secondary/"+rowID, nil, newToken(t, sysadmin.ID))
+	require.Equal(t, http.StatusOK, w.Code, "sysadmin delete: %s", w.Body.String())
+
+	w = doJSON(t, router, http.MethodGet, "/api/scoring_structure_secondary/"+rowID, nil, newToken(t, sysadmin.ID))
+	require.Equal(t, http.StatusNotFound, w.Code)
+}

--- a/ui/e2e/scoring-structure-secondary.spec.ts
+++ b/ui/e2e/scoring-structure-secondary.spec.ts
@@ -36,19 +36,22 @@ async function createScoringStructure(
 	await expect(page).toHaveURL(/\/scoring-structures\/[0-9a-f]+$/);
 }
 
-test('scoring structure secondaries: add, reorder, remove, save', async ({ page }) => {
+test('scoring structure secondaries: add, save, reorder, remove', async ({ page }) => {
 	await login(page);
 
 	const unique = Date.now();
 	const gameA = `Test Game A ${unique}`;
 	const gameB = `Test Game B ${unique}`;
+	const gameC = `Test Game C ${unique}`;
 	const match = `Test Match ${unique}`;
 
-	// Two game-based structures to use as secondaries (a set-based primary
+	// Three game-based structures to use as secondaries (a set-based primary
 	// uses game-based secondaries), and a set-based primary (best of 3 sets ->
-	// plays at most 3 sets -> needs 3 secondaries).
+	// plays at most 3 sets -> needs 3 secondaries). The dropdown excludes
+	// already-assigned structures, so three distinct games are needed.
 	await createScoringStructure(page, gameA, 'Game', '11', '1', '0');
 	await createScoringStructure(page, gameB, 'Game', '11', '1', '0');
+	await createScoringStructure(page, gameC, 'Game', '11', '1', '0');
 	await createScoringStructure(page, match, 'Set', '2', '1', '0');
 
 	// No secondaries assigned yet, with the required-count hint.
@@ -61,29 +64,33 @@ test('scoring structure secondaries: add, reorder, remove, save', async ({ page 
 
 	const secondaryNames = page.locator('.secondary-name');
 
-	// Add three secondaries (the same structure may be used at multiple
-	// positions). Each add replaces the full list via a PUT, so wait for the
-	// save to settle (the count hint updates from the response) before the
-	// next add.
-	const toAssign = [gameA, gameB, gameA];
-	for (let i = 0; i < toAssign.length; i++) {
+	// Build the draft by adding each secondary in turn. Edits accumulate
+	// locally and are only committed once the exact required count is reached.
+	const toAdd = [gameA, gameB, gameC];
+	for (let i = 0; i < toAdd.length; i++) {
 		await page
 			.getByLabel('Secondary structure to assign')
-			.selectOption({ label: toAssign[i] });
+			.selectOption({ label: toAdd[i] });
 		await page.getByRole('button', { name: 'Add secondary' }).click();
-		if (i < toAssign.length - 1) {
+		if (i < toAdd.length - 1) {
 			await expect(page.getByText(`(${i + 1} currently assigned)`)).toBeVisible();
 		}
 	}
 	await expect(secondaryNames.nth(0)).toHaveText(gameA);
 	await expect(secondaryNames.nth(1)).toHaveText(gameB);
-	await expect(secondaryNames.nth(2)).toHaveText(gameA);
+	await expect(secondaryNames.nth(2)).toHaveText(gameC);
+	await expect(
+		page.getByText('All 3 required secondary scoring structures assigned.')
+	).toBeVisible();
+
+	// Commit the draft once complete.
+	await page.getByRole('button', { name: 'Save secondaries' }).click();
 	await expect(
 		page.getByText('All 3 required secondary scoring structures assigned.')
 	).toBeVisible();
 
 	// Reorder: move the first row (gameA) down so gameB becomes the first
-	// tie-breaker. The new order is preserved.
+	// tie-breaker, then commit.
 	await page
 		.locator('li')
 		.filter({ hasText: gameA })
@@ -92,7 +99,8 @@ test('scoring structure secondaries: add, reorder, remove, save', async ({ page 
 		.click();
 	await expect(secondaryNames.nth(0)).toHaveText(gameB);
 	await expect(secondaryNames.nth(1)).toHaveText(gameA);
-	await expect(secondaryNames.nth(2)).toHaveText(gameA);
+	await expect(secondaryNames.nth(2)).toHaveText(gameC);
+	await page.getByRole('button', { name: 'Save secondaries' }).click();
 
 	// Saving the primary succeeds now that the required number of secondaries
 	// is assigned.
@@ -100,12 +108,11 @@ test('scoring structure secondaries: add, reorder, remove, save', async ({ page 
 	await page.getByRole('button', { name: 'Save changes' }).click();
 	await expect(page.getByRole('heading', { name: `${match} Updated` })).toBeVisible();
 
-	// Remove one secondary; the structure is now under-assigned, so saving the
-	// primary fails validation.
+	// Remove one secondary; the draft is now under-assigned, so the save is
+	// disabled until the exact required count is restored.
 	await page
 		.locator('li')
-		.filter({ hasText: gameA })
-		.last()
+		.filter({ hasText: gameC })
 		.getByRole('button', { name: 'Remove' })
 		.click();
 	await expect(
@@ -113,32 +120,29 @@ test('scoring structure secondaries: add, reorder, remove, save', async ({ page 
 			'This win condition can play at most 3 sets, so a composite structure needs exactly 3 secondary scoring structures (2 currently assigned).'
 		)
 	).toBeVisible();
+	await expect(page.getByRole('button', { name: /Add 1 more to save/ })).toBeDisabled();
 
-	await page.getByRole('button', { name: 'Save changes' }).click();
-	await expect(
-		page.getByText('secondary scoring structures length is 2, but we can play 3 max sets')
-	).toBeVisible();
-
-	// Re-add a secondary; saving the primary succeeds again.
-	await page.getByLabel('Secondary structure to assign').selectOption({ label: gameB });
+	// Re-add a secondary and commit; the draft is complete again.
+	await page.getByLabel('Secondary structure to assign').selectOption({ label: gameC });
 	await page.getByRole('button', { name: 'Add secondary' }).click();
 	await expect(
 		page.getByText('All 3 required secondary scoring structures assigned.')
 	).toBeVisible();
+	await page.getByRole('button', { name: 'Save secondaries' }).click();
 
 	await page.getByLabel('Name').fill(`${match} Final`);
 	await page.getByRole('button', { name: 'Save changes' }).click();
 	await expect(page.getByRole('heading', { name: `${match} Final` })).toBeVisible();
 
 	// Clean up. Deleting the primary cascades to its secondary join rows, so
-	// the two game structures are no longer referenced and can be deleted to
+	// the three game structures are no longer referenced and can be deleted to
 	// keep the shared dev db clean. Both deletes confirm via an in-app popover.
 	await page.getByRole('button', { name: 'Delete scoring structure' }).click();
 	await page.getByRole('button', { name: 'Delete', exact: true }).click();
 	await expect(page).toHaveURL('/scoring-structures');
 	await expect(page.getByRole('link', { name: `${match} Final` })).toHaveCount(0);
 
-	for (const name of [gameA, gameB]) {
+	for (const name of [gameA, gameB, gameC]) {
 		await page.goto('/scoring-structures');
 		await page.getByRole('link', { name: name }).click();
 		await expect(page).toHaveURL(/\/scoring-structures\/[0-9a-f]+$/);

--- a/ui/e2e/scoring-structure-secondary.spec.ts
+++ b/ui/e2e/scoring-structure-secondary.spec.ts
@@ -1,0 +1,150 @@
+import { expect, test, type Page } from '@playwright/test';
+import { waitForHydration } from './helpers';
+
+// The Go backend runs with --dev-token from the repo root (see
+// playwright.config.ts), so POST /api/one_time_password returns the magic-link
+// token in the response body. Login with the user seeded by SeedDevData.
+async function login(page: Page) {
+	await page.goto('/login');
+	await page.waitForLoadState('networkidle');
+	await page.getByLabel('Email').fill('jdarthur@gatech.edu');
+	await page.getByRole('button', { name: 'Send login link' }).click();
+	const link = page.getByRole('main').getByRole('link', { name: 'Log in' });
+	await expect(link).toBeVisible();
+	await link.click();
+	await expect(page).toHaveURL('/');
+}
+
+// createScoringStructure fills out the /scoring-structures/new form and
+// creates a structure with the given values, landing on its detail page.
+async function createScoringStructure(
+	page: Page,
+	name: string,
+	countingType: string,
+	winThreshold: string,
+	mustWinBy: string,
+	instantWinThreshold: string
+) {
+	await page.goto('/scoring-structures/new');
+	await waitForHydration(page);
+	await page.getByLabel('Name').fill(name);
+	await page.getByLabel('Score counting type').selectOption({ label: countingType });
+	await page.getByLabel('Win threshold', { exact: true }).fill(winThreshold);
+	await page.getByLabel('Must win by', { exact: true }).fill(mustWinBy);
+	await page.getByLabel('Instant win threshold', { exact: true }).fill(instantWinThreshold);
+	await page.getByRole('button', { name: 'Create scoring structure' }).click();
+	await expect(page).toHaveURL(/\/scoring-structures\/[0-9a-f]+$/);
+}
+
+test('scoring structure secondaries: add, reorder, remove, save', async ({ page }) => {
+	await login(page);
+
+	const unique = Date.now();
+	const gameA = `Test Game A ${unique}`;
+	const gameB = `Test Game B ${unique}`;
+	const match = `Test Match ${unique}`;
+
+	// Two game-based structures to use as secondaries (a set-based primary
+	// uses game-based secondaries), and a set-based primary (best of 3 sets ->
+	// plays at most 3 sets -> needs 3 secondaries).
+	await createScoringStructure(page, gameA, 'Game', '11', '1', '0');
+	await createScoringStructure(page, gameB, 'Game', '11', '1', '0');
+	await createScoringStructure(page, match, 'Set', '2', '1', '0');
+
+	// No secondaries assigned yet, with the required-count hint.
+	await expect(page.getByText('No secondary scoring structures assigned yet.')).toBeVisible();
+	await expect(
+		page.getByText(
+			'This win condition can play at most 3 sets, so a composite structure needs exactly 3 secondary scoring structures (0 currently assigned).'
+		)
+	).toBeVisible();
+
+	const secondaryNames = page.locator('.secondary-name');
+
+	// Add three secondaries (the same structure may be used at multiple
+	// positions). Each add replaces the full list via a PUT, so wait for the
+	// save to settle (the count hint updates from the response) before the
+	// next add.
+	const toAssign = [gameA, gameB, gameA];
+	for (let i = 0; i < toAssign.length; i++) {
+		await page
+			.getByLabel('Secondary structure to assign')
+			.selectOption({ label: toAssign[i] });
+		await page.getByRole('button', { name: 'Add secondary' }).click();
+		if (i < toAssign.length - 1) {
+			await expect(page.getByText(`(${i + 1} currently assigned)`)).toBeVisible();
+		}
+	}
+	await expect(secondaryNames.nth(0)).toHaveText(gameA);
+	await expect(secondaryNames.nth(1)).toHaveText(gameB);
+	await expect(secondaryNames.nth(2)).toHaveText(gameA);
+	await expect(
+		page.getByText('All 3 required secondary scoring structures assigned.')
+	).toBeVisible();
+
+	// Reorder: move the first row (gameA) down so gameB becomes the first
+	// tie-breaker. The new order is preserved.
+	await page
+		.locator('li')
+		.filter({ hasText: gameA })
+		.first()
+		.getByRole('button', { name: '↓' })
+		.click();
+	await expect(secondaryNames.nth(0)).toHaveText(gameB);
+	await expect(secondaryNames.nth(1)).toHaveText(gameA);
+	await expect(secondaryNames.nth(2)).toHaveText(gameA);
+
+	// Saving the primary succeeds now that the required number of secondaries
+	// is assigned.
+	await page.getByLabel('Name').fill(`${match} Updated`);
+	await page.getByRole('button', { name: 'Save changes' }).click();
+	await expect(page.getByRole('heading', { name: `${match} Updated` })).toBeVisible();
+
+	// Remove one secondary; the structure is now under-assigned, so saving the
+	// primary fails validation.
+	await page
+		.locator('li')
+		.filter({ hasText: gameA })
+		.last()
+		.getByRole('button', { name: 'Remove' })
+		.click();
+	await expect(
+		page.getByText(
+			'This win condition can play at most 3 sets, so a composite structure needs exactly 3 secondary scoring structures (2 currently assigned).'
+		)
+	).toBeVisible();
+
+	await page.getByRole('button', { name: 'Save changes' }).click();
+	await expect(
+		page.getByText('secondary scoring structures length is 2, but we can play 3 max sets')
+	).toBeVisible();
+
+	// Re-add a secondary; saving the primary succeeds again.
+	await page.getByLabel('Secondary structure to assign').selectOption({ label: gameB });
+	await page.getByRole('button', { name: 'Add secondary' }).click();
+	await expect(
+		page.getByText('All 3 required secondary scoring structures assigned.')
+	).toBeVisible();
+
+	await page.getByLabel('Name').fill(`${match} Final`);
+	await page.getByRole('button', { name: 'Save changes' }).click();
+	await expect(page.getByRole('heading', { name: `${match} Final` })).toBeVisible();
+
+	// Clean up. Deleting the primary cascades to its secondary join rows, so
+	// the two game structures are no longer referenced and can be deleted to
+	// keep the shared dev db clean. Both deletes confirm via an in-app popover.
+	await page.getByRole('button', { name: 'Delete scoring structure' }).click();
+	await page.getByRole('button', { name: 'Delete', exact: true }).click();
+	await expect(page).toHaveURL('/scoring-structures');
+	await expect(page.getByRole('link', { name: `${match} Final` })).toHaveCount(0);
+
+	for (const name of [gameA, gameB]) {
+		await page.goto('/scoring-structures');
+		await page.getByRole('link', { name: name }).click();
+		await expect(page).toHaveURL(/\/scoring-structures\/[0-9a-f]+$/);
+		await page.getByRole('button', { name: 'Delete scoring structure' }).click();
+		await page.getByRole('button', { name: 'Delete', exact: true }).click();
+		await expect(page).toHaveURL('/scoring-structures');
+		await expect(page.getByRole('link', { name: name })).toHaveCount(0);
+	}
+});

--- a/ui/src/lib/scoringStructure.ts
+++ b/ui/src/lib/scoringStructure.ts
@@ -8,6 +8,15 @@
 //	PUT    /api/scoring_structure/:id    -> { resource: ScoringStructure }
 //	DELETE /api/scoring_structure/:id    -> { resource: ScoringStructure }
 //	GET    /api/score_counting_types     -> { resource: ScoreCountingType[] }
+//	GET    /api/scoring_structure/:id/secondary_scoring_structures
+//	      -> { resource: ScoringStructure[] }  (ordered by SecondaryIndex)
+//	PUT    /api/scoring_structure/:id/secondary_scoring_structures
+//	      -> { resource: ScoringStructure[] }  (body: { secondary_scoring_structures: string[] })
+//
+// The PUT replaces the structure's entire ordered list of secondary
+// (tie-breaker) scoring structure references; an empty list makes the
+// structure non-composite. Only the structure's owner (or a sysadmin) may set
+// them.
 //
 // A ScoringStructure is how a match is scored (win condition + counting
 // type), owned by a User. Record IDs are 16-char hex strings; an empty string
@@ -31,6 +40,43 @@ export interface ScoringStructure {
 export interface ScoreCountingType {
 	type: number;
 	name: string;
+}
+
+// ScoreCountingType values, mirroring model.ScoreCountingType in Go.
+export const ScoreCountingTypes = {
+	Point: 0,
+	Game: 1,
+	Set: 2
+} as const;
+
+// secondaryCountingTypeFor returns the score-counting type that secondary
+// (tie-breaker) structures must use for a primary with the given counting
+// type (model.ScoreCountingType.Secondary), or null if the primary cannot be
+// composite (Point-based win conditions).
+export function secondaryCountingTypeFor(type: number): number | null {
+	switch (type) {
+		case ScoreCountingTypes.Set:
+			return ScoreCountingTypes.Game;
+		case ScoreCountingTypes.Game:
+			return ScoreCountingTypes.Point;
+		default:
+			return null;
+	}
+}
+
+// maximumScoreCountingUnits mirrors model.ScoringStructure.
+// MaximumScoreCountingUnitsPlayed: the maximum number of primary units that
+// can be played under this win condition, which a composite structure must
+// score via secondary structures. Returns null if the win condition cannot be
+// composite (win-by-2-or-more without an instant-win threshold).
+export function maximumScoreCountingUnits(winCondition: WinCondition): number | null {
+	if (winCondition.instant_win_threshold > 0) {
+		return winCondition.instant_win_threshold * 2 - 1;
+	}
+	if (winCondition.must_win_by > 1) {
+		return null;
+	}
+	return winCondition.win_threshold * 2 - 1;
 }
 
 export interface ScoringStructureInput {
@@ -87,6 +133,28 @@ export async function updateScoringStructure(id: string, input: ScoringStructure
 			method: 'PUT',
 			headers: { 'Content-Type': 'application/json' },
 			body: JSON.stringify(input)
+		})
+	);
+}
+
+// getScoringStructureSecondaries returns the structure's secondary
+// (tie-breaker) scoring structures as full records, ordered by SecondaryIndex.
+export async function getScoringStructureSecondaries(id: string): Promise<ScoringStructure[]> {
+	return unwrap(await authFetch(`${BASE}/${id}/secondary_scoring_structures`));
+}
+
+// setScoringStructureSecondaries replaces the structure's entire ordered list
+// of secondary scoring structure references (an empty list makes it
+// non-composite), returning the updated list ordered by SecondaryIndex.
+export async function setScoringStructureSecondaries(
+	id: string,
+	secondaryIds: string[]
+): Promise<ScoringStructure[]> {
+	return unwrap(
+		await authFetch(`${BASE}/${id}/secondary_scoring_structures`, {
+			method: 'PUT',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ secondary_scoring_structures: secondaryIds })
 		})
 	);
 }

--- a/ui/src/routes/scoring-structures/[id]/+page.svelte
+++ b/ui/src/routes/scoring-structures/[id]/+page.svelte
@@ -48,6 +48,10 @@
 	// Secondary (tie-breaker) scoring structures assigned to this structure,
 	// ordered by SecondaryIndex.
 	let secondaries = $state<ScoringStructure[]>([]);
+	// Local draft of secondary edits, built incrementally. The backend requires
+	// a composite to have exactly the required number of secondaries, so edits
+	// accumulate here and are committed in one call via the Save button.
+	let draftSecondaries = $state<ScoringStructure[]>([]);
 	let allStructures = $state<ScoringStructure[]>([]);
 	let selectedSecondaryId = $state('');
 	let secondariesError = $state('');
@@ -71,7 +75,17 @@
 	const eligibleStructures = $derived(
 		secondaryType === null
 			? []
-			: allStructures.filter((s) => s.win_condition_counting_type === secondaryType)
+			: allStructures.filter(
+					(s) =>
+						s.win_condition_counting_type === secondaryType &&
+						!draftSecondaries.some((d) => d.id === s.id)
+				)
+	);
+	// The backend requires a composite to have exactly this many secondaries.
+	const canSaveSecondaries = $derived(
+		secondaryType !== null &&
+			requiredSecondaryCount !== null &&
+			draftSecondaries.length === requiredSecondaryCount
 	);
 	const secondaryTypeName = $derived(
 		countingTypes.find((t) => t.type === secondaryType)?.name.toLowerCase() ?? ''
@@ -118,6 +132,7 @@
 	async function loadSecondaries() {
 		try {
 			secondaries = await getScoringStructureSecondaries(id());
+			draftSecondaries = secondaries;
 		} catch (e) {
 			secondariesError = e instanceof Error ? e.message : 'Failed to load secondary scoring structures';
 		}
@@ -129,12 +144,15 @@
 		}
 	}
 
-	async function saveSecondaries(secondaryIds: string[]) {
+	async function saveSecondaries() {
 		secondariesError = '';
 		secondariesSaving = true;
 		try {
-			secondaries = await setScoringStructureSecondaries(id(), secondaryIds);
-			selectedSecondaryId = '';
+			secondaries = await setScoringStructureSecondaries(
+				id(),
+				draftSecondaries.map((s) => s.id)
+			);
+			draftSecondaries = secondaries;
 		} catch (err) {
 			secondariesError = err instanceof Error ? err.message : 'Failed to update secondary scoring structures';
 		} finally {
@@ -142,22 +160,23 @@
 		}
 	}
 
-	function handleAddSecondary(e: Event) {
-		e.preventDefault();
-		if (!selectedSecondaryId) return;
-		saveSecondaries([...secondaries.map((s) => s.id), selectedSecondaryId]);
+	function addToDraft() {
+		const chosen = allStructures.find((s) => s.id === selectedSecondaryId);
+		if (!chosen) return;
+		draftSecondaries = [...draftSecondaries, chosen];
+		selectedSecondaryId = '';
 	}
 
-	function handleRemoveSecondary(index: number) {
-		saveSecondaries(secondaries.filter((_, i) => i !== index).map((s) => s.id));
+	function removeFromDraft(index: number) {
+		draftSecondaries = draftSecondaries.filter((_, i) => i !== index);
 	}
 
-	function handleMoveSecondary(index: number, direction: -1 | 1) {
+	function moveDraft(index: number, direction: -1 | 1) {
 		const target = index + direction;
-		if (target < 0 || target >= secondaries.length) return;
-		const next = secondaries.map((s) => s.id);
+		if (target < 0 || target >= draftSecondaries.length) return;
+		const next = [...draftSecondaries];
 		[next[index], next[target]] = [next[target], next[index]];
-		saveSecondaries(next);
+		draftSecondaries = next;
 	}
 
 	async function handleSave(e: Event) {
@@ -290,9 +309,9 @@
 	<section class="mt-6 max-w-md">
 		<h2 class="text-xl font-semibold tracking-tight">Secondary scoring structures</h2>
 
-		{#if secondaries.length > 0}
+		{#if draftSecondaries.length > 0}
 			<ul class="mt-4 flex flex-col gap-2">
-				{#each secondaries as secondary, i}
+				{#each draftSecondaries as secondary, i}
 					<li class="flex items-center justify-between gap-2 rounded-lg border p-2 pl-3">
 						<span class="flex items-center gap-2">
 							<span class="text-sm text-muted-foreground">{i + 1}.</span>
@@ -303,8 +322,8 @@
 								type="button"
 								variant="outline"
 								size="sm"
-								onclick={() => handleMoveSecondary(i, -1)}
-								disabled={secondariesSaving || i === 0}
+								onclick={() => moveDraft(i, -1)}
+								disabled={i === 0}
 							>
 								↑
 							</Button>
@@ -312,8 +331,8 @@
 								type="button"
 								variant="outline"
 								size="sm"
-								onclick={() => handleMoveSecondary(i, 1)}
-								disabled={secondariesSaving || i === secondaries.length - 1}
+								onclick={() => moveDraft(i, 1)}
+								disabled={i === draftSecondaries.length - 1}
 							>
 								↓
 							</Button>
@@ -321,8 +340,7 @@
 								type="button"
 								variant="outline"
 								size="sm"
-								onclick={() => handleRemoveSecondary(i)}
-								disabled={secondariesSaving}
+								onclick={() => removeFromDraft(i)}
 							>
 								Remove
 							</Button>
@@ -335,8 +353,8 @@
 		{#if secondaryType === null}
 			<p class="mt-2 text-sm text-muted-foreground">
 				Point-based scoring structures cannot have secondary (tie-breaker) scoring structures
-				{#if secondaries.length > 0}
-					— remove the {secondaries.length} assigned secondaries (or change the counting type)
+				{#if draftSecondaries.length > 0}
+					— remove the {draftSecondaries.length} assigned secondaries (or change the counting type)
 					before saving.
 				{/if}
 			</p>
@@ -344,8 +362,8 @@
 			<p class="mt-2 text-sm text-muted-foreground">
 				Win conditions that require winning by 2 or more without an instant-win threshold cannot
 				be composite
-				{#if secondaries.length > 0}
-					— remove the {secondaries.length} assigned secondaries (or change the win condition)
+				{#if draftSecondaries.length > 0}
+					— remove the {draftSecondaries.length} assigned secondaries (or change the win condition)
 					before saving.
 				{/if}
 			</p>
@@ -355,24 +373,24 @@
 				in tie-breaker order.
 			</p>
 
-			{#if secondaries.length === 0}
+			{#if draftSecondaries.length === 0}
 				<p class="mt-4 text-muted-foreground">No secondary scoring structures assigned yet.</p>
 			{/if}
 
-			{#if secondaries.length !== requiredSecondaryCount}
+			{#if draftSecondaries.length !== requiredSecondaryCount}
 				<p class="mt-2 text-sm text-muted-foreground">
 					This win condition can play at most {requiredSecondaryCount} {unitNoun}s, so a
 					composite structure needs exactly {requiredSecondaryCount} secondary scoring
-					structures ({secondaries.length} currently assigned).
+					structures ({draftSecondaries.length} currently assigned).
 				</p>
-			{:else if secondaries.length > 0}
+			{:else if draftSecondaries.length > 0}
 				<p class="mt-2 text-sm text-muted-foreground">
 					All {requiredSecondaryCount} required secondary scoring structures assigned.
 				</p>
 			{/if}
 
 			{#if eligibleStructures.length > 0}
-				<form onsubmit={handleAddSecondary} class="mt-4 flex items-center gap-2">
+				<div class="mt-4 flex items-center gap-2">
 					<NativeSelect
 						bind:value={selectedSecondaryId}
 						aria-label="Secondary structure to assign"
@@ -385,15 +403,34 @@
 							<NativeSelectOption value={s.id}>{s.name}</NativeSelectOption>
 						{/each}
 					</NativeSelect>
-					<Button type="submit" disabled={secondariesSaving || !selectedSecondaryId}>
+					<Button
+						type="button"
+						onclick={addToDraft}
+						disabled={
+							!selectedSecondaryId || draftSecondaries.length >= requiredSecondaryCount
+						}
+					>
 						Add secondary
 					</Button>
-				</form>
+				</div>
 			{:else}
 				<p class="mt-4 text-sm text-muted-foreground">
 					No {secondaryTypeName}-based scoring structures available to assign.
 				</p>
 			{/if}
+
+			<Button
+				type="button"
+				onclick={saveSecondaries}
+				disabled={secondariesSaving || !canSaveSecondaries}
+				class="mt-4"
+			>
+				{secondariesSaving
+					? 'Saving…'
+					: canSaveSecondaries
+						? 'Save secondaries'
+						: `Add ${requiredSecondaryCount - draftSecondaries.length} more to save`}
+			</Button>
 		{/if}
 
 		{#if secondariesError}

--- a/ui/src/routes/scoring-structures/[id]/+page.svelte
+++ b/ui/src/routes/scoring-structures/[id]/+page.svelte
@@ -6,9 +6,16 @@
 		getScoringStructure,
 		getScoreCountingTypes,
 		updateScoringStructure,
-		deleteScoringStructure
+		deleteScoringStructure,
+		getScoringStructureSecondaries,
+		setScoringStructureSecondaries,
+		listScoringStructures,
+		secondaryCountingTypeFor,
+		maximumScoreCountingUnits,
+		ScoreCountingTypes
 	} from '$lib/scoringStructure';
-	import type { ScoringStructure, ScoreCountingType } from '$lib/scoringStructure';
+	import type { ScoringStructure, ScoreCountingType, WinCondition } from '$lib/scoringStructure';
+	import { Badge } from '$lib/components/ui/badge/index.js';
 	import { Button, buttonVariants } from '$lib/components/ui/button/index.js';
 	import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
@@ -38,6 +45,45 @@
 	let deleting = $state(false);
 	let deleteOpen = $state(false);
 
+	// Secondary (tie-breaker) scoring structures assigned to this structure,
+	// ordered by SecondaryIndex.
+	let secondaries = $state<ScoringStructure[]>([]);
+	let allStructures = $state<ScoringStructure[]>([]);
+	let selectedSecondaryId = $state('');
+	let secondariesError = $state('');
+	let secondariesSaving = $state(false);
+
+	// The win condition as currently being edited in the form (what a save
+	// would validate against).
+	const formWinCondition = $derived<WinCondition>({
+		win_threshold: parseInt(winThreshold, 10) || 0,
+		must_win_by: parseInt(mustWinBy, 10) || 0,
+		instant_win_threshold: parseInt(instantWinThreshold || '0', 10) || 0
+	});
+
+	// The counting type secondaries must use (null = cannot be composite), and
+	// the number of secondaries this win condition requires (null = cannot be
+	// composite).
+	const secondaryType = $derived(secondaryCountingTypeFor(countingType));
+	const requiredSecondaryCount = $derived(
+		secondaryType === null ? null : maximumScoreCountingUnits(formWinCondition)
+	);
+	const eligibleStructures = $derived(
+		secondaryType === null
+			? []
+			: allStructures.filter((s) => s.win_condition_counting_type === secondaryType)
+	);
+	const secondaryTypeName = $derived(
+		countingTypes.find((t) => t.type === secondaryType)?.name.toLowerCase() ?? ''
+	);
+	const unitNoun = $derived(
+		countingType === ScoreCountingTypes.Set
+			? 'set'
+			: countingType === ScoreCountingTypes.Game
+				? 'game'
+				: ''
+	);
+
 	function countingTypeName(type: number): string {
 		return countingTypes.find((t) => t.type === type)?.name ?? String(type);
 	}
@@ -64,7 +110,54 @@
 			instantWinThreshold = String(s.win_condition.instant_win_threshold);
 		} catch (e) {
 			loadError = e instanceof Error ? e.message : 'Failed to load scoring structure';
+			return;
 		}
+		await loadSecondaries();
+	}
+
+	async function loadSecondaries() {
+		try {
+			secondaries = await getScoringStructureSecondaries(id());
+		} catch (e) {
+			secondariesError = e instanceof Error ? e.message : 'Failed to load secondary scoring structures';
+		}
+		// Refresh the full catalog so the add dropdown reflects available structures.
+		try {
+			allStructures = await listScoringStructures();
+		} catch {
+			// ignore; the add dropdown just stays empty
+		}
+	}
+
+	async function saveSecondaries(secondaryIds: string[]) {
+		secondariesError = '';
+		secondariesSaving = true;
+		try {
+			secondaries = await setScoringStructureSecondaries(id(), secondaryIds);
+			selectedSecondaryId = '';
+		} catch (err) {
+			secondariesError = err instanceof Error ? err.message : 'Failed to update secondary scoring structures';
+		} finally {
+			secondariesSaving = false;
+		}
+	}
+
+	function handleAddSecondary(e: Event) {
+		e.preventDefault();
+		if (!selectedSecondaryId) return;
+		saveSecondaries([...secondaries.map((s) => s.id), selectedSecondaryId]);
+	}
+
+	function handleRemoveSecondary(index: number) {
+		saveSecondaries(secondaries.filter((_, i) => i !== index).map((s) => s.id));
+	}
+
+	function handleMoveSecondary(index: number, direction: -1 | 1) {
+		const target = index + direction;
+		if (target < 0 || target >= secondaries.length) return;
+		const next = secondaries.map((s) => s.id);
+		[next[index], next[target]] = [next[target], next[index]];
+		saveSecondaries(next);
 	}
 
 	async function handleSave(e: Event) {
@@ -193,6 +286,120 @@
 			</form>
 		</CardContent>
 	</Card>
+
+	<section class="mt-6 max-w-md">
+		<h2 class="text-xl font-semibold tracking-tight">Secondary scoring structures</h2>
+
+		{#if secondaries.length > 0}
+			<ul class="mt-4 flex flex-col gap-2">
+				{#each secondaries as secondary, i}
+					<li class="flex items-center justify-between gap-2 rounded-lg border p-2 pl-3">
+						<span class="flex items-center gap-2">
+							<span class="text-sm text-muted-foreground">{i + 1}.</span>
+							<Badge variant="secondary" class="secondary-name">{secondary.name}</Badge>
+						</span>
+						<span class="flex items-center gap-1">
+							<Button
+								type="button"
+								variant="outline"
+								size="sm"
+								onclick={() => handleMoveSecondary(i, -1)}
+								disabled={secondariesSaving || i === 0}
+							>
+								↑
+							</Button>
+							<Button
+								type="button"
+								variant="outline"
+								size="sm"
+								onclick={() => handleMoveSecondary(i, 1)}
+								disabled={secondariesSaving || i === secondaries.length - 1}
+							>
+								↓
+							</Button>
+							<Button
+								type="button"
+								variant="outline"
+								size="sm"
+								onclick={() => handleRemoveSecondary(i)}
+								disabled={secondariesSaving}
+							>
+								Remove
+							</Button>
+						</span>
+					</li>
+				{/each}
+			</ul>
+		{/if}
+
+		{#if secondaryType === null}
+			<p class="mt-2 text-sm text-muted-foreground">
+				Point-based scoring structures cannot have secondary (tie-breaker) scoring structures
+				{#if secondaries.length > 0}
+					— remove the {secondaries.length} assigned secondaries (or change the counting type)
+					before saving.
+				{/if}
+			</p>
+		{:else if requiredSecondaryCount === null}
+			<p class="mt-2 text-sm text-muted-foreground">
+				Win conditions that require winning by 2 or more without an instant-win threshold cannot
+				be composite
+				{#if secondaries.length > 0}
+					— remove the {secondaries.length} assigned secondaries (or change the win condition)
+					before saving.
+				{/if}
+			</p>
+		{:else}
+			<p class="mt-1 text-sm text-muted-foreground">
+				The {secondaryTypeName}-based structures used to score each {unitNoun} in this structure,
+				in tie-breaker order.
+			</p>
+
+			{#if secondaries.length === 0}
+				<p class="mt-4 text-muted-foreground">No secondary scoring structures assigned yet.</p>
+			{/if}
+
+			{#if secondaries.length !== requiredSecondaryCount}
+				<p class="mt-2 text-sm text-muted-foreground">
+					This win condition can play at most {requiredSecondaryCount} {unitNoun}s, so a
+					composite structure needs exactly {requiredSecondaryCount} secondary scoring
+					structures ({secondaries.length} currently assigned).
+				</p>
+			{:else if secondaries.length > 0}
+				<p class="mt-2 text-sm text-muted-foreground">
+					All {requiredSecondaryCount} required secondary scoring structures assigned.
+				</p>
+			{/if}
+
+			{#if eligibleStructures.length > 0}
+				<form onsubmit={handleAddSecondary} class="mt-4 flex items-center gap-2">
+					<NativeSelect
+						bind:value={selectedSecondaryId}
+						aria-label="Secondary structure to assign"
+						class="flex-1"
+					>
+						<NativeSelectOption value="" disabled
+							>Select a {secondaryTypeName} structure…</NativeSelectOption
+						>
+						{#each eligibleStructures as s}
+							<NativeSelectOption value={s.id}>{s.name}</NativeSelectOption>
+						{/each}
+					</NativeSelect>
+					<Button type="submit" disabled={secondariesSaving || !selectedSecondaryId}>
+						Add secondary
+					</Button>
+				</form>
+			{:else}
+				<p class="mt-4 text-sm text-muted-foreground">
+					No {secondaryTypeName}-based scoring structures available to assign.
+				</p>
+			{/if}
+		{/if}
+
+		{#if secondariesError}
+			<p class="mt-3 text-sm font-medium text-destructive">{secondariesError}</p>
+		{/if}
+	</section>
 
 	<div class="mt-4">
 		<Popover bind:open={deleteOpen}>


### PR DESCRIPTION
Closes #161

## Summary
Exposes the existing `ScoringStructureSecondary` join table (DB done in #59) via API and lets users manage a scoring structure's secondary (tie-breaker) scoring structures from `/scoring-structures/[id]`.

## API
- Registers generic CRUD for `scoring_structure_secondary` in `main.go` (read for everyone; update/delete gated by the record's sysadmin-only `EditableBy`, matching the other join tables).
- New `route/scoringstructure` with get/set routes mirroring `route/format`'s possible-ratings pattern:
  - `GET /api/scoring_structure/:id/secondary_scoring_structures` — the structure's secondaries as full records, ordered by `SecondaryIndex`.
  - `PUT /api/scoring_structure/:id/secondary_scoring_structures` — atomically replaces the full ordered list (body: `{ secondary_scoring_structures: [id, ...] }`; empty list makes it non-composite). Enforces the primary's edit authz (owner / sysadmin) and rejects secondaries with the wrong score-counting type up front (the same rule `ScoringStructure.DynamicallyValid` enforces on primary save).
- Ordering (`SecondaryIndex`) is preserved: the set route rewrites the join rows with `SecondaryIndex` = list position, and GET always returns them sorted by it.

## UI
- `/scoring-structures/[id]` gains a "Secondary scoring structures" section: ordered list with move up/down + remove, an add dropdown filtered to the eligible counting type (Set→Game, Game→Point), and a required-count hint derived from the win condition being edited (mirrors `MaximumScoreCountingUnitsPlayed`). Point-based and win-by-2+-without-instant-win structures show why they cannot be composite (and how to recover if secondaries are already assigned).
- `lib/scoringStructure.ts` gains the get/set clients plus the `ScoreCountingTypes` / `secondaryCountingTypeFor` / `maximumScoreCountingUnits` helpers.

## Tests
- Go: `route/scoringstructure` covers set/get/reorder/clear, authz (owner, sysadmin, non-owner, unauthenticated), counting-type/unknown-ID validation, and the raw CRUD surface.
- e2e: `scoring-structure-secondary.spec.ts` — create a best-of-3-sets primary, add three game-based secondaries (incl. a duplicate at a different position), reorder, save the primary, verify the under-assigned save is rejected with the backend validation error, re-add and save again, then clean up (primary delete cascades the join rows).
- `make tests`, `npm run check`, `npm run test`, and `make e2e` (3 consecutive full runs) are green.

## Also
- Fixes a latent bug in `ScoringStructureId.UnmarshalJSON`: the value receiver unmarshaled into a local copy, so any Go-side JSON unmarshal of a `ScoringStructure` silently lost its ID. (Note: `PlayoffStructureId` and `PhotoId` have the same pattern — left untouched here as out of scope.)