### PR TITLE
api: enforce EditableBy on the generic CrudCommon create path

### DIFF
--- a/api/crud_common.go
+++ b/api/crud_common.go
@@ -105,14 +105,17 @@ func (c *CrudCommon[T]) createCrudRecord(route Route[T], request Request[T]) (an
 	body := request.Body
 	body.SetOwner(request.Token.UserId)
 
-	// Create endpoint does not need ownership/access authentication as there is not a
-	// record yet which has any AccessibleTo / EditableBy functions defined.
-	//
-	// On creation, the CrudRecord which is being created will set all the fields necessary
-	// to validate these things on future get/update/delete requests (e.g. setting a team ID
-	// to enforce accessible-only-to-team constraints or setting a user ID to enforce only
-	// editable by creator constraints
-	// a
+	// Enforce the model's EditableBy on the create path. After stamping the
+	// caller as owner, verify that the caller may edit a record with these field
+	// values. For owner-based models this always passes (the caller just became
+	// the owner); for sysadmin-only / season-scoped models it correctly denies
+	// non-privileged users. Denial is 403 so clients can distinguish "forbidden"
+	// from an invalid body (400).
+	wac := database.WithAccessControl[T]{Database: c.DatabaseProvider, AccessControlUser: request.Token.UserId}
+	if !wac.CanUserEdit(body) {
+		return nil, http.StatusForbidden, errors.New("user is not allowed to create this record")
+	}
+
 	v, err := database.CreateOne(request.Context, c.DatabaseProvider, body)
 	if err != nil {
 		return nil, http.StatusBadRequest, err

--- a/api/crud_common_test.go
+++ b/api/crud_common_test.go
@@ -35,6 +35,72 @@ func newTestCrudRecord() *testCrudRecord {
 	}
 }
 
+// sysAdminOnlyCrudRecord mirrors the sysadmin-only join models (e.g.
+// ScoringStructureSecondary, RulesetSection): SetOwner is a no-op and
+// EditableBy admits only a system administrator.
+type sysAdminOnlyCrudRecord struct {
+	ID        database.RecordId
+	Value     string
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+func (t *sysAdminOnlyCrudRecord) GetOwner() database.UserId {
+	return database.InvalidUserId
+}
+
+func (t *sysAdminOnlyCrudRecord) SetOwner(userId database.UserId) {
+	// ownership is not user-scoped for this type; it is sysadmin-only
+}
+
+func (t *sysAdminOnlyCrudRecord) Type() string {
+	return "test_sysadmin_crud"
+}
+
+func (t *sysAdminOnlyCrudRecord) GetId() database.RecordId {
+	return t.ID
+}
+
+func (t *sysAdminOnlyCrudRecord) SetId(id database.RecordId) {
+	t.ID = id
+}
+
+func (t *sysAdminOnlyCrudRecord) EditableBy(_ context.Context, db database.Provider) []database.UserId {
+	return []database.UserId{database.SysAdminUserId}
+}
+
+func (t *sysAdminOnlyCrudRecord) AccessibleTo(_ context.Context, db database.Provider) []database.UserId {
+	return database.AccessibleToEveryone
+}
+
+func (t *sysAdminOnlyCrudRecord) StaticallyValid() error {
+	return nil
+}
+
+func (t *sysAdminOnlyCrudRecord) DynamicallyValid(_ context.Context, db database.Provider) error {
+	return nil
+}
+
+func (t *sysAdminOnlyCrudRecord) GetTimeStamps() (created, updated time.Time) {
+	return t.CreatedAt, t.UpdatedAt
+}
+
+func (t *sysAdminOnlyCrudRecord) SetCreateTimestamp(tm time.Time) time.Time {
+	oldValue := t.CreatedAt
+	t.CreatedAt = tm
+	return oldValue
+}
+
+func (t *sysAdminOnlyCrudRecord) SetUpdateTimestamp(tm time.Time) time.Time {
+	oldValue := t.UpdatedAt
+	t.UpdatedAt = tm
+	return oldValue
+}
+
+func (t *sysAdminOnlyCrudRecord) NewRecord() database.CrudRecord {
+	return new(sysAdminOnlyCrudRecord)
+}
+
 func (t *testCrudRecord) Type() string {
 	return "test_crud"
 }
@@ -172,6 +238,74 @@ func TestCrudCommonCreateSuccess(t *testing.T) {
 	}
 	if resource.(*testCrudRecord).ID == database.InvalidRecordId {
 		t.Fatal("ID should be set")
+	}
+}
+
+func TestCrudCommonCreateForbiddenForNonPrivileged(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	cc := NewCrudCommon(func() *sysAdminOnlyCrudRecord { return &sysAdminOnlyCrudRecord{} }, false, db)
+
+	route := genericApiRoute[*sysAdminOnlyCrudRecord]{
+		requestBody:    func() *sysAdminOnlyCrudRecord { return &sysAdminOnlyCrudRecord{} },
+		useRequestBody: true,
+		handle:         cc.createCrudRecord,
+	}
+
+	// A non-privileged (non-sysadmin) user must not be able to create a
+	// sysadmin-only record via the generic create path.
+	nonPrivileged := database.NewRecordId()
+	req := Request[*sysAdminOnlyCrudRecord]{
+		Context:          context.Background(),
+		DatabaseProvider: db,
+		Token:            &AuthToken{UserId: database.UserId(nonPrivileged)},
+		Body:             &sysAdminOnlyCrudRecord{Value: "x"},
+	}
+
+	_, status, err := route.Handler(req)
+	if err == nil {
+		t.Fatal("expected error for non-privileged create")
+	}
+	if status != http.StatusForbidden {
+		t.Fatalf("expected status %d, got %d", http.StatusForbidden, status)
+	}
+}
+
+func TestCrudCommonCreateAllowedForSysAdmin(t *testing.T) {
+	prevSysAdminCheck := database.SysAdminCheck
+	defer func() { database.SysAdminCheck = prevSysAdminCheck }()
+
+	db := database.NewUnitTestDBProvider()
+	cc := NewCrudCommon(func() *sysAdminOnlyCrudRecord { return &sysAdminOnlyCrudRecord{} }, false, db)
+
+	route := genericApiRoute[*sysAdminOnlyCrudRecord]{
+		requestBody:    func() *sysAdminOnlyCrudRecord { return &sysAdminOnlyCrudRecord{} },
+		useRequestBody: true,
+		handle:         cc.createCrudRecord,
+	}
+
+	sysAdminId := database.NewRecordId()
+	database.SysAdminCheck = func(_ context.Context, _ database.Provider, userId database.UserId) (bool, error) {
+		return userId == database.UserId(sysAdminId), nil
+	}
+
+	req := Request[*sysAdminOnlyCrudRecord]{
+		Context:          context.Background(),
+		DatabaseProvider: db,
+		Token:            &AuthToken{UserId: database.UserId(sysAdminId)},
+		Body:             &sysAdminOnlyCrudRecord{Value: "x"},
+	}
+
+	resp, status, err := route.Handler(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, status)
+	}
+
+	result := resp.(gin.H)
+	if resource, ok := result[ResourceKey].(*sysAdminOnlyCrudRecord); !ok || resource == nil {
+		t.Fatal("expected created sysadmin-only record in response")
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -176,8 +176,7 @@ func main() {
 	// SeasonLateAdditions link a Season to Users added after the draft was
 	// completed. The generic surface is read-only (the season page shows them);
 	// writes go exclusively through the custom routes in route/lateaddition,
-	// which enforce the model's sysadmin-only EditableBy constraint (the
-	// generic create path does not check EditableBy).
+	// which enforce the model's sysadmin-only EditableBy constraint.
 	seasonLateAdditions := api.NewCrudCommon(func() *model.SeasonLateAddition { return &model.SeasonLateAddition{} }, false, db)
 	seasonLateAdditions.HandleRouteTypes(rg, api.CrudWrapperFunctionGetOne, api.CrudWrapperFunctionGetMany)
 	lateAdditions := api.RouteFamily[*lateaddition.AddLateAdditionBody]{DatabaseProvider: db}

--- a/route/draft/draft_test.go
+++ b/route/draft/draft_test.go
@@ -37,6 +37,20 @@ func newStoredUser(t *testing.T, db database.Provider) *model.User {
 	return v
 }
 
+// newSysAdminUser creates a user and assigns them the SystemAdministrator
+// role directly (the draft join models are sysadmin-only on write).
+func newSysAdminUser(t *testing.T, db database.Provider) *model.User {
+	t.Helper()
+	user := newStoredUser(t, db)
+	assignment := &model.UserRoleAssignment{
+		UserId: user.ID,
+		Role:   model.SystemAdministrator,
+	}
+	_, err := database.CreateOne(context.Background(), db, assignment)
+	require.NoError(t, err)
+	return user
+}
+
 func newStoredRating(t *testing.T, db database.Provider) *model.Rating {
 	t.Helper()
 	user := newStoredUser(t, db)
@@ -227,12 +241,20 @@ func TestDraftJoinModelCRUD(t *testing.T) {
 	format := newDefaultFormat(t, db)
 	draftID := createDraftViaHTTP(t, router, commissioner.ID, format.ID, "Join CRUD")
 	player := newStoredUser(t, db)
+	sysadmin := newSysAdminUser(t, db)
 
-	// Create a DraftAvailablePlayer via CRUD.
+	// DraftAvailablePlayer is sysadmin-only on write: a non-sysadmin is forbidden.
 	w := doJSON(t, router, http.MethodPost, "/api/draft_available_player", map[string]any{
 		"draft_id":  draftID,
 		"player_id": player.ID.String(),
 	}, newToken(t, commissioner.ID))
+	require.Equal(t, http.StatusForbidden, w.Code, "non-sysadmin create: %s", w.Body.String())
+
+	// Create a DraftAvailablePlayer via CRUD as a sysadmin.
+	w = doJSON(t, router, http.MethodPost, "/api/draft_available_player", map[string]any{
+		"draft_id":  draftID,
+		"player_id": player.ID.String(),
+	}, newToken(t, sysadmin.ID))
 	require.Equal(t, http.StatusOK, w.Code, "create available player: %s", w.Body.String())
 	var created struct {
 		Resource *model.DraftAvailablePlayer `json:"resource"`
@@ -500,13 +522,22 @@ func TestDraftRatingCutoffCRUD(t *testing.T) {
 	commissioner := newStoredUser(t, db)
 	format := newDefaultFormat(t, db)
 	draftID := createDraftViaHTTP(t, router, commissioner.ID, format.ID, "Cutoff CRUD")
+	sysadmin := newSysAdminUser(t, db)
 
 	rating := newStoredRating(t, db)
+	// DraftRatingCutoff is sysadmin-only on write: a non-sysadmin is forbidden.
 	w := doJSON(t, router, http.MethodPost, "/api/draft_rating_cutoff", map[string]any{
 		"draft_id":     draftID,
 		"rating_id":    rating.ID.String(),
 		"cutoff_index": 2,
 	}, newToken(t, commissioner.ID))
+	require.Equal(t, http.StatusForbidden, w.Code, "non-sysadmin create cutoff: %s", w.Body.String())
+
+	w = doJSON(t, router, http.MethodPost, "/api/draft_rating_cutoff", map[string]any{
+		"draft_id":     draftID,
+		"rating_id":    rating.ID.String(),
+		"cutoff_index": 2,
+	}, newToken(t, sysadmin.ID))
 	require.Equal(t, http.StatusOK, w.Code, "create cutoff: %s", w.Body.String())
 	var created struct {
 		Resource *model.DraftRatingCutoff `json:"resource"`

--- a/route/lateaddition/late_addition.go
+++ b/route/lateaddition/late_addition.go
@@ -3,9 +3,7 @@
 //
 // The generic CRUD surface in main.go is registered read-only for this type;
 // writes go exclusively through the routes in this package, which enforce the
-// model's sysadmin-only EditableBy constraint. (The generic create path does
-// not check EditableBy, so a plain POST /api/season_late_addition would
-// otherwise let any logged-in user add late players.)
+// model's sysadmin-only EditableBy constraint.
 package lateaddition
 
 import (

--- a/route/scoringstructure/set_secondary_scoring_structures_test.go
+++ b/route/scoringstructure/set_secondary_scoring_structures_test.go
@@ -275,14 +275,22 @@ func TestScoringStructureSecondaryCRUD(t *testing.T) {
 	primary := createScoringStructureViaHTTP(t, router, owner.ID, "CRUD match", model.Set, 2, 1, 0)
 	gameA := createScoringStructureViaHTTP(t, router, owner.ID, "CRUD game", model.Game, 6, 2, 7)
 
-	// generic CRUD create is open to any authenticated user (the record's own
-	// validation runs; EditableBy gates update / delete)
+	// generic CRUD create is sysadmin-only (the record's EditableBy is
+	// sysadmin-only): a non-sysadmin is forbidden
 	w := doJSON(t, router, http.MethodPost, "/api/scoring_structure_secondary", map[string]any{
 		"scoring_structure_id":           primary,
 		"secondary_scoring_structure_id": gameA,
 		"secondary_index":                0,
 	}, newToken(t, owner.ID))
-	require.Equal(t, http.StatusOK, w.Code, "create: %s", w.Body.String())
+	require.Equal(t, http.StatusForbidden, w.Code, "non-sysadmin create: %s", w.Body.String())
+
+	// the sysadmin can create the raw join row
+	w = doJSON(t, router, http.MethodPost, "/api/scoring_structure_secondary", map[string]any{
+		"scoring_structure_id":           primary,
+		"secondary_scoring_structure_id": gameA,
+		"secondary_index":                0,
+	}, newToken(t, sysadmin.ID))
+	require.Equal(t, http.StatusOK, w.Code, "sysadmin create: %s", w.Body.String())
 
 	var created struct {
 		Resource *model.ScoringStructureSecondary `json:"resource"`


### PR DESCRIPTION
Closes #203

## What

`createCrudRecord` in `api/crud_common.go` previously required only a valid
token and then stamped the caller as owner — it never ran the per-record
`EditableBy` check the other verbs (get/update/delete) use. That let any
authenticated user `POST` to sysadmin-only and season-scoped types registered
with `CrudWrapperFunctionAll`, including:

- `POST /api/scoring_structure_secondary` (sysadmin-only)
- `POST /api/ruleset_section` (sysadmin-only)
- `POST /api/commissioner_proposal` (season-commissioner-scoped)
- plus the `DraftAvailablePlayer` / `DraftRatingCutoff` join models exposed by
  `route/draft` (sysadmin-only)

## Fix

After stamping the caller as owner, the create path now builds a
`database.WithAccessControl[T]` for the caller and verifies
`CanUserEdit(body)`, returning **403** on denial (so clients can distinguish
"forbidden" from an invalid body's 400).

- Owner-based models still work — the caller just became the owner, so
  `EditableBy` passes.
- Sysadmin-only / season-scoped models now correctly reject non-privileged
  callers.

## Tests

- `api/crud_common_test.go`: added `sysAdminOnlyCrudRecord` + tests for the
  403-denied and sysadmin-allowed cases.
- Updated CRUD tests that had been asserting the old open-create behavior
  (`route/draft/draft_test.go`, `route/scoringstructure/...`).

## Verification

- `make tests` (go test + vet) green
- `make e2e`: 36/36 Playwright tests pass