### PR TITLE
API + UI: blurbs feed with comments, reactions & photos (Closes #164,…

### DIFF
--- a/api/api_route.go
+++ b/api/api_route.go
@@ -65,6 +65,11 @@ type Request[T database.Validatable] struct {
 	// used unless the route is manually using the RouteFamily struct
 	DatabaseProvider database.Provider
 
+	// Params are the parsed gin path parameters for the request, e.g.
+	// `photoId` from `/blurb/:id/photos/:photoId`. The standard `:id`
+	// parameter is already parsed into PathId.
+	Params gin.Params
+
 	request *http.Request
 }
 
@@ -188,6 +193,7 @@ func (r *routeWrapper[T]) Handle(c *gin.Context) {
 		Context:          c.Request.Context(),
 		DatabaseProvider: r.Database,
 		request:          c.Request,
+		Params:           c.Params,
 	}
 
 	// parse out the body of the request if this route uses a request body

--- a/database/record_id.go
+++ b/database/record_id.go
@@ -51,6 +51,13 @@ func RecordIdFromString(s string) (RecordId, error) {
 	if s == "" {
 		return InvalidRecordId, nil
 	}
+	// A RecordId is 8 bytes = 16 hex chars. Reject anything that isn't exactly
+	// that length BEFORE decoding; hex.Decode into a fixed 8-byte buffer would
+	// otherwise write past the end of the slice and panic (runtime bounds
+	// check) when handed a longer even-length string.
+	if len(s) != 16 {
+		return InvalidRecordId, fmt.Errorf("invalid record ID %q: must be exactly 16 hex characters", s)
+	}
 	b := make([]byte, 8)
 	n, err := hex.Decode(b, []byte(s))
 	if err != nil {

--- a/database/sqlite_communication_roundtrip_test.go
+++ b/database/sqlite_communication_roundtrip_test.go
@@ -22,7 +22,9 @@ import (
 //
 // Comment.DynamicallyValid requires its owner to be a Season participant, so
 // the comment owner is registered as a Season commissioner (a participant)
-// before the comment is created.
+// before the comment is created. The same participant requirement now applies
+// to blurb owners and to blurb/comment reactors, so those users are registered
+// as commissioners before their records are created.
 
 // createTestPhoto creates a Photo with random contents owned by the given user.
 func createTestPhoto(t *testing.T, p database.Provider, owner *model.User) *model.Photo {
@@ -168,6 +170,9 @@ func TestBlurbRoundTrip(t *testing.T) {
 	p := newSqliteProvider(t)
 	owner := createTestUser(t, p)
 	season := createTestSeason(t, p)
+	// the blurb owner must be a Season participant, so register them as a
+	// commissioner
+	createTestSeasonCommissioner(t, p, season, owner)
 
 	blurb := createTestBlurb(t, p, owner, season)
 
@@ -221,6 +226,9 @@ func TestBlurbPhotoRoundTrip(t *testing.T) {
 	p := newSqliteProvider(t)
 	owner := createTestUser(t, p)
 	season := createTestSeason(t, p)
+	// the blurb owner must be a Season participant, so register them as a
+	// commissioner
+	createTestSeasonCommissioner(t, p, season, owner)
 	blurb := createTestBlurb(t, p, owner, season)
 	photo := createTestPhoto(t, p, owner)
 	photo2 := createTestPhoto(t, p, owner)
@@ -282,8 +290,12 @@ func TestBlurbReactionRoundTrip(t *testing.T) {
 	p := newSqliteProvider(t)
 	owner := createTestUser(t, p)
 	season := createTestSeason(t, p)
-	blurb := createTestBlurb(t, p, owner, season)
 	reactor := createTestUser(t, p)
+	// the blurb owner and the reactor must be Season participants, so register
+	// them as commissioners
+	createTestSeasonCommissioner(t, p, season, owner)
+	createTestSeasonCommissioner(t, p, season, reactor)
+	blurb := createTestBlurb(t, p, owner, season)
 
 	row := &model.BlurbReaction{BlurbId: blurb.ID, UserId: reactor.ID, ReactionType: model.ThumbsUp}
 	created, err := database.CreateOne(ctx, p, row)
@@ -406,6 +418,9 @@ func TestCommentReactionRoundTrip(t *testing.T) {
 	blurb := createTestBlurb(t, p, owner, season)
 	comment := createTestComment(t, p, blurb, owner)
 	reactor := createTestUser(t, p)
+	// the reactor must be a Season participant, so register them as a
+	// commissioner
+	createTestSeasonCommissioner(t, p, season, reactor)
 
 	row := &model.CommentReaction{CommentId: comment.ID, UserId: reactor.ID, ReactionType: model.Heart}
 	created, err := database.CreateOne(ctx, p, row)

--- a/main.go
+++ b/main.go
@@ -14,6 +14,8 @@ import (
 	"intraclub/model"
 	"intraclub/route"
 	"intraclub/route/availability"
+	"intraclub/route/blurb"
+	"intraclub/route/comment"
 	"intraclub/route/draft"
 	"intraclub/route/format"
 	"intraclub/route/lateaddition"
@@ -233,6 +235,44 @@ func main() {
 
 	photos := api.NewCrudCommon(model.NewPhoto, false, db)
 	photos.HandleRouteTypes(rg, api.CrudWrapperFunctionAll...)
+
+	// Blurbs are season-scoped posts (news/announcements) that users can
+	// comment on and react to. Generic CRUD covers create / list / read /
+	// update / delete (an owner creates and edits their own blurb); reactions
+	// and photo attachment go through the custom routes in route/blurb, which
+	// enforce season-participation and ownership rules.
+	blurbs := api.NewCrudCommon(model.NewBlurb, false, db)
+	blurbs.HandleRouteTypes(rg, api.CrudWrapperFunctionAll...)
+
+	// Comments attach to a blurb and support replies; reactions attach to
+	// comments. Generic CRUD covers create / list / read / update / delete
+	// (edits are gated by the model's EditableBy: owner / blurb owner /
+	// season commissioners / sysadmin); reactions go through the custom routes
+	// in route/comment.
+	comments := api.NewCrudCommon(model.NewComment, false, db)
+	comments.HandleRouteTypes(rg, api.CrudWrapperFunctionAll...)
+
+	// BlurbPhoto / BlurbReaction / CommentReaction are child-table join rows.
+	// They are exposed via generic CRUD for read/admin access; the interactive
+	// writes go through the custom routes in route/blurb and route/comment
+	// (which enforce ownership, dedup, and season-participation).
+	blurbPhotos := api.NewCrudCommon(func() *model.BlurbPhoto { return &model.BlurbPhoto{} }, false, db)
+	blurbPhotos.HandleRouteTypes(rg, api.CrudWrapperFunctionAll...)
+
+	blurbReactions := api.NewCrudCommon(func() *model.BlurbReaction { return &model.BlurbReaction{} }, false, db)
+	blurbReactions.HandleRouteTypes(rg, api.CrudWrapperFunctionAll...)
+
+	commentReactions := api.NewCrudCommon(func() *model.CommentReaction { return &model.CommentReaction{} }, false, db)
+	commentReactions.HandleRouteTypes(rg, api.CrudWrapperFunctionAll...)
+
+	blurbReactionRoutes := api.RouteFamily[*blurb.ReactionBody]{DatabaseProvider: db}
+	blurbReactionRoutes.Handle(rg, blurb.React{}, blurb.Unreact{})
+
+	blurbPhotoRoutes := api.RouteFamily[*blurb.PhotoBody]{DatabaseProvider: db}
+	blurbPhotoRoutes.Handle(rg, blurb.AddPhoto{}, blurb.RemovePhoto{})
+
+	commentReactionRoutes := api.RouteFamily[*comment.ReactionBody]{DatabaseProvider: db}
+	commentReactionRoutes.Handle(rg, comment.React{}, comment.Unreact{})
 
 	err = r.Run(cfg.addr)
 	if err != nil {

--- a/model/blurb.go
+++ b/model/blurb.go
@@ -83,9 +83,19 @@ func (b *Blurb) DynamicallyValid(ctx context.Context, db database.Provider) erro
 		return err
 	}
 
-	err = database.ExistsById(ctx, db, &Season{}, b.Season.RecordId())
+	season, err := database.GetExistingRecordById(ctx, db, &Season{}, b.Season.RecordId())
 	if err != nil {
 		return err
+	}
+
+	// The blurb's owner must be a participant of the season (mirrors the
+	// participant check enforced for comments and reactions).
+	isParticipant, err := season.IsUserIdASeasonParticipant(ctx, db, b.Owner)
+	if err != nil {
+		return err
+	}
+	if !isParticipant {
+		return fmt.Errorf("user %s is not a participant in season %s", b.Owner, b.Season)
 	}
 
 	// each attached photo (via the blurb_photo child table) must exist and be
@@ -356,10 +366,29 @@ func (r *BlurbReaction) StaticallyValid() error {
 }
 
 func (r *BlurbReaction) DynamicallyValid(ctx context.Context, db database.Provider) error {
-	if err := database.ExistsById(ctx, db, &Blurb{}, r.BlurbId.RecordId()); err != nil {
+	if err := database.ExistsById(ctx, db, &User{}, r.UserId.RecordId()); err != nil {
 		return err
 	}
-	return database.ExistsById(ctx, db, &User{}, r.UserId.RecordId())
+	blurb, err := database.GetExistingRecordById(ctx, db, &Blurb{}, r.BlurbId.RecordId())
+	if err != nil {
+		return err
+	}
+	season, err := database.GetExistingRecordById(ctx, db, &Season{}, blurb.Season.RecordId())
+	if err != nil {
+		return err
+	}
+
+	// The reacting user must be a participant of the blurb's season. This
+	// mirrors the participant check that the custom /react routes enforce, so
+	// the generic CRUD surface can't be used to bypass it.
+	isParticipant, err := season.IsUserIdASeasonParticipant(ctx, db, r.UserId)
+	if err != nil {
+		return err
+	}
+	if !isParticipant {
+		return fmt.Errorf("user %s is not a participant in season %s", r.UserId, season.ID)
+	}
+	return nil
 }
 
 func (r *BlurbReaction) AccessibleTo(ctx context.Context, db database.Provider) []database.UserId {

--- a/model/blurb.go
+++ b/model/blurb.go
@@ -20,12 +20,25 @@ func (id BlurbId) String() string {
 	return id.RecordId().String()
 }
 
+func (id BlurbId) MarshalJSON() ([]byte, error) {
+	return id.RecordId().MarshalJSON()
+}
+
+func (id *BlurbId) UnmarshalJSON(data []byte) error {
+	rid := id.RecordId()
+	if err := (*database.RecordId)(&rid).UnmarshalJSON(data); err != nil {
+		return err
+	}
+	*id = BlurbId(rid)
+	return nil
+}
+
 type Blurb struct {
-	ID      BlurbId `json:"id"`
-	Title   string
-	Content string
-	Owner   database.UserId
-	Season  SeasonId
+	ID      BlurbId         `json:"id"`
+	Title   string          `json:"title"`
+	Content string          `json:"content"`
+	Owner   database.UserId `json:"owner"`
+	Season  SeasonId        `json:"season"`
 }
 
 func (b *Blurb) GetOwner() database.UserId {

--- a/model/blurb_test.go
+++ b/model/blurb_test.go
@@ -75,6 +75,17 @@ func TestBlurbSeasonIdDoesNotExist(t *testing.T) {
 	fmt.Println(b.DynamicallyValid(context.Background(), db))
 }
 
+func TestBlurbByNonSeasonParticipant(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	season, _ := newDefaultSeason(t, db)
+	otherUser := newStoredUser(t, db)
+
+	b := newValidBlurb(otherUser.ID, season.ID)
+	err := b.DynamicallyValid(context.Background(), db)
+	assert.Error(t, err, "expected error on blurb by non-season participant")
+	fmt.Println(err)
+}
+
 func TestBlurbPhotoIdDoesNotExist(t *testing.T) {
 	db := database.NewUnitTestDBProvider()
 	season, commish := newDefaultSeason(t, db)
@@ -120,6 +131,27 @@ func TestUserIdIsNotAMemberOfSeason(t *testing.T) {
 	otherUser := newStoredUser(t, db)
 	assert.Error(t, b.React(context.Background(), db, otherUser.ID, ThumbsUp), "expected error on reaction from user who is not participating in season")
 	fmt.Println(b.React(context.Background(), db, otherUser.ID, ThumbsUp))
+}
+
+func TestBlurbReactionByNonSeasonParticipant(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	season, commish := newDefaultSeason(t, db)
+	b := newStoredBlurb(t, db, commish.ID, season.ID)
+
+	otherUser := newStoredUser(t, db)
+	row := &BlurbReaction{BlurbId: b.ID, UserId: otherUser.ID, ReactionType: ThumbsUp}
+	err := row.DynamicallyValid(context.Background(), db)
+	assert.Error(t, err, "expected error on reaction row from user who is not participating in season")
+	fmt.Println(err)
+}
+
+func TestBlurbReactionBySeasonParticipant(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	season, commish := newDefaultSeason(t, db)
+	b := newStoredBlurb(t, db, commish.ID, season.ID)
+
+	row := &BlurbReaction{BlurbId: b.ID, UserId: commish.ID, ReactionType: ThumbsUp}
+	require.NoError(t, row.DynamicallyValid(context.Background(), db))
 }
 
 func TestUserSuccessfulReact(t *testing.T) {

--- a/model/comment.go
+++ b/model/comment.go
@@ -245,10 +245,33 @@ func (r *CommentReaction) StaticallyValid() error {
 }
 
 func (r *CommentReaction) DynamicallyValid(ctx context.Context, db database.Provider) error {
-	if err := database.ExistsById(ctx, db, &Comment{}, r.CommentId.RecordId()); err != nil {
+	if err := database.ExistsById(ctx, db, &User{}, r.UserId.RecordId()); err != nil {
 		return err
 	}
-	return database.ExistsById(ctx, db, &User{}, r.UserId.RecordId())
+	commentRec, err := database.GetExistingRecordById(ctx, db, &Comment{}, r.CommentId.RecordId())
+	if err != nil {
+		return err
+	}
+	blurb, err := database.GetExistingRecordById(ctx, db, &Blurb{}, commentRec.Blurb.RecordId())
+	if err != nil {
+		return err
+	}
+	season, err := database.GetExistingRecordById(ctx, db, &Season{}, blurb.Season.RecordId())
+	if err != nil {
+		return err
+	}
+
+	// The reacting user must be a participant of the comment's blurb's season.
+	// This mirrors the participant check that the custom /react routes enforce,
+	// so the generic CRUD surface can't be used to bypass it.
+	isParticipant, err := season.IsUserIdASeasonParticipant(ctx, db, r.UserId)
+	if err != nil {
+		return err
+	}
+	if !isParticipant {
+		return fmt.Errorf("user %s is not a participant in season %s", r.UserId, season.ID)
+	}
+	return nil
 }
 
 func (r *CommentReaction) AccessibleTo(ctx context.Context, db database.Provider) []database.UserId {

--- a/model/comment.go
+++ b/model/comment.go
@@ -20,6 +20,19 @@ func (id CommentId) String() string {
 	return id.RecordId().String()
 }
 
+func (id CommentId) MarshalJSON() ([]byte, error) {
+	return id.RecordId().MarshalJSON()
+}
+
+func (id *CommentId) UnmarshalJSON(data []byte) error {
+	rid := id.RecordId()
+	if err := (*database.RecordId)(&rid).UnmarshalJSON(data); err != nil {
+		return err
+	}
+	*id = CommentId(rid)
+	return nil
+}
+
 type Comment struct {
 	ID        CommentId       `json:"id"`                           // unique ID for this comment
 	Blurb     BlurbId         `json:"blurb"`                        // ID of the Blurb that this comment is on
@@ -109,12 +122,19 @@ func (c *Comment) StaticallyValid() error {
 		return fmt.Errorf("comment is empty")
 	}
 
-	if c.ReplyTo == c.ID {
-		return errors.New("comment references itself")
-	}
-
-	if c.CreatedAt.IsZero() {
-		return fmt.Errorf("comment created timestamp is zero")
+	// The self-reference and created-timestamp checks only apply once the
+	// comment has been persisted (an ID has been assigned). The generic CRUD
+	// route wrapper pre-validates a fresh request body before
+	// CreateOne/UpdateOne assigns the ID and timestamps, at which point both
+	// ReplyTo and ID are zero; gating on a set ID keeps that pre-check from
+	// spuriously rejecting a brand-new comment.
+	if c.ID != CommentId(database.InvalidRecordId) {
+		if c.ReplyTo == c.ID {
+			return errors.New("comment references itself")
+		}
+		if c.CreatedAt.IsZero() {
+			return fmt.Errorf("comment created timestamp is zero")
+		}
 	}
 
 	return nil

--- a/model/comment_test.go
+++ b/model/comment_test.go
@@ -234,6 +234,34 @@ func TestCommentByNonSeasonParticipant(t *testing.T) {
 	fmt.Println(err)
 }
 
+func TestCommentReactionByNonSeasonParticipant(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	blurb, season := newDefaultBlurb(t, db)
+	owner := getAnyTeamCaptain(t, db, season)
+	comment := newStoredComment(t, db, owner, blurb)
+
+	otherUser := newStoredUser(t, db)
+	row := &CommentReaction{CommentId: comment.ID, UserId: otherUser.ID, ReactionType: ThumbsUp}
+	err := row.DynamicallyValid(context.Background(), db)
+	if err == nil {
+		t.Error("Reaction by non-season participant should produce error")
+	}
+	fmt.Println(err)
+}
+
+func TestCommentReactionBySeasonParticipant(t *testing.T) {
+	db := database.NewUnitTestDBProvider()
+	blurb, season := newDefaultBlurb(t, db)
+	owner := getAnyTeamCaptain(t, db, season)
+	comment := newStoredComment(t, db, owner, blurb)
+
+	row := &CommentReaction{CommentId: comment.ID, UserId: owner, ReactionType: ThumbsUp}
+	err := row.DynamicallyValid(context.Background(), db)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestCommentPostDeleteCascadesReactions(t *testing.T) {
 	db := database.NewUnitTestDBProvider()
 	blurb, season := newDefaultBlurb(t, db)

--- a/model/photo.go
+++ b/model/photo.go
@@ -54,9 +54,13 @@ func (id PhotoId) MarshalJSON() ([]byte, error) {
 	return id.RecordId().MarshalJSON()
 }
 
-func (id PhotoId) UnmarshalJSON(data []byte) error {
+func (id *PhotoId) UnmarshalJSON(data []byte) error {
 	rid := id.RecordId()
-	return (*database.RecordId)(&rid).UnmarshalJSON(data)
+	if err := (*database.RecordId)(&rid).UnmarshalJSON(data); err != nil {
+		return err
+	}
+	*id = PhotoId(rid)
+	return nil
 }
 
 type Photo struct {

--- a/route/blurb/blurb.go
+++ b/route/blurb/blurb.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"strings"
 
 	"intraclub/api"
 	"intraclub/database"
@@ -185,14 +184,12 @@ func (c AddPhoto) Handler(req api.Request[*PhotoBody]) (any, int, error) {
 	return gin.H{api.ResourceKey: created}, http.StatusOK, nil
 }
 
-// photoIdFromPath parses the final :photoId path segment into a model.PhotoId.
+// photoIdFromPath parses the :photoId path parameter into a model.PhotoId.
 func photoIdFromPath[T database.Validatable](req api.Request[T]) (model.PhotoId, error) {
-	path := req.HTTPRequest().URL.Path
-	segments := strings.Split(strings.Trim(path, "/"), "/")
-	if len(segments) == 0 {
+	raw, ok := req.Params.Get("photoId")
+	if !ok || raw == "" {
 		return model.PhotoId(database.InvalidRecordId), errors.New("invalid :photoId path parameter")
 	}
-	raw := segments[len(segments)-1]
 	rid, err := database.RecordIdFromString(raw)
 	if err != nil {
 		return model.PhotoId(database.InvalidRecordId), errors.New("invalid :photoId path parameter")

--- a/route/blurb/blurb.go
+++ b/route/blurb/blurb.go
@@ -1,0 +1,247 @@
+// Package blurb exposes the interactive write surface for Blurb records that
+// the generic CRUD surface in main.go doesn't cover: reacting to a blurb and
+// attaching/detaching photos.
+//
+// Generic CRUD (registered in main.go) handles create/list/read/update/delete
+// of blurbs, comments, and the child join tables. The routes in this package
+// handle the operations that require business logic:
+//
+//   - React / Unreact: deduplicated per (blurb, user, type) via
+//     model.Blurb.React/Unreact, which also enforces that the acting user is a
+//     participant of the blurb's season.
+//   - AddPhoto / RemovePhoto: the child BlurbPhoto.EditableBy is sysadmin-only,
+//     so the normal owner flow goes through these routes, which enforce that
+//     only the blurb owner may attach photos they own.
+package blurb
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"intraclub/api"
+	"intraclub/database"
+	"intraclub/model"
+
+	"github.com/gin-gonic/gin"
+)
+
+// BaseRoute is the base API route for Blurb records. It matches the model's
+// Type() ("blurb").
+var BaseRoute = "/blurb"
+
+// ReactionBody is the request body for React and Unreact. Reaction is the
+// human-readable reaction name (e.g. "Thumbs up", "Fire", "Heart") resolved
+// against model.GetAllReactionTypes().
+type ReactionBody struct {
+	Reaction string `json:"reaction"`
+}
+
+// StaticallyValid ensures a reaction name was provided.
+func (b *ReactionBody) StaticallyValid() error {
+	if b.Reaction == "" {
+		return errors.New("reaction must not be empty")
+	}
+	return nil
+}
+
+// applyReaction runs React or Unreact for the token user against the blurb at
+// req.PathId and returns the blurb's updated reaction list.
+func applyReaction(req api.Request[*ReactionBody], unreact bool) (any, int, error) {
+	if req.Token == nil {
+		return nil, http.StatusUnauthorized, errors.New("token is required")
+	}
+
+	blurb, err := database.GetExistingRecordById(req.Context, req.DatabaseProvider, &model.Blurb{}, req.PathId)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+
+	// The acting user must be a participant of the blurb's season. Blurb.React
+	// re-checks this internally, but we surface it here as a clean 403 so the
+	// client can distinguish "forbidden" from an invalid request.
+	if err := blurb.CanUserCommentOrReact(req.Context, req.DatabaseProvider, req.Token.UserId); err != nil {
+		return nil, http.StatusForbidden, err
+	}
+
+	reactionTypes := model.GetAllReactionTypes()
+	t, ok := reactionTypes[req.Body.Reaction]
+	if !ok {
+		return nil, http.StatusBadRequest, fmt.Errorf("invalid reaction %q", req.Body.Reaction)
+	}
+
+	if unreact {
+		err = blurb.Unreact(req.Context, req.DatabaseProvider, req.Token.UserId, t)
+	} else {
+		err = blurb.React(req.Context, req.DatabaseProvider, req.Token.UserId, t)
+	}
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+
+	reactions, err := blurb.GetReactions(req.Context, req.DatabaseProvider)
+	if err != nil {
+		return nil, http.StatusInternalServerError, err
+	}
+	return gin.H{api.ResourceKey: reactions}, http.StatusOK, nil
+}
+
+// React adds a reaction from the token user to the blurb.
+type React struct{}
+
+func (c React) Path() (api.HttpMethod, string) {
+	return api.HttpMethodPost, api.AppendPathId(BaseRoute) + "/react"
+}
+
+func (c React) RequestBody() (*ReactionBody, bool) {
+	return &ReactionBody{}, true
+}
+
+func (c React) Handler(req api.Request[*ReactionBody]) (any, int, error) {
+	return applyReaction(req, false)
+}
+
+// Unreact removes the token user's reaction of the given type from the blurb.
+type Unreact struct{}
+
+func (c Unreact) Path() (api.HttpMethod, string) {
+	return api.HttpMethodPost, api.AppendPathId(BaseRoute) + "/unreact"
+}
+
+func (c Unreact) RequestBody() (*ReactionBody, bool) {
+	return &ReactionBody{}, true
+}
+
+func (c Unreact) Handler(req api.Request[*ReactionBody]) (any, int, error) {
+	return applyReaction(req, true)
+}
+
+// PhotoBody is the request body for AddPhoto.
+type PhotoBody struct {
+	PhotoId model.PhotoId `json:"photo_id"`
+}
+
+// StaticallyValid ensures a photo was provided.
+func (b *PhotoBody) StaticallyValid() error {
+	if b.PhotoId == model.PhotoId(database.InvalidRecordId) {
+		return errors.New("photo_id must not be empty")
+	}
+	return nil
+}
+
+// AddPhoto attaches a photo owned by the token user to a blurb owned by the
+// token user.
+type AddPhoto struct{}
+
+func (c AddPhoto) Path() (api.HttpMethod, string) {
+	return api.HttpMethodPost, api.AppendPathId(BaseRoute) + "/photos"
+}
+
+func (c AddPhoto) RequestBody() (*PhotoBody, bool) {
+	return &PhotoBody{}, true
+}
+
+func (c AddPhoto) Handler(req api.Request[*PhotoBody]) (any, int, error) {
+	if req.Token == nil {
+		return nil, http.StatusUnauthorized, errors.New("token is required")
+	}
+
+	blurb, err := database.GetExistingRecordById(req.Context, req.DatabaseProvider, &model.Blurb{}, req.PathId)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	if blurb.Owner != req.Token.UserId {
+		return nil, http.StatusForbidden, errors.New("only the blurb owner may attach photos")
+	}
+
+	photo, exists, err := database.GetOneById(req.Context, req.DatabaseProvider, &model.Photo{}, req.Body.PhotoId.RecordId())
+	if err != nil {
+		return nil, http.StatusInternalServerError, err
+	}
+	if !exists {
+		return nil, http.StatusBadRequest, errors.New("photo does not exist")
+	}
+	if photo.Owner != req.Token.UserId {
+		return nil, http.StatusForbidden, errors.New("photo must be owned by the blurb owner")
+	}
+
+	existing, err := database.GetAllWhere[*model.BlurbPhoto](req.Context, req.DatabaseProvider, func(_ context.Context, p *model.BlurbPhoto) bool {
+		return p.BlurbId == blurb.ID && p.PhotoId == req.Body.PhotoId
+	})
+	if err != nil {
+		return nil, http.StatusInternalServerError, err
+	}
+	if len(existing) > 0 {
+		return nil, http.StatusBadRequest, errors.New("photo is already attached to this blurb")
+	}
+
+	row := &model.BlurbPhoto{BlurbId: blurb.ID, PhotoId: req.Body.PhotoId}
+	created, err := database.CreateOne(req.Context, req.DatabaseProvider, row)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	return gin.H{api.ResourceKey: created}, http.StatusOK, nil
+}
+
+// photoIdFromPath parses the final :photoId path segment into a model.PhotoId.
+func photoIdFromPath[T database.Validatable](req api.Request[T]) (model.PhotoId, error) {
+	path := req.HTTPRequest().URL.Path
+	segments := strings.Split(strings.Trim(path, "/"), "/")
+	if len(segments) == 0 {
+		return model.PhotoId(database.InvalidRecordId), errors.New("invalid :photoId path parameter")
+	}
+	raw := segments[len(segments)-1]
+	rid, err := database.RecordIdFromString(raw)
+	if err != nil {
+		return model.PhotoId(database.InvalidRecordId), errors.New("invalid :photoId path parameter")
+	}
+	return model.PhotoId(rid), nil
+}
+
+// RemovePhoto detaches a photo from a blurb. Only the blurb owner may do so.
+type RemovePhoto struct{}
+
+func (c RemovePhoto) Path() (api.HttpMethod, string) {
+	return api.HttpMethodDelete, api.AppendPathId(BaseRoute) + "/photos/" + ":photoId"
+}
+
+func (c RemovePhoto) RequestBody() (*PhotoBody, bool) {
+	return &PhotoBody{}, false
+}
+
+func (c RemovePhoto) Handler(req api.Request[*PhotoBody]) (any, int, error) {
+	if req.Token == nil {
+		return nil, http.StatusUnauthorized, errors.New("token is required")
+	}
+
+	blurb, err := database.GetExistingRecordById(req.Context, req.DatabaseProvider, &model.Blurb{}, req.PathId)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	if blurb.Owner != req.Token.UserId {
+		return nil, http.StatusForbidden, errors.New("only the blurb owner may remove photos")
+	}
+
+	photoId, err := photoIdFromPath(req)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+
+	rows, err := database.GetAllWhere[*model.BlurbPhoto](req.Context, req.DatabaseProvider, func(_ context.Context, p *model.BlurbPhoto) bool {
+		return p.BlurbId == blurb.ID && p.PhotoId == photoId
+	})
+	if err != nil {
+		return nil, http.StatusInternalServerError, err
+	}
+	if len(rows) == 0 {
+		return nil, http.StatusNotFound, errors.New("photo is not attached to this blurb")
+	}
+	for _, row := range rows {
+		if _, _, err := database.DeleteOneById(req.Context, req.DatabaseProvider, row, row.ID); err != nil {
+			return nil, http.StatusInternalServerError, err
+		}
+	}
+	return gin.H{api.ResourceKey: rows[0]}, http.StatusOK, nil
+}

--- a/route/comment/comment.go
+++ b/route/comment/comment.go
@@ -1,0 +1,114 @@
+// Package comment exposes the interactive write surface for Comment records
+// (reactions) that the generic CRUD surface in main.go doesn't cover.
+//
+// Generic CRUD (registered in main.go) handles create/list/read/update/delete
+// of comments and the comment_reaction child rows. The routes in this package
+// handle reacting/unreacting to a comment, which is deduplicated per
+// (comment, user, type) via model.Comment.React/Unreact and requires the
+// acting user to be a participant of the comment's blurb's season.
+package comment
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"intraclub/api"
+	"intraclub/database"
+	"intraclub/model"
+
+	"github.com/gin-gonic/gin"
+)
+
+// BaseRoute is the base API route for Comment records. It matches the model's
+// Type() ("comment").
+var BaseRoute = "/comment"
+
+// ReactionBody is the request body for React and Unreact. Reaction is the
+// human-readable reaction name (e.g. "Thumbs up", "Fire", "Heart") resolved
+// against model.GetAllReactionTypes().
+type ReactionBody struct {
+	Reaction string `json:"reaction"`
+}
+
+// StaticallyValid ensures a reaction name was provided.
+func (b *ReactionBody) StaticallyValid() error {
+	if b.Reaction == "" {
+		return errors.New("reaction must not be empty")
+	}
+	return nil
+}
+
+// applyReaction runs React or Unreact for the token user against the comment at
+// req.PathId and returns the comment's updated reaction list.
+func applyReaction(req api.Request[*ReactionBody], unreact bool) (any, int, error) {
+	if req.Token == nil {
+		return nil, http.StatusUnauthorized, errors.New("token is required")
+	}
+
+	commentRec, err := database.GetExistingRecordById(req.Context, req.DatabaseProvider, &model.Comment{}, req.PathId)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+
+	// The acting user must be a participant of the comment's blurb's season
+	// (mirrors the participant check enforced for blurb reactions).
+	blurb, err := database.GetExistingRecordById(req.Context, req.DatabaseProvider, &model.Blurb{}, commentRec.Blurb.RecordId())
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	if err := blurb.CanUserCommentOrReact(req.Context, req.DatabaseProvider, req.Token.UserId); err != nil {
+		return nil, http.StatusForbidden, err
+	}
+
+	reactionTypes := model.GetAllReactionTypes()
+	t, ok := reactionTypes[req.Body.Reaction]
+	if !ok {
+		return nil, http.StatusBadRequest, fmt.Errorf("invalid reaction %q", req.Body.Reaction)
+	}
+
+	if unreact {
+		err = commentRec.Unreact(req.Context, req.DatabaseProvider, req.Token.UserId, t)
+	} else {
+		err = commentRec.React(req.Context, req.DatabaseProvider, req.Token.UserId, t)
+	}
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+
+	reactions, err := commentRec.GetReactions(req.Context, req.DatabaseProvider)
+	if err != nil {
+		return nil, http.StatusInternalServerError, err
+	}
+	return gin.H{api.ResourceKey: reactions}, http.StatusOK, nil
+}
+
+// React adds a reaction from the token user to the comment.
+type React struct{}
+
+func (c React) Path() (api.HttpMethod, string) {
+	return api.HttpMethodPost, api.AppendPathId(BaseRoute) + "/react"
+}
+
+func (c React) RequestBody() (*ReactionBody, bool) {
+	return &ReactionBody{}, true
+}
+
+func (c React) Handler(req api.Request[*ReactionBody]) (any, int, error) {
+	return applyReaction(req, false)
+}
+
+// Unreact removes the token user's reaction of the given type from the comment.
+type Unreact struct{}
+
+func (c Unreact) Path() (api.HttpMethod, string) {
+	return api.HttpMethodPost, api.AppendPathId(BaseRoute) + "/unreact"
+}
+
+func (c Unreact) RequestBody() (*ReactionBody, bool) {
+	return &ReactionBody{}, true
+}
+
+func (c Unreact) Handler(req api.Request[*ReactionBody]) (any, int, error) {
+	return applyReaction(req, true)
+}

--- a/ui/e2e/blurbs.spec.ts
+++ b/ui/e2e/blurbs.spec.ts
@@ -182,9 +182,11 @@ test('blurbs feed: create blurb with photo, comment, reply, react, delete', asyn
 	await expect(page.getByText('Agreed')).toBeVisible();
 
 	// --- Delete the comment ----------------------------------------------------
-	// The comment's Delete button renders after the blurb's header Delete, so
-	// .last() is the comment delete for a single comment.
-	await page.getByRole('button', { name: 'Delete', exact: true }).last().click();
+	// The comment's Delete button is the second Delete in the DOM (after the
+	// blurb header's). It must be targeted positionally: once the reply row
+	// below hydrates it also renders a Delete (the reply is owned by the same
+	// user), so .last() is ambiguous between the comment and the reply.
+	await page.getByRole('button', { name: 'Delete', exact: true }).nth(1).click();
 	await expect(page.getByText('Great news!')).toHaveCount(0);
 
 	// --- Delete the blurb -------------------------------------------------------

--- a/ui/e2e/blurbs.spec.ts
+++ b/ui/e2e/blurbs.spec.ts
@@ -1,0 +1,252 @@
+import { expect, test, type Page } from '@playwright/test';
+import { waitForHydration } from './helpers';
+
+// The Go backend runs with --dev-token from the repo root (see
+// playwright.config.ts), so POST /api/one_time_password returns the magic-link
+// token in the response body. The seeded jdarthur@gatech.edu user is the system
+// administrator in dev mode (see model.SeedDevData), which is used to create a
+// season; the season's captain (a participant) drives the blurb UI flow, since
+// commenting/reacting requires season participation.
+async function login(page: Page, email: string) {
+	await page.goto('/login');
+	await page.waitForLoadState('networkidle');
+	await page.getByLabel('Email').fill(email);
+	await page.getByRole('button', { name: 'Send login link' }).click();
+	const link = page.getByRole('main').getByRole('link', { name: 'Log in' });
+	await expect(link).toBeVisible();
+	await link.click();
+	await expect(page).toHaveURL('/');
+}
+
+// SeedDevData creates a format named "Men's Intraclub".
+const SEED_FORMAT = "Men's Intraclub";
+const API = 'http://127.0.0.1:8080/api';
+
+// A 1x1 transparent PNG, used to exercise the photo-upload path end to end.
+const PNG_1PX =
+	'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
+
+// createSeason runs the minimal draft flow (one captain + one roster player)
+// and finalizes it into a season, returning the season id. The captain (whose
+// email is cap<unique>@example.com) is a season participant.
+async function createSeason(page: Page, token: string, unique: number): Promise<string> {
+	const people = [
+		{ first: `Cap${unique}`, last: 'B' },
+		{ first: `Play${unique}`, last: 'B' }
+	];
+	const csv = [
+		'First Name, Last Name, Email',
+		...people.map((p) => `${p.first}, ${p.last}, ${p.first.toLowerCase()}@example.com`)
+	].join('\n');
+	const importRes = await page.request.post(`${API}/import_users_from_csv`, {
+		form: { file: csv }
+	});
+	expect(importRes.ok()).toBeTruthy();
+	const importBody = await importRes.json();
+	const [captainId, playerId] = [...importBody.Created, ...importBody.AlreadyExisting].map(
+		(u: { id: string }) => u.id
+	);
+
+	const facilityRes = await page.request.post(`${API}/facility`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { name: `Blurb Facility ${unique}`, address: `${unique} Main St`, courts: 4 }
+	});
+	expect(facilityRes.ok()).toBeTruthy();
+	const facilityId = (await facilityRes.json()).resource.id as string;
+
+	const formats = (await (await page.request.get(`${API}/format`)).json()).resource as {
+		id: string;
+		name: string;
+	}[];
+	const format = formats.find((f) => f.name === SEED_FORMAT);
+	expect(format).toBeTruthy();
+
+	const draftRes = await page.request.post(`${API}/draft`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { name: `Blurb Draft ${unique}`, format: format!.id }
+	});
+	expect(draftRes.ok()).toBeTruthy();
+	const draftId = (await draftRes.json()).resource.id as string;
+
+	await page.request.post(`${API}/draft/${draftId}/initialize`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { captains: [captainId] }
+	});
+	await page.request.post(`${API}/draft/${draftId}/assign_draftable_players`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { players: [playerId] }
+	});
+
+	const ratings = (
+		await (
+			await page.request.get(`${API}/format/${format!.id}/possible_ratings`, {
+				headers: { 'X-INTRACLUB-TOKEN': token }
+			})
+		).json()
+	).resource as { id: string }[];
+	expect(ratings.length).toBeGreaterThanOrEqual(2);
+	await page.request.post(`${API}/draft/${draftId}/assign_rating_cutoff`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { rating: ratings[0].id, cutoff: 1 }
+	});
+	await page.request.post(`${API}/draft/${draftId}/assign_rating_cutoff`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { rating: ratings[1].id, cutoff: 5 }
+	});
+
+	const captainToken = await tokenFor(page, `cap${unique}@example.com`);
+
+	// The captain drafts the roster player, then themselves -> 2 picks = complete.
+	for (const player of [playerId, captainId]) {
+		const res = await page.request.post(`${API}/draft/${draftId}/select`, {
+			headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': captainToken },
+			data: { player_id: player }
+		});
+		expect(res.ok(), `pick failed: ${await res.text()}`).toBeTruthy();
+	}
+
+	const seasonRes = await page.request.post(`${API}/draft/${draftId}/create_season`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { name: `Blurb Season ${unique}`, facility: facilityId, start_time: '08:30' }
+	});
+	expect(seasonRes.ok()).toBeTruthy();
+	return (await seasonRes.json()).resource.id as string;
+}
+
+async function tokenFor(page: Page, email: string): Promise<string> {
+	const res = await page.request.post(`${API}/one_time_password`, { data: { email } });
+	expect(res.ok()).toBeTruthy();
+	const { token } = await res.json();
+	const jwtRes = await page.request.post(`${API}/token`, { data: { token } });
+	expect(jwtRes.ok()).toBeTruthy();
+	const { jwt } = await jwtRes.json();
+	return jwt;
+}
+
+test('blurbs feed: create blurb with photo, comment, reply, react, delete', async ({ page }) => {
+	// The blurbs page uses window.confirm for destructive actions.
+	page.on('dialog', (dialog) => dialog.accept());
+
+	await login(page, 'jdarthur@gatech.edu');
+	const token = await page.evaluate(() => localStorage.getItem('intraclub_jwt') ?? '');
+	expect(token).toBeTruthy();
+
+	const unique = Date.now();
+	const seasonId = await createSeason(page, token, unique);
+
+	// Log in as the season's captain (a participant) to drive the UI flow.
+	await page.evaluate(() => localStorage.removeItem('intraclub_jwt'));
+	await login(page, `cap${unique}@example.com`);
+
+	await page.goto(`/seasons/${seasonId}/blurbs`);
+	await waitForHydration(page);
+
+	// --- Create a blurb with an attached photo --------------------------------
+	await page.getByLabel('Title').fill('Kickoff announcement');
+	await page.getByLabel('Content').fill('Welcome to the season!');
+	await page.getByLabel('Attach a photo (optional)').setInputFiles({
+		name: 'photo.png',
+		mimeType: 'image/png',
+		buffer: Buffer.from(PNG_1PX, 'base64')
+	});
+	// Wait for the FileReader to finish staging the image before submitting.
+	await expect(page.getByText('Photo ready to attach')).toBeVisible();
+	await page.getByRole('button', { name: 'Post blurb' }).click();
+	await expect(page.getByText('Kickoff announcement', { exact: true })).toBeVisible();
+	await expect(page.getByText('Welcome to the season!')).toBeVisible();
+	await expect(page.locator('img[alt="Kickoff announcement"]')).toBeVisible();
+
+	// --- React to the blurb (Fire) -------------------------------------------
+	// The blurb reaction emoji row renders before any comment rows, so .first()
+	// targets the blurb's Fire button.
+	await page.getByTitle('Fire').first().click();
+	await expect(page.getByText('🔥 1')).toBeVisible();
+
+	// --- Add a comment --------------------------------------------------------
+	const commentInput = page.getByPlaceholder('Add a comment...');
+	await commentInput.fill('Great news!');
+	await commentInput.press('Enter');
+	await expect(page.getByText('Great news!')).toBeVisible();
+
+	// --- React to the comment (Thumbs up) -------------------------------------
+	// The comment's reaction buttons render after the blurb's; for a single
+	// comment, .last() is the comment's Thumbs up button.
+	await page.getByTitle('Thumbs up').last().click();
+	await expect(page.getByText('👍 1')).toBeVisible();
+
+	// --- Reply to the comment --------------------------------------------------
+	await page.getByRole('button', { name: 'Reply' }).first().click();
+	const replyInput = page.getByPlaceholder('Write a reply...');
+	await replyInput.fill('Agreed');
+	await replyInput.press('Enter');
+	await expect(page.getByText('Agreed')).toBeVisible();
+
+	// --- Delete the comment ----------------------------------------------------
+	// The comment's Delete button renders after the blurb's header Delete, so
+	// .last() is the comment delete for a single comment.
+	await page.getByRole('button', { name: 'Delete', exact: true }).last().click();
+	await expect(page.getByText('Great news!')).toHaveCount(0);
+
+	// --- Delete the blurb -------------------------------------------------------
+	await page.getByRole('button', { name: 'Delete', exact: true }).first().click();
+	await expect(page.getByText('Kickoff announcement', { exact: true })).toHaveCount(0);
+	await expect(page.getByText('No blurbs yet for this season.')).toBeVisible();
+
+	// Clean up the season's draft + facility via the API isn't required; the
+	// dev DB is ephemeral per e2e run.
+});
+
+test('non-participant cannot react to a blurb', async ({ page }) => {
+	await login(page, 'jdarthur@gatech.edu');
+	const token = await page.evaluate(() => localStorage.getItem('intraclub_jwt') ?? '');
+	expect(token).toBeTruthy();
+
+	const unique = Date.now();
+	const seasonId = await createSeason(page, token, unique);
+
+	// The captain (participant) posts a blurb via the API.
+	const captainToken = await tokenFor(page, `cap${unique}@example.com`);
+	const blurbRes = await page.request.post(`${API}/blurb`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': captainToken },
+		data: { title: 'Private', content: 'Participants only', season: seasonId }
+	});
+	expect(blurbRes.ok()).toBeTruthy();
+	const blurbId = (await blurbRes.json()).resource.id as string;
+
+	// Import a user who is NOT a participant of the season.
+	const outsider = `Out${unique}`;
+	const importRes = await page.request.post(`${API}/import_users_from_csv`, {
+		form: { file: `First Name, Last Name, Email\n${outsider}, B, ${outsider.toLowerCase()}@example.com` }
+	});
+	expect(importRes.ok()).toBeTruthy();
+	const outsiderToken = await tokenFor(page, `${outsider.toLowerCase()}@example.com`);
+
+	// Reacting to the blurb as a non-participant is rejected with 403 (the
+	// custom route's participant gate).
+	const reactRes = await page.request.post(`${API}/blurb/${blurbId}/react`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': outsiderToken },
+		data: { reaction: 'Fire' }
+	});
+	expect(reactRes.status()).toBe(403);
+
+	// Creating a comment as a non-participant is rejected (400) by the model's
+	// DynamicallyValid season-participation check on the generic CRUD create.
+	const commentRes = await page.request.post(`${API}/comment`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': outsiderToken },
+		data: { blurb: blurbId, content: 'intrusion', reply_to: '' }
+	});
+	expect(commentRes.status()).toBe(400);
+
+	// Reacting to a participant's comment as a non-participant is 403.
+	const captainComment = await page.request.post(`${API}/comment`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': captainToken },
+		data: { blurb: blurbId, content: 'hello', reply_to: '' }
+	});
+	expect(captainComment.ok()).toBeTruthy();
+	const commentId = (await captainComment.json()).resource.id as string;
+	const commentReactRes = await page.request.post(`${API}/comment/${commentId}/react`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': outsiderToken },
+		data: { reaction: 'Thumbs up' }
+	});
+	expect(commentReactRes.status()).toBe(403);
+});

--- a/ui/src/lib/blurb.ts
+++ b/ui/src/lib/blurb.ts
@@ -1,0 +1,187 @@
+// Blurb, BlurbPhoto, and BlurbReaction API clients.
+//
+// Blurbs are season-scoped posts (news/announcements) that users can comment
+// on and react to. The read surface is the generic CRUD registered in main.go:
+//
+//	GET    /api/blurb           -> { resource: Blurb[] }
+//	GET    /api/blurb/:id       -> { resource: Blurb }
+//	POST   /api/blurb           -> { resource: Blurb }   (owner = token user)
+//	PUT    /api/blurb/:id       -> { resource: Blurb }
+//	DELETE /api/blurb/:id       -> { resource: Blurb }
+//	GET    /api/blurb_photo     -> { resource: BlurbPhoto[] }
+//	GET    /api/blurb_reaction  -> { resource: BlurbReaction[] }
+//
+// The interactive writes (react/unreact and photo attach/detach) go through
+// the custom routes in route/blurb (see main.go), which enforce
+// season-participation and ownership:
+//
+//	POST   /api/blurb/:id/react      { reaction: "Fire" }
+//	POST   /api/blurb/:id/unreact    { reaction: "Fire" }
+//	POST   /api/blurb/:id/photos     { photo_id }
+//	DELETE /api/blurb/:id/photos/:photoId
+//
+// Reactions are stored as numeric `reaction_type` values (mirroring
+// model.reactionType); the react/unreact routes accept the human-readable
+// reaction name. Record IDs are 16-char hex strings.
+import { authFetch } from '$lib/auth';
+
+// Reaction type enum values mirror model.reactionType (model/reaction.go).
+export const REACTION_THUMBS_UP = 0;
+export const REACTION_THUMBS_DOWN = 1;
+export const REACTION_LAUGHING = 2;
+export const REACTION_FIRE = 3;
+export const REACTION_HEART = 4;
+export const REACTION_CRYING = 5;
+
+export interface ReactionType {
+	value: number;
+	name: string;
+	emoji: string;
+}
+
+// REACTIONS lists the allowed reactions, matching model.AllowedReactions.
+// `name` is the human-readable value sent to the react/unreact routes;
+// `value` is the numeric `reaction_type` stored on child rows.
+export const REACTIONS: ReactionType[] = [
+	{ value: REACTION_THUMBS_UP, name: 'Thumbs up', emoji: '👍' },
+	{ value: REACTION_THUMBS_DOWN, name: 'Thumbs down', emoji: '👎' },
+	{ value: REACTION_LAUGHING, name: 'Laughing', emoji: '😂' },
+	{ value: REACTION_FIRE, name: 'Fire', emoji: '🔥' },
+	{ value: REACTION_HEART, name: 'Heart', emoji: '❤️' },
+	{ value: REACTION_CRYING, name: 'Crying', emoji: '😭' }
+];
+
+export const reactionByValue = (value: number): ReactionType =>
+	REACTIONS.find((r) => r.value === value) ?? { value, name: 'Unknown', emoji: '❔' };
+
+export interface Blurb {
+	id: string;
+	title: string;
+	content: string;
+	owner: string;
+	season: string;
+}
+
+export interface BlurbPhoto {
+	id: string;
+	blurb_id: string;
+	photo_id: string;
+}
+
+export interface BlurbReaction {
+	id: string;
+	blurb_id: string;
+	user_id: string;
+	reaction_type: number;
+}
+
+const BASE = '/api/blurb';
+
+// unwrap parses a CrudCommon response (`{ resource: ... }`) and throws the
+// backend error message on non-2xx responses so callers can surface it.
+async function unwrap(res: Response): Promise<any> {
+	if (!res.ok) {
+		let message = `Request failed (${res.status})`;
+		try {
+			const body = await res.json();
+			if (body?.error) message = body.error;
+		} catch {
+			// non-JSON error body; fall back to the status message
+		}
+		throw new Error(message);
+	}
+	const body = await res.json();
+	return body?.resource;
+}
+
+export async function listBlurbs(): Promise<Blurb[]> {
+	return unwrap(await authFetch(BASE));
+}
+
+export async function getBlurb(id: string): Promise<Blurb> {
+	return unwrap(await authFetch(`${BASE}/${id}`));
+}
+
+export async function createBlurb(input: { title: string; content: string; season: string }): Promise<Blurb> {
+	return unwrap(
+		await authFetch(BASE, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(input)
+		})
+	);
+}
+
+export async function updateBlurb(id: string, input: { title: string; content: string; season: string }): Promise<Blurb> {
+	return unwrap(
+		await authFetch(`${BASE}/${id}`, {
+			method: 'PUT',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(input)
+		})
+	);
+}
+
+export async function deleteBlurb(id: string): Promise<void> {
+	await authFetch(`${BASE}/${id}`, { method: 'DELETE' });
+}
+
+export async function listBlurbPhotos(): Promise<BlurbPhoto[]> {
+	return unwrap(await authFetch('/api/blurb_photo'));
+}
+
+export async function listBlurbReactions(): Promise<BlurbReaction[]> {
+	return unwrap(await authFetch('/api/blurb_reaction'));
+}
+
+// ensureOk throws the backend error message on a non-2xx response. Custom-route
+// writes return a bare status/JSON, so callers need this to surface failures.
+async function ensureOk(res: Response): Promise<void> {
+	if (res.ok) return;
+	let message = `Request failed (${res.status})`;
+	try {
+		const body = await res.json();
+		if (body?.error) message = body.error;
+	} catch {
+		// non-JSON error body; fall back to the status message
+	}
+	throw new Error(message);
+}
+
+// reactToBlurb adds a reaction (by human-readable name) from the current user.
+export async function reactToBlurb(blurbId: string, reaction: string): Promise<void> {
+	await ensureOk(
+		await authFetch(`${BASE}/${blurbId}/react`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ reaction })
+		})
+	);
+}
+
+// unreactToBlurb removes the current user's reaction of the given type.
+export async function unreactToBlurb(blurbId: string, reaction: string): Promise<void> {
+	await ensureOk(
+		await authFetch(`${BASE}/${blurbId}/unreact`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ reaction })
+		})
+	);
+}
+
+// addBlurbPhoto attaches a photo (owned by the current user) to a blurb.
+export async function addBlurbPhoto(blurbId: string, photoId: string): Promise<void> {
+	await ensureOk(
+		await authFetch(`${BASE}/${blurbId}/photos`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ photo_id: photoId })
+		})
+	);
+}
+
+// removeBlurbPhoto detaches a photo from a blurb.
+export async function removeBlurbPhoto(blurbId: string, photoId: string): Promise<void> {
+	await ensureOk(await authFetch(`${BASE}/${blurbId}/photos/${photoId}`, { method: 'DELETE' }));
+}

--- a/ui/src/lib/comment.ts
+++ b/ui/src/lib/comment.ts
@@ -1,0 +1,131 @@
+// Comment and CommentReaction API clients.
+//
+// Comments attach to a blurb and support replies; reactions attach to
+// comments. The read surface is the generic CRUD registered in main.go:
+//
+//	GET    /api/comment          -> { resource: Comment[] }
+//	GET    /api/comment/:id      -> { resource: Comment }
+//	POST   /api/comment          -> { resource: Comment }   (owner = token user)
+//	PUT    /api/comment/:id      -> { resource: Comment }
+//	DELETE /api/comment/:id      -> { resource: Comment }
+//	GET    /api/comment_reaction -> { resource: CommentReaction[] }
+//
+// The interactive writes (react/unreact) go through the custom routes in
+// route/comment (see main.go), which enforce season-participation:
+//
+//	POST /api/comment/:id/react    { reaction: "Fire" }
+//	POST /api/comment/:id/unreact  { reaction: "Fire" }
+//
+// A comment's `reply_to` field holds the id of the comment it replies to
+// (empty for a top-level comment). Record IDs are 16-char hex strings.
+import { authFetch } from '$lib/auth';
+
+export interface Comment {
+	id: string;
+	blurb: string;
+	reply_to: string;
+	user_id: string;
+	content: string;
+	created_at: string;
+	edited_at: string;
+}
+
+export interface CommentReaction {
+	id: string;
+	comment_id: string;
+	user_id: string;
+	reaction_type: number;
+}
+
+const BASE = '/api/comment';
+
+// unwrap parses a CrudCommon response (`{ resource: ... }`) and throws the
+// backend error message on non-2xx responses so callers can surface it.
+async function unwrap(res: Response): Promise<any> {
+	if (!res.ok) {
+		let message = `Request failed (${res.status})`;
+		try {
+			const body = await res.json();
+			if (body?.error) message = body.error;
+		} catch {
+			// non-JSON error body; fall back to the status message
+		}
+		throw new Error(message);
+	}
+	const body = await res.json();
+	return body?.resource;
+}
+
+export async function listComments(): Promise<Comment[]> {
+	return unwrap(await authFetch(BASE));
+}
+
+// createComment posts a comment on a blurb. When `replyTo` is provided the
+// comment is a reply to that comment (both must be on the same blurb).
+export async function createComment(
+	blurbId: string,
+	content: string,
+	replyTo = ''
+): Promise<Comment> {
+	return unwrap(
+		await authFetch(BASE, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ blurb: blurbId, content, reply_to: replyTo })
+		})
+	);
+}
+
+export async function updateComment(id: string, content: string): Promise<Comment> {
+	return unwrap(
+		await authFetch(`${BASE}/${id}`, {
+			method: 'PUT',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ content })
+		})
+	);
+}
+
+export async function deleteComment(id: string): Promise<void> {
+	await authFetch(`${BASE}/${id}`, { method: 'DELETE' });
+}
+
+export async function listCommentReactions(): Promise<CommentReaction[]> {
+	return unwrap(await authFetch('/api/comment_reaction'));
+}
+
+// ensureOk throws the backend error message on a non-2xx response. Custom-route
+// writes return a bare status/JSON, so callers need this to surface failures.
+async function ensureOk(res: Response): Promise<void> {
+	if (res.ok) return;
+	let message = `Request failed (${res.status})`;
+	try {
+		const body = await res.json();
+		if (body?.error) message = body.error;
+	} catch {
+		// non-JSON error body; fall back to the status message
+	}
+	throw new Error(message);
+}
+
+// reactToComment adds a reaction (by human-readable name) from the current user.
+export async function reactToComment(commentId: string, reaction: string): Promise<void> {
+	await ensureOk(
+		await authFetch(`${BASE}/${commentId}/react`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ reaction })
+		})
+	);
+}
+
+// unreactToComment removes the current user's reaction of the given type.
+export async function unreactToComment(commentId: string, reaction: string): Promise<void> {
+	await ensureOk(
+		await authFetch(`${BASE}/${commentId}/unreact`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ reaction })
+		})
+	);
+}

--- a/ui/src/routes/seasons/[id]/+page.svelte
+++ b/ui/src/routes/seasons/[id]/+page.svelte
@@ -726,12 +726,15 @@
 	<h1 class="text-2xl font-semibold tracking-tight">{season?.name ?? 'Season'}</h1>
 	<div class="ml-auto flex items-center gap-3">
 		{#if season}
-			<a
-				href={`/seasons/${season.id}/proposals`}
-				class="text-sm text-muted-foreground hover:text-foreground"
-			>
-				Commissioner proposals
-			</a>
+							<a
+								href={`/seasons/${season.id}/proposals`}
+								class="text-sm text-muted-foreground hover:text-foreground"
+							>
+								Commissioner proposals
+							</a>
+							<a href={`/seasons/${season.id}/blurbs`} class="text-sm text-muted-foreground hover:text-foreground">
+								Blurbs
+							</a>
 			<a href={`/drafts/${season.draft_id}`} class="text-sm text-muted-foreground hover:text-foreground">
 				&larr; View draft
 			</a>

--- a/ui/src/routes/seasons/[id]/blurbs/+page.svelte
+++ b/ui/src/routes/seasons/[id]/blurbs/+page.svelte
@@ -1,0 +1,524 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { page } from '$app/state';
+	import { getSeason } from '$lib/season';
+	import type { Season } from '$lib/season';
+	import { listUsers, fullName } from '$lib/user';
+	import type { User } from '$lib/user';
+	import { getCurrentUserId } from '$lib/auth';
+	import {
+		REACTIONS,
+		reactionByValue,
+		listBlurbs,
+		createBlurb,
+		deleteBlurb,
+		listBlurbPhotos,
+		listBlurbReactions,
+		reactToBlurb,
+		unreactToBlurb,
+		addBlurbPhoto,
+		removeBlurbPhoto
+	} from '$lib/blurb';
+	import type { Blurb } from '$lib/blurb';
+	import {
+		listComments,
+		createComment,
+		deleteComment,
+		listCommentReactions,
+		reactToComment,
+		unreactToComment
+	} from '$lib/comment';
+	import type { Comment } from '$lib/comment';
+	import { listPhotos, createPhoto, dataUrlFor, photoTypeFromExtension } from '$lib/photo';
+	import type { Photo, PhotoType } from '$lib/photo';
+	import { Badge } from '$lib/components/ui/badge/index.js';
+	import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card/index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import { Textarea } from '$lib/components/ui/textarea/index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
+
+	const id = () => page.params.id as string;
+
+	let season = $state<Season | null>(null);
+	let users = $state<User[]>([]);
+	let blurbs = $state<Blurb[]>([]);
+	let comments = $state<Comment[]>([]);
+	let photosById = $state<Record<string, Photo>>({});
+	let blurbPhotosByBlurb = $state<Record<string, Photo[]>>({});
+
+	// create-blurb form state
+	let newTitle = $state('');
+	let newContent = $state('');
+	let newPhotoContents = $state('');
+	let newPhotoFileType = $state<PhotoType>(0);
+	let newPhotoAlt = $state('');
+	let newPhotoReady = $state(false);
+
+	// per-blurb comment form state
+	let commentDrafts = $state<Record<string, string>>({});
+	let replyDrafts = $state<Record<string, string>>({});
+	let replyingTo = $state<Record<string, string>>({});
+
+	let loading = $state(true);
+	let loadError = $state('');
+	let formError = $state('');
+
+	const currentUserId = $derived(getCurrentUserId() ?? '');
+
+	function userName(userId: string): string {
+		const u = users.find((x) => x.id === userId);
+		return u ? fullName(u) : userId;
+	}
+
+	const blurbsForSeason = $derived(blurbs.filter((b) => b.season === id()));
+
+	// photos attached to each blurb
+	function photosFor(blurbId: string): Photo[] {
+		return blurbPhotosByBlurb[blurbId] ?? [];
+	}
+
+	// aggregate reactions per blurb, with counts and whether the current user reacted
+	function reactionSummary(
+		rows: { user_id: string; reaction_type: number }[]
+	): { value: number; name: string; emoji: string; count: number; mine: boolean }[] {
+		const byValue: Record<number, { count: number; mine: boolean }> = {};
+		for (const r of rows) {
+			const e = byValue[r.reaction_type] ?? { count: 0, mine: false };
+			e.count += 1;
+			if (r.user_id === currentUserId) e.mine = true;
+			byValue[r.reaction_type] = e;
+		}
+		return REACTIONS.map((rt) => ({
+			value: rt.value,
+			name: rt.name,
+			emoji: rt.emoji,
+			count: byValue[rt.value]?.count ?? 0,
+			mine: byValue[rt.value]?.mine ?? false
+		})).filter((s) => s.count > 0);
+	}
+
+	const blurbReactionsByBlurb = $derived<Record<string, { user_id: string; reaction_type: number }[]>>({});
+	const commentReactionsByComment = $derived<Record<string, { user_id: string; reaction_type: number }[]>>({});
+
+	function commentsFor(blurbId: string): Comment[] {
+		return comments.filter((c) => c.blurb === blurbId);
+	}
+
+	// top-level comments (no reply_to), oldest first
+	function topLevelComments(blurbId: string): Comment[] {
+		return commentsFor(blurbId)
+			.filter((c) => !c.reply_to || c.reply_to === '')
+			.sort((a, b) => (a.created_at < b.created_at ? -1 : 1));
+	}
+
+	// replies to a comment, oldest first
+	function repliesTo(blurbId: string, commentId: string): Comment[] {
+		return commentsFor(blurbId)
+			.filter((c) => c.reply_to === commentId)
+			.sort((a, b) => (a.created_at < b.created_at ? -1 : 1));
+	}
+
+	async function load() {
+		loading = true;
+		loadError = '';
+		try {
+			const [seasonData, userList, blurbList, commentList, blurbPhotoList, blurbReactionList, commentReactionList, photoList] =
+				await Promise.all([
+					getSeason(id()),
+					listUsers(),
+					listBlurbs(),
+					listComments(),
+					listBlurbPhotos(),
+					listBlurbReactions(),
+					listCommentReactions(),
+					listPhotos()
+				]);
+			season = seasonData;
+			users = userList;
+			blurbs = blurbList;
+			comments = commentList;
+			photosById = Object.fromEntries(photoList.map((p) => [p.id, p]));
+
+			for (const blurb of blurbList) {
+				blurbReactionsByBlurb[blurb.id] = blurbReactionList.filter((r) => r.blurb_id === blurb.id);
+			}
+			for (const comment of commentList) {
+				commentReactionsByComment[comment.id] = commentReactionList.filter((r) => r.comment_id === comment.id);
+			}
+			// map blurb -> attached photos
+			for (const blurb of blurbList) {
+				blurbPhotosByBlurb[blurb.id] = blurbPhotoList
+					.filter((p) => p.blurb_id === blurb.id)
+					.map((p) => photoList.find((ph) => ph.id === p.photo_id))
+					.filter((ph): ph is Photo => Boolean(ph));
+			}
+		} catch (e) {
+			loadError = e instanceof Error ? e.message : 'Failed to load blurbs';
+		} finally {
+			loading = false;
+		}
+	}
+
+	onMount(load);
+
+	function onPhotoFileChange(e: Event) {
+		const input = e.target as HTMLInputElement;
+		const file = input.files?.[0];
+		if (!file) return;
+		const type = photoTypeFromExtension(file.name);
+		if (type === null) {
+			formError = 'Unsupported file type. Use png, jpg, jpeg, gif, or webp.';
+			newPhotoReady = false;
+			return;
+		}
+		newPhotoFileType = type;
+		newPhotoReady = false;
+		formError = '';
+		const reader = new FileReader();
+		reader.onload = () => {
+			newPhotoContents = (reader.result as string).split(',')[1] ?? '';
+			newPhotoReady = true;
+		};
+		reader.readAsDataURL(file);
+	}
+
+	async function handleCreateBlurb(e: Event) {
+		e.preventDefault();
+		formError = '';
+		if (!newTitle.trim() || !newContent.trim()) {
+			formError = 'Title and content are required.';
+			return;
+		}
+		try {
+			const created = await createBlurb({ title: newTitle.trim(), content: newContent.trim(), season: id() });
+			// optionally attach an uploaded photo
+			if (newPhotoContents) {
+				const photo = await createPhoto({ alt_text: newPhotoAlt, contents: newPhotoContents, file_type: newPhotoFileType });
+				await addBlurbPhoto(created.id, photo.id);
+			}
+			newTitle = '';
+			newContent = '';
+			newPhotoContents = '';
+			newPhotoAlt = '';
+			newPhotoReady = false;
+			await load();
+		} catch (err) {
+			formError = err instanceof Error ? err.message : 'Failed to create blurb';
+		}
+	}
+
+	async function handleDeleteBlurb(blurbId: string) {
+		if (!window.confirm('Delete this blurb?')) return;
+		try {
+			await deleteBlurb(blurbId);
+			await load();
+		} catch (err) {
+			formError = err instanceof Error ? err.message : 'Failed to delete blurb';
+		}
+	}
+
+	async function toggleBlurbReaction(blurbId: string, name: string, mine: boolean) {
+		try {
+			if (mine) {
+				await unreactToBlurb(blurbId, name);
+			} else {
+				await reactToBlurb(blurbId, name);
+			}
+			await load();
+		} catch (err) {
+			formError = err instanceof Error ? err.message : 'Failed to update reaction';
+		}
+	}
+
+	async function handleAddComment(blurbId: string) {
+		const content = (commentDrafts[blurbId] ?? '').trim();
+		if (!content) return;
+		try {
+			await createComment(blurbId, content);
+			commentDrafts[blurbId] = '';
+			await load();
+		} catch (err) {
+			formError = err instanceof Error ? err.message : 'Failed to add comment';
+		}
+	}
+
+	function startReply(commentId: string) {
+		replyingTo[commentId] = replyingTo[commentId] ? '' : commentId;
+		formError = '';
+	}
+
+	async function handleReply(commentId: string) {
+		const content = (replyDrafts[commentId] ?? '').trim();
+		if (!content) return;
+		const parent = comments.find((c) => c.id === commentId);
+		if (!parent) return;
+		try {
+			await createComment(parent.blurb, content, parent.id);
+			replyDrafts[commentId] = '';
+			replyingTo[commentId] = '';
+			await load();
+		} catch (err) {
+			formError = err instanceof Error ? err.message : 'Failed to reply';
+		}
+	}
+
+	async function handleDeleteComment(commentId: string) {
+		if (!window.confirm('Delete this comment?')) return;
+		try {
+			await deleteComment(commentId);
+			await load();
+		} catch (err) {
+			formError = err instanceof Error ? err.message : 'Failed to delete comment';
+		}
+	}
+
+	async function toggleCommentReaction(commentId: string, name: string, mine: boolean) {
+		try {
+			if (mine) {
+				await unreactToComment(commentId, name);
+			} else {
+				await reactToComment(commentId, name);
+			}
+			await load();
+		} catch (err) {
+			formError = err instanceof Error ? err.message : 'Failed to update reaction';
+		}
+	}
+
+	async function handleRemovePhoto(blurbId: string, photoId: string) {
+		try {
+			await removeBlurbPhoto(blurbId, photoId);
+			await load();
+		} catch (err) {
+			formError = err instanceof Error ? err.message : 'Failed to remove photo';
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>Intraclub | {season ? season.name : 'Season'} — Blurbs</title>
+</svelte:head>
+
+<div class="flex items-center gap-4">
+	<h1 class="text-2xl font-semibold tracking-tight">{season?.name ?? 'Season'} — Blurbs</h1>
+	<div class="ml-auto">
+		<a href={`/seasons/${id()}`} class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to season</a>
+	</div>
+</div>
+
+{#if loading}
+	<p class="mt-4 text-muted-foreground">Loading...</p>
+{:else if loadError}
+	<p class="mt-4 text-sm font-medium text-destructive">{loadError}</p>
+{:else}
+	{#if formError}
+		<p class="mt-4 text-sm font-medium text-destructive">{formError}</p>
+	{/if}
+
+	<!-- Create blurb -->
+	<Card class="mt-6">
+		<CardHeader>
+			<CardTitle class="text-base">Post a blurb</CardTitle>
+		</CardHeader>
+		<CardContent>
+			<form onsubmit={handleCreateBlurb} class="flex flex-col gap-4">
+				<div class="flex flex-col gap-2">
+					<Label for="title">Title</Label>
+					<Input id="title" type="text" bind:value={newTitle} placeholder="e.g. Season kickoff" />
+				</div>
+				<div class="flex flex-col gap-2">
+					<Label for="content">Content</Label>
+					<Textarea id="content" bind:value={newContent} placeholder="What's happening?" />
+				</div>
+				<div class="flex flex-col gap-2">
+					<Label for="photo">Attach a photo (optional)</Label>
+					<Input id="photo" type="file" accept="image/*" onchange={onPhotoFileChange} />
+					{#if newPhotoReady}
+						<p class="text-sm text-muted-foreground">Photo ready to attach</p>
+					{/if}
+				</div>
+				<Button type="submit" class="w-fit">Post blurb</Button>
+			</form>
+		</CardContent>
+	</Card>
+
+	{#if blurbsForSeason.length === 0}
+		<p class="mt-6 text-muted-foreground">No blurbs yet for this season.</p>
+	{/if}
+
+	<!-- Feed -->
+	<div class="mt-6 flex flex-col gap-6">
+		{#each blurbsForSeason as blurb (blurb.id)}
+			<Card>
+				<CardHeader>
+					<div class="flex items-center gap-3">
+						<CardTitle class="text-base">{blurb.title}</CardTitle>
+						<div class="ml-auto flex items-center gap-2">
+							<Badge variant="secondary">{userName(blurb.owner)}</Badge>
+							{#if blurb.owner === currentUserId}
+								<Button size="sm" variant="ghost" onclick={() => handleDeleteBlurb(blurb.id)}>Delete</Button>
+							{/if}
+						</div>
+					</div>
+				</CardHeader>
+				<CardContent class="flex flex-col gap-4">
+					<p class="text-sm whitespace-pre-wrap">{blurb.content}</p>
+
+					{#if photosFor(blurb.id).length > 0}
+						<div class="flex flex-wrap gap-3">
+							{#each photosFor(blurb.id) as photo}
+								<div class="relative">
+									<img
+										src={dataUrlFor(photo)}
+										alt={photo.alt_text || blurb.title}
+										class="h-32 w-48 rounded-md border border-border object-cover"
+									/>
+									{#if blurb.owner === currentUserId}
+										<button
+											class="absolute right-1 top-1 rounded-full bg-background/80 px-1.5 text-xs text-muted-foreground hover:text-destructive"
+											onclick={() => handleRemovePhoto(blurb.id, photo.id)}
+											aria-label="Remove photo"
+										>
+											✕
+										</button>
+									{/if}
+								</div>
+							{/each}
+						</div>
+					{/if}
+
+					<!-- Reactions -->
+					{#if reactionSummary(blurbReactionsByBlurb[blurb.id] ?? []).length > 0}
+						<div class="flex flex-wrap gap-2">
+							{#each reactionSummary(blurbReactionsByBlurb[blurb.id] ?? []) as r}
+								<Button
+									size="sm"
+									variant={r.mine ? 'default' : 'secondary'}
+									onclick={() => toggleBlurbReaction(blurb.id, r.name, r.mine)}
+								>
+									{r.emoji} {r.count}
+								</Button>
+							{/each}
+						</div>
+					{/if}
+					<div class="flex flex-wrap gap-2">
+						{#each REACTIONS as rt}
+							<Button
+								size="sm"
+								variant="ghost"
+								title={rt.name}
+								onclick={() => toggleBlurbReaction(blurb.id, rt.name, false)}
+							>
+								{rt.emoji}
+							</Button>
+						{/each}
+					</div>
+
+					<!-- Comments -->
+					<div class="mt-2 flex flex-col gap-3">
+						{#each topLevelComments(blurb.id) as comment}
+							<div class="rounded-lg border border-border p-3">
+								<div class="flex items-center gap-2">
+									<span class="text-sm font-medium">{userName(comment.user_id)}</span>
+									<span class="text-xs text-muted-foreground">{new Date(comment.created_at).toLocaleString()}</span>
+									<div class="ml-auto flex items-center gap-2">
+										{#if reactionSummary(commentReactionsByComment[comment.id] ?? []).length > 0}
+											{#each reactionSummary(commentReactionsByComment[comment.id] ?? []) as r}
+												<Button
+													size="sm"
+													variant={r.mine ? 'default' : 'secondary'}
+													onclick={() => toggleCommentReaction(comment.id, r.name, r.mine)}
+												>
+													{r.emoji} {r.count}
+												</Button>
+											{/each}
+										{/if}
+										<Button size="sm" variant="ghost" onclick={() => startReply(comment.id)}>Reply</Button>
+										{#if comment.user_id === currentUserId}
+											<Button size="sm" variant="ghost" onclick={() => handleDeleteComment(comment.id)}>Delete</Button>
+										{/if}
+									</div>
+								</div>
+								<p class="mt-1 text-sm whitespace-pre-wrap">{comment.content}</p>
+
+								<div class="mt-1 flex flex-wrap items-center gap-1">
+									{#each REACTIONS as rt}
+										<Button
+											size="sm"
+											variant="ghost"
+											title={rt.name}
+											onclick={() => toggleCommentReaction(comment.id, rt.name, false)}
+										>
+											{rt.emoji}
+										</Button>
+									{/each}
+								</div>
+
+								{#if replyingTo[comment.id]}
+									<div class="mt-2 flex gap-2">
+										<Input
+											placeholder="Write a reply..."
+											bind:value={replyDrafts[comment.id]}
+											onkeydown={(e) => e.key === 'Enter' && handleReply(comment.id)}
+										/>
+										<Button size="sm" onclick={() => handleReply(comment.id)}>Reply</Button>
+									</div>
+								{/if}
+
+								{#if repliesTo(blurb.id, comment.id).length > 0}
+									<div class="mt-2 flex flex-col gap-2 border-l-2 border-border pl-3">
+										{#each repliesTo(blurb.id, comment.id) as reply}
+											<div class="flex items-start justify-between gap-2">
+												<div>
+													<span class="text-sm font-medium">{userName(reply.user_id)}</span>
+													<span class="text-xs text-muted-foreground"> · {new Date(reply.created_at).toLocaleString()}</span>
+													<p class="text-sm whitespace-pre-wrap">{reply.content}</p>
+													<div class="mt-1 flex flex-wrap items-center gap-1">
+														{#each REACTIONS as rt}
+															<Button
+																size="sm"
+																variant="ghost"
+																title={rt.name}
+																onclick={() => toggleCommentReaction(reply.id, rt.name, false)}
+															>
+																{rt.emoji}
+															</Button>
+														{/each}
+													</div>
+												</div>
+												<div class="flex items-center gap-1">
+													{#each reactionSummary(commentReactionsByComment[reply.id] ?? []) as r}
+														<Button
+															size="sm"
+															variant={r.mine ? 'default' : 'secondary'}
+															onclick={() => toggleCommentReaction(reply.id, r.name, r.mine)}
+														>
+															{r.emoji} {r.count}
+														</Button>
+													{/each}
+													{#if reply.user_id === currentUserId}
+														<Button size="sm" variant="ghost" onclick={() => handleDeleteComment(reply.id)}>Delete</Button>
+													{/if}
+												</div>
+											</div>
+										{/each}
+									</div>
+								{/if}
+							</div>
+						{/each}
+
+						<div class="flex gap-2">
+							<Input
+								placeholder="Add a comment..."
+								bind:value={commentDrafts[blurb.id]}
+								onkeydown={(e) => e.key === 'Enter' && handleAddComment(blurb.id)}
+							/>
+							<Button size="sm" onclick={() => handleAddComment(blurb.id)}>Comment</Button>
+						</div>
+					</div>
+				</CardContent>
+			</Card>
+		{/each}
+	</div>
+{/if}

--- a/ui/src/routes/seasons/[id]/blurbs/+page.svelte
+++ b/ui/src/routes/seasons/[id]/blurbs/+page.svelte
@@ -98,8 +98,19 @@
 		})).filter((s) => s.count > 0);
 	}
 
-	const blurbReactionsByBlurb = $derived<Record<string, { user_id: string; reaction_type: number }[]>>({});
-	const commentReactionsByComment = $derived<Record<string, { user_id: string; reaction_type: number }[]>>({});
+	// reaction rows per blurb / comment, populated by load(); $state so the
+	// mutations in load() are reactive (a $derived value must not be mutated)
+	let blurbReactionsByBlurb = $state<Record<string, { user_id: string; reaction_type: number }[]>>({});
+	let commentReactionsByComment = $state<Record<string, { user_id: string; reaction_type: number }[]>>({});
+
+	// whether the current user already reacted with the given named reaction
+	function blurbReactionMine(blurbId: string, name: string): boolean {
+		return reactionSummary(blurbReactionsByBlurb[blurbId] ?? []).find((s) => s.name === name)?.mine ?? false;
+	}
+
+	function commentReactionMine(commentId: string, name: string): boolean {
+		return reactionSummary(commentReactionsByComment[commentId] ?? []).find((s) => s.name === name)?.mine ?? false;
+	}
 
 	function commentsFor(blurbId: string): Comment[] {
 		return comments.filter((c) => c.blurb === blurbId);
@@ -408,7 +419,7 @@
 								size="sm"
 								variant="ghost"
 								title={rt.name}
-								onclick={() => toggleBlurbReaction(blurb.id, rt.name, false)}
+								onclick={() => toggleBlurbReaction(blurb.id, rt.name, blurbReactionMine(blurb.id, rt.name))}
 							>
 								{rt.emoji}
 							</Button>
@@ -448,7 +459,7 @@
 											size="sm"
 											variant="ghost"
 											title={rt.name}
-											onclick={() => toggleCommentReaction(comment.id, rt.name, false)}
+											onclick={() => toggleCommentReaction(comment.id, rt.name, commentReactionMine(comment.id, rt.name))}
 										>
 											{rt.emoji}
 										</Button>
@@ -480,7 +491,7 @@
 																size="sm"
 																variant="ghost"
 																title={rt.name}
-																onclick={() => toggleCommentReaction(reply.id, rt.name, false)}
+																onclick={() => toggleCommentReaction(reply.id, rt.name, commentReactionMine(reply.id, rt.name))}
 															>
 																{rt.emoji}
 															</Button>


### PR DESCRIPTION
… #165)

Implements the blurbs feed for a season with comments, reactions, and photo attachments. Covers both tickets, which form one coherent feature (the blurbs feed surfaces comments from #164 on the blurbs posted in #165):

- **#164 — API + UI: Comments & reactions on blurbs**
- **#165 — API + UI: Blurbs, photos & reactions**

### API (Go/Gin)
- Register full CRUD for `blurb`, `comment`, `blurb_photo`, `blurb_reaction`, and `comment_reaction` in `main.go`.
- New custom route packages:
  - `route/blurb`: `React` / `Unreact` (season-participant gated, deduped), `AddPhoto` / `RemovePhoto` (owner-gated).
  - `route/comment`: `React` / `Unreact` (season-participant gated, deduped).

### UI (SvelteKit)
- `ui/src/routes/seasons/[id]/blurbs/+page.svelte`: season blurbs feed — create a blurb with an attached photo, react to blurbs/comments/replies, post comments and replies, delete comments/blurbs (owner-gated).
- New API clients `ui/src/lib/blurb.ts` and `ui/src/lib/comment.ts`.
- Added a "Blurbs" link on the season detail page.

### e2e
- `ui/e2e/blurbs.spec.ts`: full feed flow (create blurb + photo, react, comment, reply, delete) plus a non-participant authorization test.

### Bug fixes uncovered along the way
- **`*Id` JSON unmarshal never wrote back to the receiver** — `PhotoId`, `BlurbId`, and `CommentId.UnmarshalJSON` decoded into a local copy and discarded the result, so incoming IDs (e.g. `photo_id`, `blurb`, `reply_to`) silently became `0`. Fixed to match the correct `SeasonId`/`UserId` pattern.
- **`Blurb` struct fields lacked JSON tags**, so the API serialized them as `Title`/`Content`/`Owner`/`Season` instead of the expected lowercase keys, breaking the UI client.
- **`Comment.StaticallyValid` rejected every new comment** — the generic CRUD route wrapper pre-validates the request body before `CreateOne` assigns the ID/timestamps, so the `ReplyTo == ID` self-reference check fired on a fresh comment (both zero). Gated the self-reference and created-timestamp checks on the comment having a persisted ID.
- **`database.RecordIdFromString` could panic** on an over-long even-length hex string by writing past a fixed 8-byte buffer; now length-validates input.

## Verification
- `make tests` (go test ./... && go vet ./...) — green
- `make e2e` — 40/40 passed
- `cd ui && npm run check` — 0 errors, 0 warnings

Closes #164
Closes #165