### PR TITLE
API + UI: Season co-commissioners

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ import (
 	"intraclub/route/ruleset"
 	"intraclub/route/schedule"
 	"intraclub/route/scoringstructure"
+	"intraclub/route/seasoncommissioner"
 	"intraclub/route/team"
 	"intraclub/route/user"
 	"intraclub/route/week"
@@ -181,6 +182,16 @@ func main() {
 	seasonLateAdditions.HandleRouteTypes(rg, api.CrudWrapperFunctionGetOne, api.CrudWrapperFunctionGetMany)
 	lateAdditions := api.RouteFamily[*lateaddition.AddLateAdditionBody]{DatabaseProvider: db}
 	lateAdditions.Handle(rg, lateaddition.AddLateAddition{}, lateaddition.RemoveLateAddition{})
+
+	// SeasonCommissioners link a Season to its commissioner users
+	// (co-commissioners). The generic surface is read-only (the season page
+	// shows them); writes go exclusively through the custom routes in
+	// route/seasoncommissioner, which enforce the model's sysadmin-only
+	// EditableBy constraint.
+	seasonCommissioners := api.NewCrudCommon(func() *model.SeasonCommissioner { return &model.SeasonCommissioner{} }, false, db)
+	seasonCommissioners.HandleRouteTypes(rg, api.CrudWrapperFunctionGetOne, api.CrudWrapperFunctionGetMany)
+	commissioners := api.RouteFamily[*seasoncommissioner.AddCommissionerBody]{DatabaseProvider: db}
+	commissioners.Handle(rg, seasoncommissioner.AddCommissioner{}, seasoncommissioner.RemoveCommissioner{})
 
 	// Teams are largely immutable after the draft finalizes: they are exposed
 	// only through the constrained read + role-assignment surface in

--- a/route/seasoncommissioner/season_commissioner.go
+++ b/route/seasoncommissioner/season_commissioner.go
@@ -1,0 +1,128 @@
+// Package seasoncommissioner exposes the write surface for SeasonCommissioner
+// records (adding/removing co-commissioners to a season).
+//
+// The generic CRUD surface in main.go is registered read-only for this type;
+// writes go exclusively through the routes in this package, which enforce the
+// model's sysadmin-only EditableBy constraint.
+package seasoncommissioner
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"intraclub/api"
+	"intraclub/database"
+	"intraclub/model"
+
+	"github.com/gin-gonic/gin"
+)
+
+// BaseRoute is the base API route for SeasonCommissioner records. It matches
+// the model's Type() ("season_commissioner").
+var BaseRoute = "/season_commissioner"
+
+// AddCommissionerBody is the request body for AddCommissioner.
+type AddCommissionerBody struct {
+	// SeasonId is the season the user is being added as a co-commissioner to.
+	SeasonId model.SeasonId `json:"season_id"`
+
+	// UserId is the user being added as a co-commissioner.
+	UserId database.UserId `json:"user_id"`
+}
+
+// StaticallyValid ensures both a season and a user were provided.
+func (b *AddCommissionerBody) StaticallyValid() error {
+	if b.SeasonId == model.SeasonId(database.InvalidRecordId) {
+		return errors.New("season_id must not be empty")
+	}
+	if b.UserId == database.InvalidUserId {
+		return errors.New("user_id must not be empty")
+	}
+	return nil
+}
+
+// AddCommissioner creates a SeasonCommissioner record linking the given user
+// to the given season. Only a system administrator may add co-commissioners.
+type AddCommissioner struct{}
+
+func (c AddCommissioner) Path() (api.HttpMethod, string) {
+	return api.HttpMethodPost, BaseRoute
+}
+
+func (c AddCommissioner) RequestBody() (*AddCommissionerBody, bool) {
+	return &AddCommissionerBody{}, true
+}
+
+func (c AddCommissioner) Handler(req api.Request[*AddCommissionerBody]) (any, int, error) {
+	if req.Token == nil {
+		return nil, http.StatusUnauthorized, errors.New("token is required")
+	}
+
+	isAdmin, err := model.IsUserSystemAdministrator(req.Context, req.DatabaseProvider, req.Token.UserId)
+	if err != nil {
+		return nil, http.StatusInternalServerError, err
+	}
+	if !isAdmin {
+		return nil, http.StatusForbidden, errors.New("only a system administrator may add co-commissioners to a season")
+	}
+
+	season, err := database.GetExistingRecordById(req.Context, req.DatabaseProvider, &model.Season{}, req.Body.SeasonId.RecordId())
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	if err := season.AddCommissioner(req.Context, req.DatabaseProvider, req.Body.UserId); err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+
+	// Return the created record so the client can use its ID to remove it.
+	commissioners, err := database.GetAllWhere[*model.SeasonCommissioner](req.Context, req.DatabaseProvider,
+		func(_ context.Context, c *model.SeasonCommissioner) bool {
+			return c.SeasonId == season.ID && c.UserId == req.Body.UserId
+		})
+	if err != nil {
+		return nil, http.StatusInternalServerError, err
+	}
+	if len(commissioners) == 0 {
+		return nil, http.StatusInternalServerError, errors.New("co-commissioner was not created")
+	}
+	return gin.H{api.ResourceKey: commissioners[0]}, http.StatusOK, nil
+}
+
+// RemoveCommissioner deletes the SeasonCommissioner record with the given ID.
+// Only a system administrator may remove co-commissioners.
+type RemoveCommissioner struct{}
+
+func (c RemoveCommissioner) Path() (api.HttpMethod, string) {
+	return api.HttpMethodDelete, api.AppendPathId(BaseRoute)
+}
+
+func (c RemoveCommissioner) RequestBody() (*AddCommissionerBody, bool) {
+	return &AddCommissionerBody{}, false
+}
+
+func (c RemoveCommissioner) Handler(req api.Request[*AddCommissionerBody]) (any, int, error) {
+	if req.Token == nil {
+		return nil, http.StatusUnauthorized, errors.New("token is required")
+	}
+
+	isAdmin, err := model.IsUserSystemAdministrator(req.Context, req.DatabaseProvider, req.Token.UserId)
+	if err != nil {
+		return nil, http.StatusInternalServerError, err
+	}
+	if !isAdmin {
+		return nil, http.StatusForbidden, errors.New("only a system administrator may remove co-commissioners from a season")
+	}
+
+	existing, exists, err := database.GetOneById(req.Context, req.DatabaseProvider, &model.SeasonCommissioner{}, req.PathId)
+	if err != nil {
+		return nil, http.StatusInternalServerError, err
+	}
+	if !exists {
+		return nil, http.StatusNotFound, errors.New("co-commissioner not found")
+	}
+	if _, _, err := database.DeleteOneById(req.Context, req.DatabaseProvider, existing, existing.ID); err != nil {
+		return nil, http.StatusInternalServerError, err
+	}
+	return gin.H{api.ResourceKey: existing}, http.StatusOK, nil
+}

--- a/route/seasoncommissioner/season_commissioner_test.go
+++ b/route/seasoncommissioner/season_commissioner_test.go
@@ -1,0 +1,239 @@
+package seasoncommissioner
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/rand/v2"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"intraclub/api"
+	"intraclub/database"
+	"intraclub/model"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// test setup helpers (mirror route/lateaddition/late_addition_test.go)
+// ---------------------------------------------------------------------------
+
+func newStoredUser(t *testing.T, db database.Provider) *model.User {
+	t.Helper()
+	user := model.NewUser()
+	user.Email = model.EmailAddress(fmt.Sprintf("user%d@email.com", rand.Uint64()))
+	user.FirstName = fmt.Sprintf("Test %d", rand.Uint64())
+	user.LastName = "User"
+	user.PhoneNumber = model.PhoneNumber(fmt.Sprintf("%d", 100_000_0000+rand.Uint32N(999_999_999)))
+	v, err := database.CreateOne(context.Background(), db, user)
+	require.NoError(t, err)
+	return v
+}
+
+// newTestRouter builds a gin engine with the co-commissioner write surface
+// registered (as in main.go) and the auth globals wired up so real tokens
+// validate.
+func newTestRouter(t *testing.T, db database.Provider) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	api.UserType = &model.User{}
+	database.SysAdminCheck = model.IsUserSystemAdministrator
+
+	router := gin.New()
+	group := router.Group("/api")
+
+	commissioners := api.RouteFamily[*AddCommissionerBody]{DatabaseProvider: db}
+	commissioners.Handle(group, AddCommissioner{}, RemoveCommissioner{})
+
+	return router
+}
+
+// testKeyOnce generates a single JWT keypair shared by every token minted in a
+// test process, so tokens issued by different helpers all verify.
+var (
+	testKeyOnce sync.Once
+	testPubKey  *ecdsa.PublicKey
+	testPrivKey *ecdsa.PrivateKey
+)
+
+func newToken(t *testing.T, userId database.UserId) string {
+	t.Helper()
+	testKeyOnce.Do(func() {
+		pub, priv, err := api.GenerateKeyPair()
+		require.NoError(t, err)
+		testPubKey = pub
+		testPrivKey = priv
+	})
+	api.JwtPublicKey = testPubKey
+	api.JwtPrivateKey = testPrivKey
+	token, err := api.GenerateToken(userId.RecordId())
+	require.NoError(t, err)
+	return token
+}
+
+// doJSON performs an authenticated HTTP request against the router.
+func doJSON(t *testing.T, router *gin.Engine, method, path string, body any, token string) *httptest.ResponseRecorder {
+	t.Helper()
+	var reader io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		require.NoError(t, err)
+		reader = bytes.NewReader(b)
+	}
+	req, err := http.NewRequest(method, path, reader)
+	require.NoError(t, err)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if token != "" {
+		req.Header.Set(api.AuthTokenHeaderValue, token)
+	}
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+// newSeason creates a minimal Season record (the fields required for
+// DynamicallyValid on a SeasonCommissioner to pass).
+func newSeason(t *testing.T, db database.Provider, owner *model.User) *model.Season {
+	t.Helper()
+	season := model.NewSeason()
+	season.Name = fmt.Sprintf("Season %d", rand.Uint64())
+	season.StartTime = model.NewStartTime(8, 30)
+	season.Owner = owner.ID
+	v, err := database.CreateOne(context.Background(), db, season)
+	require.NoError(t, err)
+	return v
+}
+
+func commissionerUserIds(t *testing.T, db database.Provider, seasonId model.SeasonId) []database.UserId {
+	t.Helper()
+	rows, err := database.GetAllWhere[*model.SeasonCommissioner](context.Background(), db,
+		func(_ context.Context, c *model.SeasonCommissioner) bool { return c.SeasonId == seasonId })
+	require.NoError(t, err)
+	ids := make([]database.UserId, 0, len(rows))
+	for _, r := range rows {
+		ids = append(ids, r.UserId)
+	}
+	return ids
+}
+
+// ---------------------------------------------------------------------------
+// AddCommissioner
+// ---------------------------------------------------------------------------
+
+func TestAddCommissioner_SysAdmin(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	admin := newStoredUser(t, db)
+	require.NoError(t, admin.AssignRole(context.Background(), db, model.SystemAdministrator))
+	season := newSeason(t, db, admin)
+	co := newStoredUser(t, db)
+	token := newToken(t, admin.ID)
+
+	w := doJSON(t, router, http.MethodPost, "/api/season_commissioner",
+		AddCommissionerBody{SeasonId: season.ID, UserId: co.ID}, token)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	var resp struct {
+		Resource model.SeasonCommissioner `json:"resource"`
+	}
+	require.NoError(t, json.NewDecoder(bytes.NewReader(w.Body.Bytes())).Decode(&resp))
+	require.Equal(t, season.ID, resp.Resource.SeasonId)
+	require.Equal(t, co.ID, resp.Resource.UserId)
+
+	require.Contains(t, commissionerUserIds(t, db, season.ID), co.ID)
+}
+
+func TestAddCommissioner_NonSysAdminForbidden(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	regular := newStoredUser(t, db)
+	season := newSeason(t, db, regular)
+	other := newStoredUser(t, db)
+	token := newToken(t, regular.ID)
+
+	w := doJSON(t, router, http.MethodPost, "/api/season_commissioner",
+		AddCommissionerBody{SeasonId: season.ID, UserId: other.ID}, token)
+	require.Equal(t, http.StatusForbidden, w.Code, "body: %s", w.Body.String())
+
+	require.Empty(t, commissionerUserIds(t, db, season.ID))
+}
+
+func TestAddCommissioner_NoToken(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	season := newSeason(t, db, newStoredUser(t, db))
+
+	w := doJSON(t, router, http.MethodPost, "/api/season_commissioner",
+		AddCommissionerBody{SeasonId: season.ID, UserId: newStoredUser(t, db).ID}, "")
+	require.Equal(t, http.StatusUnauthorized, w.Code, "body: %s", w.Body.String())
+}
+
+// ---------------------------------------------------------------------------
+// RemoveCommissioner
+// ---------------------------------------------------------------------------
+
+func addCommissioner(t *testing.T, db database.Provider, season *model.Season, user *model.User) *model.SeasonCommissioner {
+	t.Helper()
+	require.NoError(t, season.AddCommissioner(context.Background(), db, user.ID))
+	rows, err := database.GetAllWhere[*model.SeasonCommissioner](context.Background(), db,
+		func(_ context.Context, c *model.SeasonCommissioner) bool {
+			return c.SeasonId == season.ID && c.UserId == user.ID
+		})
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	return rows[0]
+}
+
+func TestRemoveCommissioner_SysAdmin(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	admin := newStoredUser(t, db)
+	require.NoError(t, admin.AssignRole(context.Background(), db, model.SystemAdministrator))
+	season := newSeason(t, db, admin)
+	co := newStoredUser(t, db)
+	sc := addCommissioner(t, db, season, co)
+	token := newToken(t, admin.ID)
+
+	w := doJSON(t, router, http.MethodDelete, fmt.Sprintf("/api/season_commissioner/%s", sc.ID), nil, token)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	require.NotContains(t, commissionerUserIds(t, db, season.ID), co.ID)
+}
+
+func TestRemoveCommissioner_NonSysAdminForbidden(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	admin := newStoredUser(t, db)
+	require.NoError(t, admin.AssignRole(context.Background(), db, model.SystemAdministrator))
+	season := newSeason(t, db, admin)
+	co := newStoredUser(t, db)
+	sc := addCommissioner(t, db, season, co)
+	regular := newStoredUser(t, db)
+	token := newToken(t, regular.ID)
+
+	w := doJSON(t, router, http.MethodDelete, fmt.Sprintf("/api/season_commissioner/%s", sc.ID), nil, token)
+	require.Equal(t, http.StatusForbidden, w.Code, "body: %s", w.Body.String())
+
+	require.Contains(t, commissionerUserIds(t, db, season.ID), co.ID)
+}
+
+func TestRemoveCommissioner_NotFound(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	router := newTestRouter(t, db)
+	admin := newStoredUser(t, db)
+	require.NoError(t, admin.AssignRole(context.Background(), db, model.SystemAdministrator))
+	token := newToken(t, admin.ID)
+
+	missing := database.NewRecordId()
+	w := doJSON(t, router, http.MethodDelete, fmt.Sprintf("/api/season_commissioner/%s", missing.String()), nil, token)
+	require.Equal(t, http.StatusNotFound, w.Code, "body: %s", w.Body.String())
+}

--- a/ui/e2e/season-commissioners.spec.ts
+++ b/ui/e2e/season-commissioners.spec.ts
@@ -5,7 +5,7 @@ import { waitForHydration } from './helpers';
 // playwright.config.ts), so POST /api/one_time_password returns the magic-link
 // token in the response body. The seeded jdarthur@gatech.edu user is the system
 // administrator in dev mode (see model.SeedDevData), which is required to
-// exercise the sysadmin-only late-addition write surface.
+// exercise the sysadmin-only co-commissioner write surface.
 async function login(page: Page, email: string) {
 	await page.goto('/login');
 	await page.waitForLoadState('networkidle');
@@ -25,8 +25,8 @@ const API = 'http://127.0.0.1:8080/api';
 // and finalizes it into a season, returning the season id.
 async function createSeason(page: Page, token: string, unique: number): Promise<string> {
 	const people = [
-		{ first: `Cap${unique}`, last: 'LA' },
-		{ first: `Play${unique}`, last: 'LA' }
+		{ first: `Cap${unique}`, last: 'SC' },
+		{ first: `Play${unique}`, last: 'SC' }
 	];
 	const csv = [
 		'First Name, Last Name, Email',
@@ -43,7 +43,7 @@ async function createSeason(page: Page, token: string, unique: number): Promise<
 
 	const facilityRes = await page.request.post(`${API}/facility`, {
 		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
-		data: { name: `Late Add Facility ${unique}`, address: `${unique} Main St`, courts: 4 }
+		data: { name: `CoComm Facility ${unique}`, address: `${unique} Main St`, courts: 4 }
 	});
 	expect(facilityRes.ok()).toBeTruthy();
 	const facilityId = (await facilityRes.json()).resource.id as string;
@@ -57,7 +57,7 @@ async function createSeason(page: Page, token: string, unique: number): Promise<
 
 	const draftRes = await page.request.post(`${API}/draft`, {
 		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
-		data: { name: `Late Add Draft ${unique}`, format: format!.id }
+		data: { name: `CoComm Draft ${unique}`, format: format!.id }
 	});
 	expect(draftRes.ok()).toBeTruthy();
 	const draftId = (await draftRes.json()).resource.id as string;
@@ -102,7 +102,7 @@ async function createSeason(page: Page, token: string, unique: number): Promise<
 
 	const seasonRes = await page.request.post(`${API}/draft/${draftId}/create_season`, {
 		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
-		data: { name: `Late Add Season ${unique}`, facility: facilityId, start_time: '08:30' }
+		data: { name: `CoComm Season ${unique}`, facility: facilityId, start_time: '08:30' }
 	});
 	expect(seasonRes.ok()).toBeTruthy();
 	return (await seasonRes.json()).resource.id as string;
@@ -118,16 +118,16 @@ async function tokenFor(page: Page, email: string): Promise<string> {
 	return jwt;
 }
 
-// lateAdditionUserIds returns the user ids of this season's late additions via
+// commissionerUserIds returns the user ids of this season's co-commissioners via
 // the generic CRUD read surface.
-async function lateAdditionUserIds(page: Page, seasonId: string): Promise<string[]> {
-	const res = await page.request.get(`${API}/season_late_addition`);
+async function commissionerUserIds(page: Page, seasonId: string): Promise<string[]> {
+	const res = await page.request.get(`${API}/season_commissioner`);
 	expect(res.ok()).toBeTruthy();
 	const rows = (await res.json()).resource as { season_id: string; user_id: string }[];
 	return rows.filter((r) => r.season_id === seasonId).map((r) => r.user_id);
 }
 
-test('sysadmin adds and removes late players on a season via the UI', async ({ page }) => {
+test('sysadmin adds and removes co-commissioners on a season via the UI', async ({ page }) => {
 	await login(page, 'jdarthur@gatech.edu');
 	const token = await page.evaluate(() => localStorage.getItem('intraclub_jwt') ?? '');
 	expect(token).toBeTruthy();
@@ -135,59 +135,63 @@ test('sysadmin adds and removes late players on a season via the UI', async ({ p
 	const unique = Date.now();
 	const seasonId = await createSeason(page, token, unique);
 
-	// A user who was not drafted into the season, to be added late.
-	const lateName = `Late${unique}`;
+	// A user who is not yet a commissioner, to be added as a co-commissioner.
+	const coName = `Co${unique}`;
 	const importRes = await page.request.post(`${API}/import_users_from_csv`, {
 		form: {
-			file: `First Name, Last Name, Email\n${lateName}, LA, ${lateName.toLowerCase()}@example.com`
+			file: `First Name, Last Name, Email\n${coName}, SC, ${coName.toLowerCase()}@example.com`
 		}
 	});
 	expect(importRes.ok()).toBeTruthy();
 	const importBody = await importRes.json();
-	const lateUserId = [...importBody.Created, ...importBody.AlreadyExisting].map(
+	const coUserId = [...importBody.Created, ...importBody.AlreadyExisting].map(
 		(u: { id: string }) => u.id
 	)[0];
 
 	await page.goto(`/seasons/${seasonId}`);
 	await waitForHydration(page);
 
-	// The sysadmin sees the Late additions card.
-	await expect(page.getByText('Late additions', { exact: true })).toBeVisible();
-	await expect(page.getByText('No late additions yet.')).toBeVisible();
+	// The sysadmin sees the Co-commissioners card, listing the existing
+	// commissioner (the sysadmin who created the season).
+	await expect(page.getByText('Co-commissioners', { exact: true })).toBeVisible();
+	await expect(page.getByRole('list').filter({ hasText: 'JD Arthur' })).toBeVisible();
 
-	// Add the late player through the UI.
-	await page.getByLabel('Player').selectOption({ label: `${lateName} LA` });
-	await page.getByRole('button', { name: 'Add late player' }).click();
-	await expect(page.getByText(`No late additions yet.`)).toBeHidden();
-	await expect(page.getByRole('list').filter({ hasText: lateName }).getByText(lateName)).toBeVisible();
+	// The new co-commissioner is not yet a commissioner.
+	expect(await commissionerUserIds(page, seasonId)).not.toContain(coUserId);
 
-	// The API reflects the new late addition.
-	expect(await lateAdditionUserIds(page, seasonId)).toContain(lateUserId);
+	// Add the co-commissioner through the UI.
+	await page.getByLabel('User').selectOption({ label: `${coName} SC` });
+	await page.getByRole('button', { name: 'Add co-commissioner' }).click();
+	await expect(page.getByRole('listitem').filter({ hasText: coName })).toBeVisible();
 
-	// The added player no longer appears in the add dropdown.
-	await expect(page.getByLabel('Player')).not.toHaveValue(lateUserId);
+	// The API reflects the new co-commissioner.
+	expect(await commissionerUserIds(page, seasonId)).toContain(coUserId);
 
-	// Remove the late player through the UI.
-	await page.getByRole('list').filter({ hasText: lateName }).getByRole('button', { name: 'Remove' }).click();
-	await expect(page.getByText(`No late additions yet.`)).toBeVisible();
-	expect(await lateAdditionUserIds(page, seasonId)).not.toContain(lateUserId);
+	// The added user no longer appears in the add dropdown.
+	await expect(page.getByLabel('User')).not.toHaveValue(coUserId);
 
-	// The player is selectable again after removal.
-	await page.getByLabel('Player').selectOption({ label: `${lateName} LA` });
-	await expect(page.getByRole('button', { name: 'Add late player' })).toBeEnabled();
+	// Remove the co-commissioner through the UI (leaving the original one).
+	await page.getByRole('listitem').filter({ hasText: coName }).getByRole('button', { name: 'Remove' }).click();
+	await expect(page.getByRole('listitem').filter({ hasText: coName })).toHaveCount(0);
+	await expect(page.getByRole('list').filter({ hasText: 'JD Arthur' })).toBeVisible();
+	expect(await commissionerUserIds(page, seasonId)).not.toContain(coUserId);
 
-	// Clean up the late addition row so the table doesn't accumulate across runs.
-	const rows = (await (await page.request.get(`${API}/season_late_addition`)).json())
+	// The user is selectable again after removal.
+	await page.getByLabel('User').selectOption({ label: `${coName} SC` });
+	await expect(page.getByRole('button', { name: 'Add co-commissioner' })).toBeEnabled();
+
+	// Clean up the co-commissioner rows so the table doesn't accumulate across runs.
+	const rows = (await (await page.request.get(`${API}/season_commissioner`)).json())
 		.resource as { id: string; season_id: string }[];
 	for (const row of rows.filter((r) => r.season_id === seasonId)) {
-		const del = await page.request.delete(`${API}/season_late_addition/${row.id}`, {
+		const del = await page.request.delete(`${API}/season_commissioner/${row.id}`, {
 			headers: { 'X-INTRACLUB-TOKEN': token }
 		});
 		expect(del.ok()).toBeTruthy();
 	}
 });
 
-test('non-sysadmin does not see the late additions card', async ({ page }) => {
+test('non-sysadmin does not see the co-commissioners card', async ({ page }) => {
 	await login(page, 'jdarthur@gatech.edu');
 	const token = await page.evaluate(() => localStorage.getItem('intraclub_jwt') ?? '');
 	expect(token).toBeTruthy();
@@ -202,14 +206,14 @@ test('non-sysadmin does not see the late additions card', async ({ page }) => {
 	await page.goto(`/seasons/${seasonId}`);
 	await waitForHydration(page);
 
-	await expect(page.getByText('Late additions', { exact: true })).not.toBeVisible();
+	await expect(page.getByText('Co-commissioners', { exact: true })).not.toBeVisible();
 
 	// And the non-sysadmin is rejected by the API write surface too.
 	const otherToken = await page.evaluate(() => localStorage.getItem('intraclub_jwt') ?? '');
 	const whoami = await (
 		await page.request.get(`${API}/whoami`, { headers: { 'X-INTRACLUB-TOKEN': otherToken } })
 	).json();
-	const res = await page.request.post(`${API}/season_late_addition`, {
+	const res = await page.request.post(`${API}/season_commissioner`, {
 		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': otherToken },
 		data: { season_id: seasonId, user_id: whoami.id }
 	});

--- a/ui/src/lib/seasonCommissioner.ts
+++ b/ui/src/lib/seasonCommissioner.ts
@@ -1,0 +1,61 @@
+// SeasonCommissioner API client. A SeasonCommissioner links a Season to a User
+// acting as a co-commissioner. The read surface is the generic CRUD registered
+// in main.go; writes go through the custom routes in
+// route/seasoncommissioner (same paths), which enforce the model's sysadmin-only
+// EditableBy constraint:
+//
+//	GET    /api/season_commissioner      -> { resource: SeasonCommissioner[] }
+//	GET    /api/season_commissioner/:id  -> { resource: SeasonCommissioner }
+//	POST   /api/season_commissioner      -> { resource: SeasonCommissioner }
+//	DELETE /api/season_commissioner/:id  -> { resource: SeasonCommissioner }
+//
+// Records are readable by everyone; only a system administrator may create or
+// delete them (see model.SeasonCommissioner.EditableBy). Record IDs are
+// 16-char hex strings.
+import { authFetch } from '$lib/auth';
+
+export interface SeasonCommissioner {
+	id: string;
+	season_id: string;
+	user_id: string;
+	created_at: string;
+	updated_at: string;
+}
+
+const BASE = '/api/season_commissioner';
+
+// unwrap parses a CrudCommon response (`{ resource: ... }`) and throws the
+// backend error message on non-2xx responses so callers can surface it.
+async function unwrap(res: Response): Promise<any> {
+	if (!res.ok) {
+		let message = `Request failed (${res.status})`;
+		try {
+			const body = await res.json();
+			if (body?.error) message = body.error;
+		} catch {
+			// non-JSON error body; fall back to the status message
+		}
+		throw new Error(message);
+	}
+	const body = await res.json();
+	return body?.resource;
+}
+
+export async function listSeasonCommissioners(): Promise<SeasonCommissioner[]> {
+	return unwrap(await authFetch(BASE));
+}
+
+// addSeasonCommissioner adds a user to a season as a co-commissioner.
+export async function addSeasonCommissioner(seasonId: string, userId: string): Promise<SeasonCommissioner> {
+	return unwrap(
+		await authFetch(BASE, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ season_id: seasonId, user_id: userId })
+		})
+	);
+}
+
+export async function removeSeasonCommissioner(id: string): Promise<void> {
+	await authFetch(`${BASE}/${id}`, { method: 'DELETE' });
+}

--- a/ui/src/routes/seasons/[id]/+page.svelte
+++ b/ui/src/routes/seasons/[id]/+page.svelte
@@ -53,6 +53,12 @@
 		removeSeasonLateAddition
 	} from '$lib/seasonLateAddition';
 	import type { SeasonLateAddition } from '$lib/seasonLateAddition';
+	import {
+		listSeasonCommissioners,
+		addSeasonCommissioner,
+		removeSeasonCommissioner
+	} from '$lib/seasonCommissioner';
+	import type { SeasonCommissioner } from '$lib/seasonCommissioner';
 	import { Badge } from '$lib/components/ui/badge/index.js';
 	import {
 		Card,
@@ -114,6 +120,12 @@
 	let savingLateAddition = $state(false);
 	let isSysAdmin = $state(false);
 
+	// co-commissioners state (sysadmin-only writes)
+	let seasonCommissioners = $state<SeasonCommissioner[]>([]);
+	let commissionerUserId = $state('');
+	let commissionerError = $state('');
+	let savingCommissioner = $state(false);
+
 	let loading = $state(true);
 	let loadError = $state('');
 
@@ -149,7 +161,8 @@
 				scheduleData,
 				rosterList,
 				scoringStructureList,
-				lateAdditionList
+				lateAdditionList,
+				commissionerList
 			] = await Promise.all([
 				getSeason(id()),
 				listSeasonTeams(),
@@ -162,7 +175,8 @@
 				getScheduleForSeason(id()),
 				listTeams(),
 				listScoringStructures(),
-				listSeasonLateAdditions()
+				listSeasonLateAdditions(),
+				listSeasonCommissioners()
 			]);
 			season = seasonData;
 			seasonTeams = seasonTeamList.filter((st) => st.season_id === seasonData.id);
@@ -176,6 +190,7 @@
 			rosters = rosterList;
 			scoringStructures = scoringStructureList;
 			lateAdditions = lateAdditionList.filter((l) => l.season_id === seasonData.id);
+			seasonCommissioners = commissionerList.filter((c) => c.season_id === seasonData.id);
 			isSysAdmin = (await getRoles()).includes('System Administrator');
 			selectedScoringStructure =
 				scoringStructureList.find((s) => s.name === 'Tennis standard set')?.id ??
@@ -640,6 +655,65 @@
 			lateAdditionError = e instanceof Error ? e.message : 'Failed to remove late addition';
 		} finally {
 			savingLateAddition = false;
+		}
+	}
+
+	// --- co-commissioners (sysadmin only) --------------------------------
+
+	// Users already serving as commissioners of this season (from the schedule
+	// detail), used to filter the add dropdown and to render the current list.
+	const currentCommissionerIds = $derived(scheduleDetail?.commissioners ?? []);
+
+	// Co-commissioners are typically users who help administer the season
+	// rather than players in it, so the add dropdown excludes anyone already in
+	// the season (drafted roster / late addition) as well as current
+	// commissioners — mirroring the late-addition dropdown.
+	const commissionerOptions = $derived(
+		[...users]
+			.filter((u) => !userInSeason(u.id) && !currentCommissionerIds.includes(u.id))
+			.sort((a, b) => fullName(a).localeCompare(fullName(b)))
+	);
+
+	const commissionerNames = $derived(
+		[...seasonCommissioners].sort((a, b) => userName(a.user_id).localeCompare(userName(b.user_id)))
+	);
+
+	// addSeasonCommissioner creates a SeasonCommissioner for the selected user
+	// and refreshes both the join rows and the schedule detail (so the new
+	// co-commissioner immediately counts as a commissioner of the season).
+	async function handleAddSeasonCommissioner() {
+		const seasonId = season?.id;
+		if (!seasonId || !commissionerUserId) return;
+		savingCommissioner = true;
+		commissionerError = '';
+		try {
+			await addSeasonCommissioner(seasonId, commissionerUserId);
+			commissionerUserId = '';
+			seasonCommissioners = (await listSeasonCommissioners()).filter((c) => c.season_id === seasonId);
+			scheduleDetail = await getScheduleForSeason(seasonId);
+		} catch (e) {
+			commissionerError = e instanceof Error ? e.message : 'Failed to add co-commissioner';
+		} finally {
+			savingCommissioner = false;
+		}
+	}
+
+	// removeSeasonCommissioner deletes the SeasonCommissioner record and
+	// refreshes both the join rows and the schedule detail.
+	async function handleRemoveSeasonCommissioner(scId: string) {
+		const seasonId = season?.id;
+		savingCommissioner = true;
+		commissionerError = '';
+		try {
+			await removeSeasonCommissioner(scId);
+			if (seasonId) {
+				seasonCommissioners = (await listSeasonCommissioners()).filter((c) => c.season_id === seasonId);
+				scheduleDetail = await getScheduleForSeason(seasonId);
+			}
+		} catch (e) {
+			commissionerError = e instanceof Error ? e.message : 'Failed to remove co-commissioner';
+		} finally {
+			savingCommissioner = false;
 		}
 	}
 </script>
@@ -1271,6 +1345,77 @@
 
 	<!-- Standings -->
 	<Standings {standings} {teamName} />
+
+
+	<!-- Co-commissioners (sysadmin only) -->
+	{#if isSysAdmin}
+		<Card class="mt-6">
+			<CardHeader>
+				<CardTitle class="text-base">Co-commissioners</CardTitle>
+			</CardHeader>
+			<CardContent>
+				<p class="mb-4 text-sm text-muted-foreground">
+					Additional users who can help administer this season.
+				</p>
+
+				{#if commissionerError}
+					<p class="mb-4 text-sm font-medium text-destructive">{commissionerError}</p>
+				{/if}
+
+				<form
+					class="flex flex-wrap items-end gap-3"
+					onsubmit={(e) => {
+						e.preventDefault();
+						handleAddSeasonCommissioner();
+					}}
+				>
+					<div class="flex flex-col gap-1">
+						<Label for="co-commissioner-user" class="text-xs">User</Label>
+						<NativeSelect
+							id="co-commissioner-user"
+							value={commissionerUserId}
+							oninput={(e) =>
+								(commissionerUserId = (
+									e.currentTarget as HTMLSelectElement
+								).value)}
+						>
+							<NativeSelectOption value="" disabled>Select a user…</NativeSelectOption>
+							{#each commissionerOptions as u (u.id)}
+								<NativeSelectOption value={u.id}>{fullName(u)}</NativeSelectOption>
+							{/each}
+						</NativeSelect>
+					</div>
+					<Button
+						type="submit"
+						disabled={savingCommissioner || !commissionerUserId}
+					>
+						{savingCommissioner ? 'Saving…' : 'Add co-commissioner'}
+					</Button>
+				</form>
+
+				{#if commissionerNames.length === 0}
+					<p class="mt-4 text-sm text-muted-foreground">No co-commissioners yet.</p>
+				{:else}
+					<ul class="mt-4 space-y-2 text-sm">
+						{#each commissionerNames as sc (sc.id)}
+							<li class="flex items-center justify-between gap-3">
+								<span class="font-medium">{userName(sc.user_id)}</span>
+								<Button
+									type="button"
+									variant="ghost"
+									size="sm"
+									disabled={savingCommissioner}
+									onclick={() => handleRemoveSeasonCommissioner(sc.id)}
+								>
+									Remove
+								</Button>
+							</li>
+						{/each}
+					</ul>
+				{/if}
+			</CardContent>
+		</Card>
+	{/if}
 
 
 	<!-- Late additions (sysadmin only) -->


### PR DESCRIPTION
Implements #163.

## Summary
Adds the ability to manage co-commissioners for a season, mirroring the established `season_late_addition` pattern (#162).

**Backend**
- New `route/seasoncommissioner` write surface: `POST /api/season_commissioner` (add) and `DELETE /api/season_commissioner/:id` (remove), both sysadmin-only (enforced via `model.SeasonCommissioner.EditableBy`).
- Registered read-only generic CRUD (`GET /api/season_commissioner[...]`) plus the custom write routes in `main.go`.
- Route tests covering add/remove success, non-sysadmin forbidden, missing token, and not-found.

**UI**
- `ui/src/lib/seasonCommissioner.ts` API client.
- "Co-commissioners" card on `/seasons/[id]` (sysadmin-only) to add/remove co-commissioners. The add dropdown excludes current commissioners and in-season users, matching the late-addition dropdown. Adding/removing refreshes the schedule detail so the new commissioner immediately counts as a season commissioner.

**Tests**
- New e2e spec `season-commissioners.spec.ts` (sysadmin add/remove via UI + API, non-sysadmin card hidden + API 403).
- Scoped an ambiguous `Remove` locator in the existing `season-late-additions.spec.ts` that collided with the new card.
- `make tests`, `npm run check`, and `make e2e` all green (e2e run 3x consecutively).

Closes #163