### PR TITLE
API + UI: season late additions

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ import (
 	"intraclub/route/availability"
 	"intraclub/route/draft"
 	"intraclub/route/format"
+	"intraclub/route/lateaddition"
 	"intraclub/route/lineup"
 	"intraclub/route/match"
 	"intraclub/route/organization"
@@ -66,6 +67,11 @@ func main() {
 
 	whoAmI := api.RouteFamily[*model.User]{DatabaseProvider: db}
 	whoAmI.Handle(rg, user.WhoAmI{})
+
+	// whoami/roles lists the current user's role names; the UI uses it to gate
+	// sysadmin-only controls (e.g. season late additions).
+	roles := api.RouteFamily[*model.User]{DatabaseProvider: db}
+	roles.Handle(rg, user.Roles{})
 
 	importHandler := &route.CsvImportHandler{DatabaseProvider: db}
 	rg.Handle(api.HttpMethodPost.String(), "/import_users_from_csv", importHandler.HandleCsvImport)
@@ -166,6 +172,16 @@ func main() {
 	seasonTeams.HandleRouteTypes(rg, api.CrudWrapperFunctionGetOne, api.CrudWrapperFunctionGetMany)
 	teamRatings := api.NewCrudCommon(func() *model.TeamRating { return &model.TeamRating{} }, false, db)
 	teamRatings.HandleRouteTypes(rg, api.CrudWrapperFunctionGetOne, api.CrudWrapperFunctionGetMany)
+
+	// SeasonLateAdditions link a Season to Users added after the draft was
+	// completed. The generic surface is read-only (the season page shows them);
+	// writes go exclusively through the custom routes in route/lateaddition,
+	// which enforce the model's sysadmin-only EditableBy constraint (the
+	// generic create path does not check EditableBy).
+	seasonLateAdditions := api.NewCrudCommon(func() *model.SeasonLateAddition { return &model.SeasonLateAddition{} }, false, db)
+	seasonLateAdditions.HandleRouteTypes(rg, api.CrudWrapperFunctionGetOne, api.CrudWrapperFunctionGetMany)
+	lateAdditions := api.RouteFamily[*lateaddition.AddLateAdditionBody]{DatabaseProvider: db}
+	lateAdditions.Handle(rg, lateaddition.AddLateAddition{}, lateaddition.RemoveLateAddition{})
 
 	// Teams are largely immutable after the draft finalizes: they are exposed
 	// only through the constrained read + role-assignment surface in

--- a/model/dev_data.go
+++ b/model/dev_data.go
@@ -9,10 +9,17 @@ import (
 )
 
 func SeedDevData(db database.Provider) {
-	user := seedDevUsers(db)
-	seedDevScoringStructures(db, user.ID)
-	seedDevRatings(db, user.ID)
-	seedDevFormat(db, user.ID)
+	users := seedDevUsers(db)
+	// In dev mode the seeded jdarthur@gatech.edu user is the system
+	// administrator so the dev / e2e flows (which log in as that user) can
+	// exercise sysadmin-only write paths (e.g. season late additions).
+	if err := users[0].AssignRole(getDevContext(), db, SystemAdministrator); err != nil {
+		panic(err)
+	}
+	owner := users[0]
+	seedDevScoringStructures(db, owner.ID)
+	seedDevRatings(db, owner.ID)
+	seedDevFormat(db, owner.ID)
 }
 
 func getDevContext() context.Context {
@@ -21,7 +28,7 @@ func getDevContext() context.Context {
 	return ctx
 }
 
-func seedDevUsers(db database.Provider) *User {
+func seedDevUsers(db database.Provider) []*User {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -42,20 +49,21 @@ func seedDevUsers(db database.Provider) *User {
 		{"Imani", "Silva", "imani.silva@example.com"},
 	}
 
-	var v *User
+	// jdarthur@gatech.edu is the first user (and the dev/e2e login account).
+	created := make([]*User, 0, len(devUsers))
 	for _, u := range devUsers {
 		user := NewUser()
 		user.FirstName = u.FirstName
 		user.LastName = u.LastName
 		user.Email = EmailAddress(u.Email)
 
-		created, err := database.CreateOne(ctx, db, user)
+		createdUser, err := database.CreateOne(ctx, db, user)
 		if err != nil {
 			panic(err)
 		}
-		v = created
+		created = append(created, createdUser)
 	}
-	return v
+	return created
 }
 
 func seedDevScoringStructures(db database.Provider, u database.UserId) {

--- a/model/role.go
+++ b/model/role.go
@@ -166,6 +166,23 @@ func IsUserSystemAdministrator(ctx context.Context, db database.Provider, userId
 	return user.HasRole(ctx, db, SystemAdministrator)
 }
 
+// GetRoles returns the names of all roles assigned to this user, in the order
+// the assignments were created.
+func (u *User) GetRoles(ctx context.Context, db database.Provider) ([]string, error) {
+	filter := func(_ context.Context, c *UserRoleAssignment) bool {
+		return c.UserId == u.ID
+	}
+	assignments, err := database.GetAllWhere[*UserRoleAssignment](ctx, db, filter)
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(assignments))
+	for _, a := range assignments {
+		names = append(names, a.Role.String())
+	}
+	return names, nil
+}
+
 func (u *User) HasRole(ctx context.Context, db database.Provider, role Role) (bool, error) {
 
 	filter := func(_ context.Context, c *UserRoleAssignment) bool {

--- a/route/lateaddition/late_addition.go
+++ b/route/lateaddition/late_addition.go
@@ -1,0 +1,130 @@
+// Package lateaddition exposes the write surface for SeasonLateAddition
+// records (adding/removing players to a season after the draft completed).
+//
+// The generic CRUD surface in main.go is registered read-only for this type;
+// writes go exclusively through the routes in this package, which enforce the
+// model's sysadmin-only EditableBy constraint. (The generic create path does
+// not check EditableBy, so a plain POST /api/season_late_addition would
+// otherwise let any logged-in user add late players.)
+package lateaddition
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"intraclub/api"
+	"intraclub/database"
+	"intraclub/model"
+
+	"github.com/gin-gonic/gin"
+)
+
+// BaseRoute is the base API route for SeasonLateAddition records. It matches
+// the model's Type() ("season_late_addition").
+var BaseRoute = "/season_late_addition"
+
+// AddLateAdditionBody is the request body for AddLateAddition.
+type AddLateAdditionBody struct {
+	// SeasonId is the season the user is being added to.
+	SeasonId model.SeasonId `json:"season_id"`
+
+	// UserId is the user being added to the season after the draft.
+	UserId database.UserId `json:"user_id"`
+}
+
+// StaticallyValid ensures both a season and a user were provided.
+func (b *AddLateAdditionBody) StaticallyValid() error {
+	if b.SeasonId == model.SeasonId(database.InvalidRecordId) {
+		return errors.New("season_id must not be empty")
+	}
+	if b.UserId == database.InvalidUserId {
+		return errors.New("user_id must not be empty")
+	}
+	return nil
+}
+
+// AddLateAddition creates a SeasonLateAddition record linking the given user
+// to the given season. Only a system administrator may add late players.
+type AddLateAddition struct{}
+
+func (c AddLateAddition) Path() (api.HttpMethod, string) {
+	return api.HttpMethodPost, BaseRoute
+}
+
+func (c AddLateAddition) RequestBody() (*AddLateAdditionBody, bool) {
+	return &AddLateAdditionBody{}, true
+}
+
+func (c AddLateAddition) Handler(req api.Request[*AddLateAdditionBody]) (any, int, error) {
+	if req.Token == nil {
+		return nil, http.StatusUnauthorized, errors.New("token is required")
+	}
+
+	isAdmin, err := model.IsUserSystemAdministrator(req.Context, req.DatabaseProvider, req.Token.UserId)
+	if err != nil {
+		return nil, http.StatusInternalServerError, err
+	}
+	if !isAdmin {
+		return nil, http.StatusForbidden, errors.New("only a system administrator may add late players to a season")
+	}
+
+	season, err := database.GetExistingRecordById(req.Context, req.DatabaseProvider, &model.Season{}, req.Body.SeasonId.RecordId())
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	if err := season.AddLateAddition(req.Context, req.DatabaseProvider, req.Body.UserId); err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+
+	// Return the created record so the client can use its ID to remove it.
+	additions, err := database.GetAllWhere[*model.SeasonLateAddition](req.Context, req.DatabaseProvider,
+		func(_ context.Context, l *model.SeasonLateAddition) bool {
+			return l.SeasonId == season.ID && l.UserId == req.Body.UserId
+		})
+	if err != nil {
+		return nil, http.StatusInternalServerError, err
+	}
+	if len(additions) == 0 {
+		return nil, http.StatusInternalServerError, errors.New("late addition was not created")
+	}
+	return gin.H{api.ResourceKey: additions[0]}, http.StatusOK, nil
+}
+
+// RemoveLateAddition deletes the SeasonLateAddition record with the given ID.
+// Only a system administrator may remove late players.
+type RemoveLateAddition struct{}
+
+func (c RemoveLateAddition) Path() (api.HttpMethod, string) {
+	return api.HttpMethodDelete, api.AppendPathId(BaseRoute)
+}
+
+func (c RemoveLateAddition) RequestBody() (*AddLateAdditionBody, bool) {
+	return &AddLateAdditionBody{}, false
+}
+
+func (c RemoveLateAddition) Handler(req api.Request[*AddLateAdditionBody]) (any, int, error) {
+	if req.Token == nil {
+		return nil, http.StatusUnauthorized, errors.New("token is required")
+	}
+
+	isAdmin, err := model.IsUserSystemAdministrator(req.Context, req.DatabaseProvider, req.Token.UserId)
+	if err != nil {
+		return nil, http.StatusInternalServerError, err
+	}
+	if !isAdmin {
+		return nil, http.StatusForbidden, errors.New("only a system administrator may remove late players from a season")
+	}
+
+	existing, exists, err := database.GetOneById(req.Context, req.DatabaseProvider, &model.SeasonLateAddition{}, req.PathId)
+	if err != nil {
+		return nil, http.StatusInternalServerError, err
+	}
+	if !exists {
+		return nil, http.StatusNotFound, errors.New("late addition not found")
+	}
+	if _, _, err := database.DeleteOneById(req.Context, req.DatabaseProvider, existing, existing.ID); err != nil {
+		return nil, http.StatusInternalServerError, err
+	}
+	return gin.H{api.ResourceKey: existing}, http.StatusOK, nil
+}

--- a/route/lateaddition/late_addition_test.go
+++ b/route/lateaddition/late_addition_test.go
@@ -1,0 +1,239 @@
+package lateaddition
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/rand/v2"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"intraclub/api"
+	"intraclub/database"
+	"intraclub/model"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// test setup helpers (mirror route/team/promote_test.go)
+// ---------------------------------------------------------------------------
+
+func newStoredUser(t *testing.T, db database.Provider) *model.User {
+	t.Helper()
+	user := model.NewUser()
+	user.Email = model.EmailAddress(fmt.Sprintf("user%d@email.com", rand.Uint64()))
+	user.FirstName = fmt.Sprintf("Test %d", rand.Uint64())
+	user.LastName = "User"
+	user.PhoneNumber = model.PhoneNumber(fmt.Sprintf("%d", 100_000_0000+rand.Uint32N(999_999_999)))
+	v, err := database.CreateOne(context.Background(), db, user)
+	require.NoError(t, err)
+	return v
+}
+
+// newTestRouter builds a gin engine with the late-addition write surface
+// registered (as in main.go) and the auth globals wired up so real tokens
+// validate.
+func newTestRouter(t *testing.T, db database.Provider) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	api.UserType = &model.User{}
+	database.SysAdminCheck = model.IsUserSystemAdministrator
+
+	router := gin.New()
+	group := router.Group("/api")
+
+	lateAdditions := api.RouteFamily[*AddLateAdditionBody]{DatabaseProvider: db}
+	lateAdditions.Handle(group, AddLateAddition{}, RemoveLateAddition{})
+
+	return router
+}
+
+// testKeyOnce generates a single JWT keypair shared by every token minted in a
+// test process, so tokens issued by different helpers all verify.
+var (
+	testKeyOnce sync.Once
+	testPubKey  *ecdsa.PublicKey
+	testPrivKey *ecdsa.PrivateKey
+)
+
+func newToken(t *testing.T, userId database.UserId) string {
+	t.Helper()
+	testKeyOnce.Do(func() {
+		pub, priv, err := api.GenerateKeyPair()
+		require.NoError(t, err)
+		testPubKey = pub
+		testPrivKey = priv
+	})
+	api.JwtPublicKey = testPubKey
+	api.JwtPrivateKey = testPrivKey
+	token, err := api.GenerateToken(userId.RecordId())
+	require.NoError(t, err)
+	return token
+}
+
+// doJSON performs an authenticated HTTP request against the router.
+func doJSON(t *testing.T, router *gin.Engine, method, path string, body any, token string) *httptest.ResponseRecorder {
+	t.Helper()
+	var reader io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		require.NoError(t, err)
+		reader = bytes.NewReader(b)
+	}
+	req, err := http.NewRequest(method, path, reader)
+	require.NoError(t, err)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if token != "" {
+		req.Header.Set(api.AuthTokenHeaderValue, token)
+	}
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+// newSeason creates a minimal Season record (the fields required for
+// DynamicallyValid on a SeasonLateAddition to pass).
+func newSeason(t *testing.T, db database.Provider, owner *model.User) *model.Season {
+	t.Helper()
+	season := model.NewSeason()
+	season.Name = fmt.Sprintf("Season %d", rand.Uint64())
+	season.StartTime = model.NewStartTime(8, 30)
+	season.Owner = owner.ID
+	v, err := database.CreateOne(context.Background(), db, season)
+	require.NoError(t, err)
+	return v
+}
+
+func lateAdditionUserIds(t *testing.T, db database.Provider, seasonId model.SeasonId) []database.UserId {
+	t.Helper()
+	rows, err := database.GetAllWhere[*model.SeasonLateAddition](context.Background(), db,
+		func(_ context.Context, l *model.SeasonLateAddition) bool { return l.SeasonId == seasonId })
+	require.NoError(t, err)
+	ids := make([]database.UserId, 0, len(rows))
+	for _, r := range rows {
+		ids = append(ids, r.UserId)
+	}
+	return ids
+}
+
+// ---------------------------------------------------------------------------
+// AddLateAddition
+// ---------------------------------------------------------------------------
+
+func TestAddLateAddition_SysAdmin(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	admin := newStoredUser(t, db)
+	require.NoError(t, admin.AssignRole(context.Background(), db, model.SystemAdministrator))
+	season := newSeason(t, db, admin)
+	player := newStoredUser(t, db)
+	token := newToken(t, admin.ID)
+
+	w := doJSON(t, router, http.MethodPost, "/api/season_late_addition",
+		AddLateAdditionBody{SeasonId: season.ID, UserId: player.ID}, token)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	var resp struct {
+		Resource model.SeasonLateAddition `json:"resource"`
+	}
+	require.NoError(t, json.NewDecoder(bytes.NewReader(w.Body.Bytes())).Decode(&resp))
+	require.Equal(t, season.ID, resp.Resource.SeasonId)
+	require.Equal(t, player.ID, resp.Resource.UserId)
+
+	require.Contains(t, lateAdditionUserIds(t, db, season.ID), player.ID)
+}
+
+func TestAddLateAddition_NonSysAdminForbidden(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	regular := newStoredUser(t, db)
+	season := newSeason(t, db, regular)
+	other := newStoredUser(t, db)
+	token := newToken(t, regular.ID)
+
+	w := doJSON(t, router, http.MethodPost, "/api/season_late_addition",
+		AddLateAdditionBody{SeasonId: season.ID, UserId: other.ID}, token)
+	require.Equal(t, http.StatusForbidden, w.Code, "body: %s", w.Body.String())
+
+	require.Empty(t, lateAdditionUserIds(t, db, season.ID))
+}
+
+func TestAddLateAddition_NoToken(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	season := newSeason(t, db, newStoredUser(t, db))
+
+	w := doJSON(t, router, http.MethodPost, "/api/season_late_addition",
+		AddLateAdditionBody{SeasonId: season.ID, UserId: newStoredUser(t, db).ID}, "")
+	require.Equal(t, http.StatusUnauthorized, w.Code, "body: %s", w.Body.String())
+}
+
+// ---------------------------------------------------------------------------
+// RemoveLateAddition
+// ---------------------------------------------------------------------------
+
+func addLateAddition(t *testing.T, db database.Provider, season *model.Season, user *model.User) *model.SeasonLateAddition {
+	t.Helper()
+	require.NoError(t, season.AddLateAddition(context.Background(), db, user.ID))
+	rows, err := database.GetAllWhere[*model.SeasonLateAddition](context.Background(), db,
+		func(_ context.Context, l *model.SeasonLateAddition) bool {
+			return l.SeasonId == season.ID && l.UserId == user.ID
+		})
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	return rows[0]
+}
+
+func TestRemoveLateAddition_SysAdmin(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	admin := newStoredUser(t, db)
+	require.NoError(t, admin.AssignRole(context.Background(), db, model.SystemAdministrator))
+	season := newSeason(t, db, admin)
+	player := newStoredUser(t, db)
+	la := addLateAddition(t, db, season, player)
+	token := newToken(t, admin.ID)
+
+	w := doJSON(t, router, http.MethodDelete, fmt.Sprintf("/api/season_late_addition/%s", la.ID), nil, token)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	require.NotContains(t, lateAdditionUserIds(t, db, season.ID), player.ID)
+}
+
+func TestRemoveLateAddition_NonSysAdminForbidden(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	admin := newStoredUser(t, db)
+	require.NoError(t, admin.AssignRole(context.Background(), db, model.SystemAdministrator))
+	season := newSeason(t, db, admin)
+	player := newStoredUser(t, db)
+	la := addLateAddition(t, db, season, player)
+	regular := newStoredUser(t, db)
+	token := newToken(t, regular.ID)
+
+	w := doJSON(t, router, http.MethodDelete, fmt.Sprintf("/api/season_late_addition/%s", la.ID), nil, token)
+	require.Equal(t, http.StatusForbidden, w.Code, "body: %s", w.Body.String())
+
+	require.Contains(t, lateAdditionUserIds(t, db, season.ID), player.ID)
+}
+
+func TestRemoveLateAddition_NotFound(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	admin := newStoredUser(t, db)
+	require.NoError(t, admin.AssignRole(context.Background(), db, model.SystemAdministrator))
+	token := newToken(t, admin.ID)
+
+	missing := database.NewRecordId()
+	w := doJSON(t, router, http.MethodDelete, fmt.Sprintf("/api/season_late_addition/%s", missing.String()), nil, token)
+	require.Equal(t, http.StatusNotFound, w.Code, "body: %s", w.Body.String())
+}

--- a/route/user/roles.go
+++ b/route/user/roles.go
@@ -1,0 +1,49 @@
+package user
+
+import (
+	"errors"
+	"net/http"
+
+	"intraclub/api"
+	"intraclub/database"
+	"intraclub/model"
+
+	"github.com/gin-gonic/gin"
+)
+
+// RolesRoute is the path for the current user's role list.
+var RolesRoute = "/whoami/roles"
+
+// Roles returns the role names of the authenticated user, e.g.
+// `{"roles": ["System Administrator"]}`. The UI uses it to gate
+// sysadmin-only controls (such as season late additions).
+type Roles struct{}
+
+func (c Roles) Path() (api.HttpMethod, string) {
+	return api.HttpMethodGet, RolesRoute
+}
+
+func (c Roles) RequestBody() (*model.User, bool) {
+	// roles takes no request body: the caller's identity comes from the token.
+	// Declaring a body here makes the generic wrapper bind + StaticallyValid a
+	// zero-valued User and 400 before the handler runs (see #196).
+	return nil, false
+}
+
+func (c Roles) Handler(req api.Request[*model.User]) (any, int, error) {
+	if req.Token == nil {
+		return nil, http.StatusUnauthorized, errors.New("token is required")
+	}
+
+	user, err := database.GetExistingRecordById(req.Context, req.DatabaseProvider, &model.User{}, req.Token.UserId.RecordId())
+	if err != nil {
+		return nil, http.StatusUnauthorized, err
+	}
+
+	roles, err := user.GetRoles(req.Context, req.DatabaseProvider)
+	if err != nil {
+		return nil, http.StatusInternalServerError, err
+	}
+
+	return gin.H{"roles": roles}, http.StatusOK, nil
+}

--- a/route/user/who_am_i.go
+++ b/route/user/who_am_i.go
@@ -18,7 +18,10 @@ func (c WhoAmI) Path() (api.HttpMethod, string) {
 }
 
 func (c WhoAmI) RequestBody() (*model.User, bool) {
-	return &model.User{}, true
+	// whoami takes no request body: the caller's identity comes from the token.
+	// Declaring a body here makes the generic wrapper bind + StaticallyValid a
+	// zero-valued User and 400 before the handler runs (see #196).
+	return nil, false
 }
 
 func (c WhoAmI) Handler(req api.Request[*model.User]) (any, int, error) {

--- a/route/user/who_am_i_test.go
+++ b/route/user/who_am_i_test.go
@@ -1,0 +1,158 @@
+package user
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"encoding/json"
+	"fmt"
+	"math/rand/v2"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"intraclub/api"
+	"intraclub/database"
+	"intraclub/model"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+// ---------------------------------------------------------------------------
+// test setup helpers (mirror route/team/promote_test.go)
+// ---------------------------------------------------------------------------
+
+func newStoredUser(t *testing.T, db database.Provider) *model.User {
+	t.Helper()
+	user := model.NewUser()
+	user.Email = model.EmailAddress(fmt.Sprintf("user%d@email.com", rand.Uint64()))
+	user.FirstName = fmt.Sprintf("Test %d", rand.Uint64())
+	user.LastName = "User"
+	user.PhoneNumber = model.PhoneNumber(fmt.Sprintf("%d", 100_000_0000+rand.Uint32N(999_999_999)))
+	v, err := database.CreateOne(context.Background(), db, user)
+	require.NoError(t, err)
+	return v
+}
+
+// newTestRouter builds a gin engine with the whoami + roles endpoints
+// registered (as in main.go) and the auth globals wired up so real tokens
+// validate.
+func newTestRouter(t *testing.T, db database.Provider) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	api.UserType = &model.User{}
+	database.SysAdminCheck = model.IsUserSystemAdministrator
+
+	router := gin.New()
+	group := router.Group("/api")
+
+	whoAmI := api.RouteFamily[*model.User]{DatabaseProvider: db}
+	whoAmI.Handle(group, WhoAmI{})
+
+	roles := api.RouteFamily[*model.User]{DatabaseProvider: db}
+	roles.Handle(group, Roles{})
+
+	return router
+}
+
+// testKeyOnce generates a single JWT keypair shared by every token minted in a
+// test process, so tokens issued by different helpers all verify.
+var (
+	testKeyOnce sync.Once
+	testPubKey  *ecdsa.PublicKey
+	testPrivKey *ecdsa.PrivateKey
+)
+
+func newToken(t *testing.T, userId database.UserId) string {
+	t.Helper()
+	testKeyOnce.Do(func() {
+		pub, priv, err := api.GenerateKeyPair()
+		require.NoError(t, err)
+		testPubKey = pub
+		testPrivKey = priv
+	})
+	api.JwtPublicKey = testPubKey
+	api.JwtPrivateKey = testPrivKey
+	token, err := api.GenerateToken(userId.RecordId())
+	require.NoError(t, err)
+	return token
+}
+
+// doGet performs an authenticated HTTP GET against the router.
+func doGet(t *testing.T, router *gin.Engine, path, token string) *httptest.ResponseRecorder {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, path, nil)
+	require.NoError(t, err)
+	if token != "" {
+		req.Header.Set(api.AuthTokenHeaderValue, token)
+	}
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+// ---------------------------------------------------------------------------
+// WhoAmI
+// ---------------------------------------------------------------------------
+
+// TestWhoAmI returns 200 and the caller's user for a valid token. Regression
+// for #196: RequestBody previously declared a body, so the generic wrapper
+// StaticallyValid'd a zero-valued User and aborted with 400 before the handler
+// ran.
+func TestWhoAmI_ValidToken(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	user := newStoredUser(t, db)
+	token := newToken(t, user.ID)
+
+	w := doGet(t, router, "/api/whoami", token)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	var resp model.User
+	err := json.NewDecoder(bytes.NewReader(w.Body.Bytes())).Decode(&resp)
+	require.NoError(t, err)
+	require.Equal(t, user.ID, resp.ID)
+	require.Equal(t, user.FirstName, resp.FirstName)
+}
+
+// TestWhoAmI_NoToken returns 401 (not 400) when no token is supplied.
+func TestWhoAmI_NoToken(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+
+	w := doGet(t, router, "/api/whoami", "")
+	require.Equal(t, http.StatusUnauthorized, w.Code, "body: %s", w.Body.String())
+}
+
+// ---------------------------------------------------------------------------
+// Roles
+// ---------------------------------------------------------------------------
+
+// TestRoles returns the caller's role names for a valid token.
+func TestRoles_ValidToken(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	user := newStoredUser(t, db)
+	require.NoError(t, user.AssignRole(context.Background(), db, model.SystemAdministrator))
+	token := newToken(t, user.ID)
+
+	w := doGet(t, router, "/api/whoami/roles", token)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	var resp struct {
+		Roles []string `json:"roles"`
+	}
+	err := json.NewDecoder(bytes.NewReader(w.Body.Bytes())).Decode(&resp)
+	require.NoError(t, err)
+	require.Contains(t, resp.Roles, model.SystemAdministrator.String())
+}
+
+// TestRoles_NoToken returns 401 when no token is supplied.
+func TestRoles_NoToken(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+
+	w := doGet(t, router, "/api/whoami/roles", "")
+	require.Equal(t, http.StatusUnauthorized, w.Code, "body: %s", w.Body.String())
+}

--- a/ui/e2e/season-late-additions.spec.ts
+++ b/ui/e2e/season-late-additions.spec.ts
@@ -1,0 +1,217 @@
+import { expect, test, type Page } from '@playwright/test';
+import { waitForHydration } from './helpers';
+
+// The Go backend runs with --dev-token from the repo root (see
+// playwright.config.ts), so POST /api/one_time_password returns the magic-link
+// token in the response body. The seeded jdarthur@gatech.edu user is the system
+// administrator in dev mode (see model.SeedDevData), which is required to
+// exercise the sysadmin-only late-addition write surface.
+async function login(page: Page, email: string) {
+	await page.goto('/login');
+	await page.waitForLoadState('networkidle');
+	await page.getByLabel('Email').fill(email);
+	await page.getByRole('button', { name: 'Send login link' }).click();
+	const link = page.getByRole('main').getByRole('link', { name: 'Log in' });
+	await expect(link).toBeVisible();
+	await link.click();
+	await expect(page).toHaveURL('/');
+}
+
+// SeedDevData creates a format named "Men's Intraclub".
+const SEED_FORMAT = "Men's Intraclub";
+const API = 'http://127.0.0.1:8080/api';
+
+// createSeason runs the minimal draft flow (one captain + one roster player)
+// and finalizes it into a season, returning the season id.
+async function createSeason(page: Page, token: string, unique: number): Promise<string> {
+	const people = [
+		{ first: `Cap${unique}`, last: 'LA' },
+		{ first: `Play${unique}`, last: 'LA' }
+	];
+	const csv = [
+		'First Name, Last Name, Email',
+		...people.map((p) => `${p.first}, ${p.last}, ${p.first.toLowerCase()}@example.com`)
+	].join('\n');
+	const importRes = await page.request.post(`${API}/import_users_from_csv`, {
+		form: { file: csv }
+	});
+	expect(importRes.ok()).toBeTruthy();
+	const importBody = await importRes.json();
+	const [captainId, playerId] = [...importBody.Created, ...importBody.AlreadyExisting].map(
+		(u: { id: string }) => u.id
+	);
+
+	const facilityRes = await page.request.post(`${API}/facility`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { name: `Late Add Facility ${unique}`, address: `${unique} Main St`, courts: 4 }
+	});
+	expect(facilityRes.ok()).toBeTruthy();
+	const facilityId = (await facilityRes.json()).resource.id as string;
+
+	const formats = (await (await page.request.get(`${API}/format`)).json()).resource as {
+		id: string;
+		name: string;
+	}[];
+	const format = formats.find((f) => f.name === SEED_FORMAT);
+	expect(format).toBeTruthy();
+
+	const draftRes = await page.request.post(`${API}/draft`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { name: `Late Add Draft ${unique}`, format: format!.id }
+	});
+	expect(draftRes.ok()).toBeTruthy();
+	const draftId = (await draftRes.json()).resource.id as string;
+
+	await page.request.post(`${API}/draft/${draftId}/initialize`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { captains: [captainId] }
+	});
+	await page.request.post(`${API}/draft/${draftId}/assign_draftable_players`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { players: [playerId] }
+	});
+
+	const ratings = (
+		await (
+			await page.request.get(`${API}/format/${format!.id}/possible_ratings`, {
+				headers: { 'X-INTRACLUB-TOKEN': token }
+			})
+		).json()
+	).resource as { id: string }[];
+	// Cutoffs are required for every rating except the last (lowest-skill) one.
+	expect(ratings.length).toBeGreaterThanOrEqual(2);
+	await page.request.post(`${API}/draft/${draftId}/assign_rating_cutoff`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { rating: ratings[0].id, cutoff: 1 }
+	});
+	await page.request.post(`${API}/draft/${draftId}/assign_rating_cutoff`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { rating: ratings[1].id, cutoff: 5 }
+	});
+
+	const captainToken = await tokenFor(page, `${people[0].first.toLowerCase()}@example.com`);
+
+	// The captain drafts the roster player, then themselves -> 2 picks = complete.
+	for (const player of [playerId, captainId]) {
+		const res = await page.request.post(`${API}/draft/${draftId}/select`, {
+			headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': captainToken },
+			data: { player_id: player }
+		});
+		expect(res.ok(), `pick failed: ${await res.text()}`).toBeTruthy();
+	}
+
+	const seasonRes = await page.request.post(`${API}/draft/${draftId}/create_season`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { name: `Late Add Season ${unique}`, facility: facilityId, start_time: '08:30' }
+	});
+	expect(seasonRes.ok()).toBeTruthy();
+	return (await seasonRes.json()).resource.id as string;
+}
+
+async function tokenFor(page: Page, email: string): Promise<string> {
+	const res = await page.request.post(`${API}/one_time_password`, { data: { email } });
+	expect(res.ok()).toBeTruthy();
+	const { token } = await res.json();
+	const jwtRes = await page.request.post(`${API}/token`, { data: { token } });
+	expect(jwtRes.ok()).toBeTruthy();
+	const { jwt } = await jwtRes.json();
+	return jwt;
+}
+
+// lateAdditionUserIds returns the user ids of this season's late additions via
+// the generic CRUD read surface.
+async function lateAdditionUserIds(page: Page, seasonId: string): Promise<string[]> {
+	const res = await page.request.get(`${API}/season_late_addition`);
+	expect(res.ok()).toBeTruthy();
+	const rows = (await res.json()).resource as { season_id: string; user_id: string }[];
+	return rows.filter((r) => r.season_id === seasonId).map((r) => r.user_id);
+}
+
+test('sysadmin adds and removes late players on a season via the UI', async ({ page }) => {
+	await login(page, 'jdarthur@gatech.edu');
+	const token = await page.evaluate(() => localStorage.getItem('intraclub_jwt') ?? '');
+	expect(token).toBeTruthy();
+
+	const unique = Date.now();
+	const seasonId = await createSeason(page, token, unique);
+
+	// A user who was not drafted into the season, to be added late.
+	const lateName = `Late${unique}`;
+	const importRes = await page.request.post(`${API}/import_users_from_csv`, {
+		form: {
+			file: `First Name, Last Name, Email\n${lateName}, LA, ${lateName.toLowerCase()}@example.com`
+		}
+	});
+	expect(importRes.ok()).toBeTruthy();
+	const importBody = await importRes.json();
+	const lateUserId = [...importBody.Created, ...importBody.AlreadyExisting].map(
+		(u: { id: string }) => u.id
+	)[0];
+
+	await page.goto(`/seasons/${seasonId}`);
+	await waitForHydration(page);
+
+	// The sysadmin sees the Late additions card.
+	await expect(page.getByText('Late additions', { exact: true })).toBeVisible();
+	await expect(page.getByText('No late additions yet.')).toBeVisible();
+
+	// Add the late player through the UI.
+	await page.getByLabel('Player').selectOption({ label: `${lateName} LA` });
+	await page.getByRole('button', { name: 'Add late player' }).click();
+	await expect(page.getByText(`No late additions yet.`)).toBeHidden();
+	await expect(page.getByRole('list').filter({ hasText: lateName }).getByText(lateName)).toBeVisible();
+
+	// The API reflects the new late addition.
+	expect(await lateAdditionUserIds(page, seasonId)).toContain(lateUserId);
+
+	// The added player no longer appears in the add dropdown.
+	await expect(page.getByLabel('Player')).not.toHaveValue(lateUserId);
+
+	// Remove the late player through the UI.
+	await page.getByRole('button', { name: 'Remove' }).click();
+	await expect(page.getByText(`No late additions yet.`)).toBeVisible();
+	expect(await lateAdditionUserIds(page, seasonId)).not.toContain(lateUserId);
+
+	// The player is selectable again after removal.
+	await page.getByLabel('Player').selectOption({ label: `${lateName} LA` });
+	await expect(page.getByRole('button', { name: 'Add late player' })).toBeEnabled();
+
+	// Clean up the late addition row so the table doesn't accumulate across runs.
+	const rows = (await (await page.request.get(`${API}/season_late_addition`)).json())
+		.resource as { id: string; season_id: string }[];
+	for (const row of rows.filter((r) => r.season_id === seasonId)) {
+		const del = await page.request.delete(`${API}/season_late_addition/${row.id}`, {
+			headers: { 'X-INTRACLUB-TOKEN': token }
+		});
+		expect(del.ok()).toBeTruthy();
+	}
+});
+
+test('non-sysadmin does not see the late additions card', async ({ page }) => {
+	await login(page, 'jdarthur@gatech.edu');
+	const token = await page.evaluate(() => localStorage.getItem('intraclub_jwt') ?? '');
+	expect(token).toBeTruthy();
+
+	const unique = Date.now();
+	const seasonId = await createSeason(page, token, unique);
+
+	// Log in as a seeded non-sysadmin user.
+	await page.evaluate(() => localStorage.removeItem('intraclub_jwt'));
+	await login(page, 'avery.chen@example.com');
+
+	await page.goto(`/seasons/${seasonId}`);
+	await waitForHydration(page);
+
+	await expect(page.getByText('Late additions', { exact: true })).not.toBeVisible();
+
+	// And the non-sysadmin is rejected by the API write surface too.
+	const otherToken = await page.evaluate(() => localStorage.getItem('intraclub_jwt') ?? '');
+	const whoami = await (
+		await page.request.get(`${API}/whoami`, { headers: { 'X-INTRACLUB-TOKEN': otherToken } })
+	).json();
+	const res = await page.request.post(`${API}/season_late_addition`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': otherToken },
+		data: { season_id: seasonId, user_id: whoami.id }
+	});
+	expect(res.status()).toBe(403);
+});

--- a/ui/src/lib/auth.ts
+++ b/ui/src/lib/auth.ts
@@ -54,6 +54,20 @@ export function getCurrentUserId(): string | null {
 	}
 }
 
+// getRoles fetches the authenticated user's role names from
+// GET /api/whoami/roles, e.g. ["System Administrator"]. Returns [] when no
+// token is present.
+export async function getRoles(): Promise<string[]> {
+	const token = getToken();
+	if (!token) return [];
+	const res = await fetch('/api/whoami/roles', {
+		headers: { 'X-INTRACLUB-TOKEN': token }
+	});
+	if (!res.ok) return [];
+	const body = await res.json();
+	return Array.isArray(body?.roles) ? body.roles : [];
+}
+
 let lastToken: string | null = null;
 let expiredHandled = false;
 

--- a/ui/src/lib/seasonLateAddition.ts
+++ b/ui/src/lib/seasonLateAddition.ts
@@ -1,0 +1,61 @@
+// SeasonLateAddition API client. A SeasonLateAddition links a Season to a User
+// who joined after the draft was completed. The read surface is the generic
+// CRUD registered in main.go; writes go through the custom routes in
+// route/lateaddition (same paths), which enforce the model's sysadmin-only
+// EditableBy constraint:
+//
+//	GET    /api/season_late_addition      -> { resource: SeasonLateAddition[] }
+//	GET    /api/season_late_addition/:id  -> { resource: SeasonLateAddition }
+//	POST   /api/season_late_addition      -> { resource: SeasonLateAddition }
+//	DELETE /api/season_late_addition/:id  -> { resource: SeasonLateAddition }
+//
+// Records are readable by everyone; only a system administrator may create or
+// delete them (see model.SeasonLateAddition.EditableBy). Record IDs are
+// 16-char hex strings.
+import { authFetch } from '$lib/auth';
+
+export interface SeasonLateAddition {
+	id: string;
+	season_id: string;
+	user_id: string;
+	created_at: string;
+	updated_at: string;
+}
+
+const BASE = '/api/season_late_addition';
+
+// unwrap parses a CrudCommon response (`{ resource: ... }`) and throws the
+// backend error message on non-2xx responses so callers can surface it.
+async function unwrap(res: Response): Promise<any> {
+	if (!res.ok) {
+		let message = `Request failed (${res.status})`;
+		try {
+			const body = await res.json();
+			if (body?.error) message = body.error;
+		} catch {
+			// non-JSON error body; fall back to the status message
+		}
+		throw new Error(message);
+	}
+	const body = await res.json();
+	return body?.resource;
+}
+
+export async function listSeasonLateAdditions(): Promise<SeasonLateAddition[]> {
+	return unwrap(await authFetch(BASE));
+}
+
+// addSeasonLateAddition adds a user to a season as a late addition.
+export async function addSeasonLateAddition(seasonId: string, userId: string): Promise<SeasonLateAddition> {
+	return unwrap(
+		await authFetch(BASE, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ season_id: seasonId, user_id: userId })
+		})
+	);
+}
+
+export async function removeSeasonLateAddition(id: string): Promise<void> {
+	await authFetch(`${BASE}/${id}`, { method: 'DELETE' });
+}

--- a/ui/src/routes/seasons/[id]/+page.svelte
+++ b/ui/src/routes/seasons/[id]/+page.svelte
@@ -11,7 +11,7 @@
 	import type { Rating } from '$lib/rating';
 	import { listFacilities } from '$lib/facility';
 	import type { Facility } from '$lib/facility';
-	import { getCurrentUserId } from '$lib/auth';
+	import { getCurrentUserId, getRoles } from '$lib/auth';
 	import { listWeeksForSeason } from '$lib/week';
 	import type { Week } from '$lib/week';
 	import { listTeams } from '$lib/team';
@@ -47,6 +47,12 @@
 	import type { WeekMatchDetail, StandingsEntry, IndividualMatch } from '$lib/match';
 	import { listScoringStructures } from '$lib/scoringStructure';
 	import type { ScoringStructure } from '$lib/scoringStructure';
+	import {
+		listSeasonLateAdditions,
+		addSeasonLateAddition,
+		removeSeasonLateAddition
+	} from '$lib/seasonLateAddition';
+	import type { SeasonLateAddition } from '$lib/seasonLateAddition';
 	import { Badge } from '$lib/components/ui/badge/index.js';
 	import {
 		Card,
@@ -101,6 +107,13 @@
 	let savingScore = $state<string | null>(null);
 	let completingMatch = $state<string | null>(null);
 
+	// late additions state (sysadmin-only writes)
+	let lateAdditions = $state<SeasonLateAddition[]>([]);
+	let lateAdditionUserId = $state('');
+	let lateAdditionError = $state('');
+	let savingLateAddition = $state(false);
+	let isSysAdmin = $state(false);
+
 	let loading = $state(true);
 	let loadError = $state('');
 
@@ -135,7 +148,8 @@
 				weekList,
 				scheduleData,
 				rosterList,
-				scoringStructureList
+				scoringStructureList,
+				lateAdditionList
 			] = await Promise.all([
 				getSeason(id()),
 				listSeasonTeams(),
@@ -147,7 +161,8 @@
 				listWeeksForSeason(id()),
 				getScheduleForSeason(id()),
 				listTeams(),
-				listScoringStructures()
+				listScoringStructures(),
+				listSeasonLateAdditions()
 			]);
 			season = seasonData;
 			seasonTeams = seasonTeamList.filter((st) => st.season_id === seasonData.id);
@@ -160,6 +175,8 @@
 			scheduleDetail = scheduleData;
 			rosters = rosterList;
 			scoringStructures = scoringStructureList;
+			lateAdditions = lateAdditionList.filter((l) => l.season_id === seasonData.id);
+			isSysAdmin = (await getRoles()).includes('System Administrator');
 			selectedScoringStructure =
 				scoringStructureList.find((s) => s.name === 'Tennis standard set')?.id ??
 				scoringStructureList[0]?.id ??
@@ -572,6 +589,58 @@
 
 	function matchPlayerLabel(m: IndividualMatch): string {
 		return `${userName(m.player1)} & ${userName(m.player2)}`;
+	}
+
+	// --- late additions (sysadmin only) ------------------------------------
+
+	// Whether a user is already part of the season (on a drafted team or an
+	// existing late addition), used to filter the add dropdown.
+	function userInSeason(userId: string): boolean {
+		if (lateAdditions.some((l) => l.user_id === userId)) return true;
+		return teams.some((t) => t.members.some((m) => m.user_id === userId));
+	}
+
+	const lateAdditionOptions = $derived(
+		[...users].filter((u) => !userInSeason(u.id)).sort((a, b) => fullName(a).localeCompare(fullName(b)))
+	);
+
+	const lateAdditionNames = $derived(
+		[...lateAdditions].sort((a, b) => userName(a.user_id).localeCompare(userName(b.user_id)))
+	);
+
+	// addLateAddition creates a SeasonLateAddition for the selected user and
+	// refreshes the list from the API.
+	async function handleAddLateAddition() {
+		const seasonId = season?.id;
+		if (!seasonId || !lateAdditionUserId) return;
+		savingLateAddition = true;
+		lateAdditionError = '';
+		try {
+			await addSeasonLateAddition(seasonId, lateAdditionUserId);
+			lateAdditionUserId = '';
+			lateAdditions = (await listSeasonLateAdditions()).filter((l) => l.season_id === seasonId);
+		} catch (e) {
+			lateAdditionError = e instanceof Error ? e.message : 'Failed to add late addition';
+		} finally {
+			savingLateAddition = false;
+		}
+	}
+
+	// removeLateAddition deletes the SeasonLateAddition record and refreshes.
+	async function handleRemoveLateAddition(lateId: string) {
+		const seasonId = season?.id;
+		savingLateAddition = true;
+		lateAdditionError = '';
+		try {
+			await removeSeasonLateAddition(lateId);
+			if (seasonId) {
+				lateAdditions = (await listSeasonLateAdditions()).filter((l) => l.season_id === seasonId);
+			}
+		} catch (e) {
+			lateAdditionError = e instanceof Error ? e.message : 'Failed to remove late addition';
+		} finally {
+			savingLateAddition = false;
+		}
 	}
 </script>
 
@@ -1203,6 +1272,76 @@
 	<!-- Standings -->
 	<Standings {standings} {teamName} />
 
+
+	<!-- Late additions (sysadmin only) -->
+	{#if isSysAdmin}
+		<Card class="mt-6">
+			<CardHeader>
+				<CardTitle class="text-base">Late additions</CardTitle>
+			</CardHeader>
+			<CardContent>
+				<p class="mb-4 text-sm text-muted-foreground">
+					Players added to this season after the draft was completed.
+				</p>
+
+				{#if lateAdditionError}
+					<p class="mb-4 text-sm font-medium text-destructive">{lateAdditionError}</p>
+				{/if}
+
+				<form
+					class="flex flex-wrap items-end gap-3"
+					onsubmit={(e) => {
+						e.preventDefault();
+						handleAddLateAddition();
+					}}
+				>
+					<div class="flex flex-col gap-1">
+						<Label for="late-addition-user" class="text-xs">Player</Label>
+						<NativeSelect
+							id="late-addition-user"
+							value={lateAdditionUserId}
+							oninput={(e) =>
+								(lateAdditionUserId = (
+									e.currentTarget as HTMLSelectElement
+								).value)}
+						>
+							<NativeSelectOption value="" disabled>Select a player…</NativeSelectOption>
+							{#each lateAdditionOptions as u (u.id)}
+								<NativeSelectOption value={u.id}>{fullName(u)}</NativeSelectOption>
+							{/each}
+						</NativeSelect>
+					</div>
+					<Button
+						type="submit"
+						disabled={savingLateAddition || !lateAdditionUserId}
+					>
+						{savingLateAddition ? 'Saving…' : 'Add late player'}
+					</Button>
+				</form>
+
+				{#if lateAdditionNames.length === 0}
+					<p class="mt-4 text-sm text-muted-foreground">No late additions yet.</p>
+				{:else}
+					<ul class="mt-4 space-y-2 text-sm">
+						{#each lateAdditionNames as la (la.id)}
+							<li class="flex items-center justify-between gap-3">
+								<span class="font-medium">{userName(la.user_id)}</span>
+								<Button
+									type="button"
+									variant="ghost"
+									size="sm"
+									disabled={savingLateAddition}
+									onclick={() => handleRemoveLateAddition(la.id)}
+								>
+									Remove
+								</Button>
+							</li>
+						{/each}
+					</ul>
+				{/if}
+			</CardContent>
+		</Card>
+	{/if}
 
 	{#if teams.length === 0}
 		<p class="mt-6 text-sm text-muted-foreground">No teams have been added to this season yet.</p>


### PR DESCRIPTION
Closes #162
Fixes #196

## Season late additions (#162)

The `SeasonLateAddition` model already had full `CrudRecord` support (DB done in #56); this adds the API + UI on top.

**API**
- `main.go`: read-only generic CRUD for `SeasonLateAddition` (GET one/many) — the season page shows the current late additions to everyone.
- New `route/lateaddition` package with the write surface: `POST /api/season_late_addition` and `DELETE /api/season_late_addition/:id`. These check `model.IsUserSystemAdministrator` explicitly (403 otherwise). This matters because the generic CrudCommon create path does **not** enforce `EditableBy` (it only requires a token), so full generic CRUD would have let any logged-in user add late players — the custom routes keep the model's sysadmin-only intent.
- `model.SeedDevData`: the seeded `jdarthur@gatech.edu` dev/e2e login user is now assigned the `SystemAdministrator` role so dev-mode and e2e flows can exercise the sysadmin write paths.

**UI**
- `ui/src/lib/seasonLateAddition.ts`: API client (list / add / remove).
- `/seasons/[id]`: a sysadmin-only "Late additions" card with a player dropdown (excludes users already on a drafted team or already added late) and an add/remove list.
- `ui/src/lib/auth.ts`: `getRoles()` helper backed by the new `GET /api/whoami/roles` endpoint (see below), used to gate the card.

**e2e** — `ui/e2e/season-late-additions.spec.ts`:
- sysadmin adds and removes a late player through the UI, verified against the API read surface;
- non-sysadmin does not see the card and gets 403 from the API write surface.

## GET /api/whoami always 400s (#196)

Found while wiring the roles endpoint — fixed in this same change:

- `WhoAmI.RequestBody()` returned `(&model.User{}, true)`, so the generic route wrapper bound a zero-valued `User` and ran `StaticallyValid()` ("first name must not be empty") **before** the handler, 400ing every request regardless of auth. It now returns `(nil, false)`; the handler's existing 401 guard handles the no/invalid-token case.
- New `GET /api/whoami/roles` (also bodyless) returns the caller's role names, e.g. `{"roles": ["System Administrator"]}` — the UI's sysadmin gating.
- Audited every other `RouteFamily` GET route for the same `(&T{}, true)` pattern: `WhoAmI` was the only offender (all others already return `false`).
- Tests in `route/user/who_am_i_test.go` cover whoami + roles with a valid token (200) and with no token (401).

## Verification
- `make tests` green (incl. new `route/lateaddition` and `route/user` tests)
- `cd ui && npm run check` clean
- `make e2e` green, run twice (36/36 both runs)