### PR TITLE
API: add --slow-mode flag to inject artificial latency

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,24 @@ make standard
 The `--dev-token` flag enables development token mode (loopback-only, bypasses
 auth gating) and seeds sample data. The API listens on `http://127.0.0.1:8080`.
 
+### Simulating a slow connection
+
+Local testing on `127.0.0.1` makes every database call appear instantaneous.
+`--slow-mode` injects artificial latency into every API request to simulate a
+slow / high-RTT (edge-to-cloud) connection, which is useful for surfacing UX
+issues (missing skeletons/loading spinners), finding query chains that should
+be composite endpoints, and shaking out timing assumptions in the e2e suite:
+
+```sh
+./main --dev-token --slow-mode                       # +500ms per request (default)
+./main --dev-token --slow-mode --slow-mode-latency 2s
+INTRACLUB_SLOW_MODE=1 INTRACLUB_SLOW_MODE_LATENCY=1s ./main --dev-token
+```
+
+The `--slow-mode` flag / `INTRACLUB_SLOW_MODE` env var enable the delay, and
+`--slow-mode-latency` / `INTRACLUB_SLOW_MODE_LATENCY` set the per-request delay
+(default 500ms). Flags take precedence over environment variables.
+
 ### Database: SQLite (default)
 
 The server defaults to the **SQLite** provider, which stores everything in a

--- a/README.md
+++ b/README.md
@@ -87,6 +87,22 @@ make standard
 The `--dev-token` flag enables development token mode (loopback-only, bypasses
 auth gating) and seeds sample data. The API listens on `http://127.0.0.1:8080`.
 
+### Command-line flags
+
+All server options are configurable via command-line flags; where noted, a flag
+falls back to an environment variable when it is not passed. Flags take
+precedence over environment variables.
+
+| Flag | Default | Env var | Description |
+| --- | --- | --- | --- |
+| `--addr` | `127.0.0.1:8080` | — | Address to listen on, e.g. `127.0.0.1:8080` |
+| `--dev-token` | `false` | — | Development token mode: loopback-only, bypasses auth gating, seeds sample data |
+| `--db` | `sqlite` | — | Database provider: `memory` or `sqlite` |
+| `--db-path` | *(empty)* | `INTRACLUB_DB_PATH` | Path to the SQLite database file |
+| `--jwt-lifetime` | `2h` | `INTRACLUB_JWT_LIFETIME` | JWT token lifetime (e.g. `2h`, `90m`, `5s`) |
+| `--slow-mode` | `false` | `INTRACLUB_SLOW_MODE` | Inject artificial latency into every API request to simulate a slow / high-RTT connection |
+| `--slow-mode-latency` | `500ms` | `INTRACLUB_SLOW_MODE_LATENCY` | Per-request artificial latency to inject when slow mode is enabled |
+
 ### Simulating a slow connection
 
 Local testing on `127.0.0.1` makes every database call appear instantaneous.

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net"
 	"os"
+	"strconv"
 	"time"
 
 	"intraclub/api"
@@ -59,6 +60,15 @@ func main() {
 	}
 
 	r := gin.Default()
+
+	// slow mode injects artificial latency into every request to simulate a
+	// slow / high-RTT connection between the client and the API (see
+	// resolveSlowMode / resolveSlowModeLatency for flag + env configuration).
+	if cfg.slowMode {
+		log.Printf("slow mode enabled: injecting %s of artificial latency into every API request", cfg.slowModeLatency)
+		r.Use(slowModeMiddleware(cfg.slowModeLatency))
+	}
+
 	rg := r.Group("/api")
 
 	// noAuth for self-register and verify-email
@@ -283,9 +293,11 @@ func main() {
 // serverConfig holds the settings parsed from command-line flags and
 // environment variables that configure the running server.
 type serverConfig struct {
-	addr   string
-	dbKind database.ProviderKind
-	dbPath string
+	addr            string
+	dbKind          database.ProviderKind
+	dbPath          string
+	slowMode        bool
+	slowModeLatency time.Duration
 }
 
 // providerConfig converts the server's parsed database settings into the
@@ -304,6 +316,8 @@ func parseFlags() serverConfig {
 	defaultDBKind := database.ProviderSqlite
 	dbKind := flag.String("db", string(defaultDBKind), "Database provider (memory | sqlite)")
 	dbPath := flag.String("db-path", "", "Path to the SQLite database file; falls back to INTRACLUB_DB_PATH env")
+	slowMode := flag.Bool("slow-mode", false, "Inject artificial latency into every API request to simulate a slow / high-RTT connection; falls back to INTRACLUB_SLOW_MODE env")
+	slowModeLatency := flag.Duration("slow-mode-latency", defaultSlowModeLatency, "Per-request artificial latency to inject when slow mode is enabled; falls back to INTRACLUB_SLOW_MODE_LATENCY env")
 	flag.Parse()
 
 	jwtLifetime, err := resolveJwtLifetime(*jwtLifetimeFlag)
@@ -311,6 +325,15 @@ func parseFlags() serverConfig {
 		log.Fatalf("invalid JWT lifetime: %v", err)
 	}
 	api.JwtLifetime = jwtLifetime
+
+	slowModeEnabled, err := resolveSlowMode(flagWasSet("slow-mode"), *slowMode)
+	if err != nil {
+		log.Fatalf("invalid slow mode setting: %v", err)
+	}
+	latency, err := resolveSlowModeLatency(flagWasSet("slow-mode-latency"), *slowModeLatency)
+	if err != nil {
+		log.Fatalf("invalid slow mode latency: %v", err)
+	}
 
 	if useDevTokenMode != nil && *useDevTokenMode == true {
 		model.UseDevTokenMode = true
@@ -323,9 +346,11 @@ func parseFlags() serverConfig {
 
 	// resolve the database path from the flag or the environment variable
 	return serverConfig{
-		addr:   *addr,
-		dbKind: database.ProviderKind(*dbKind),
-		dbPath: resolveDBPath(*dbPath),
+		addr:            *addr,
+		dbKind:          database.ProviderKind(*dbKind),
+		dbPath:          resolveDBPath(*dbPath),
+		slowMode:        slowModeEnabled,
+		slowModeLatency: latency,
 	}
 }
 
@@ -357,6 +382,75 @@ func resolveJwtLifetime(flagVal string) (time.Duration, error) {
 		return 0, fmt.Errorf("JWT lifetime must be positive, got %q", raw)
 	}
 	return d, nil
+}
+
+// defaultSlowModeLatency is the per-request artificial latency injected when
+// slow mode is enabled and no latency is configured via flag or env var.
+const defaultSlowModeLatency = 500 * time.Millisecond
+
+// flagWasSet reports whether the named flag was explicitly provided on the
+// command line (as opposed to being left at its default value). It must be
+// called after flag.Parse.
+func flagWasSet(name string) bool {
+	set := false
+	flag.Visit(func(f *flag.Flag) {
+		if f.Name == name {
+			set = true
+		}
+	})
+	return set
+}
+
+// resolveSlowMode returns whether artificial latency should be injected into
+// API requests, preferring the explicit --slow-mode flag and falling back to
+// the INTRACLUB_SLOW_MODE env var, then the default (disabled).
+func resolveSlowMode(flagSet, flagVal bool) (bool, error) {
+	if flagSet {
+		return flagVal, nil
+	}
+	raw := os.Getenv("INTRACLUB_SLOW_MODE")
+	if raw == "" {
+		return false, nil
+	}
+	v, err := strconv.ParseBool(raw)
+	if err != nil {
+		return false, fmt.Errorf("invalid INTRACLUB_SLOW_MODE %q: %w", raw, err)
+	}
+	return v, nil
+}
+
+// resolveSlowModeLatency returns the per-request artificial latency, preferring
+// the explicit --slow-mode-latency flag and falling back to the
+// INTRACLUB_SLOW_MODE_LATENCY env var, then the default.
+func resolveSlowModeLatency(flagSet bool, flagVal time.Duration) (time.Duration, error) {
+	if flagSet {
+		return flagVal, nil
+	}
+	raw := os.Getenv("INTRACLUB_SLOW_MODE_LATENCY")
+	if raw == "" {
+		return defaultSlowModeLatency, nil
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return 0, fmt.Errorf("invalid INTRACLUB_SLOW_MODE_LATENCY %q: %w", raw, err)
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("slow mode latency must be positive, got %q", raw)
+	}
+	return d, nil
+}
+
+// slowModeMiddleware injects artificial latency into every request to simulate
+// a slow / high-RTT connection between the client and the API. It sleeps before
+// the handler chain runs, so the added delay is reflected in each request's
+// total latency.
+func slowModeMiddleware(delay time.Duration) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if delay > 0 {
+			time.Sleep(delay)
+		}
+		c.Next()
+	}
 }
 
 // isLoopbackAddress reports whether addr's host is a loopback interface

--- a/main_test.go
+++ b/main_test.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"net/http/httptest"
 	"os"
 	"testing"
 	"time"
 
 	"intraclub/api"
+
+	"github.com/gin-gonic/gin"
 )
 
 func TestResolveDBPath(t *testing.T) {
@@ -121,5 +124,134 @@ func TestResolveJwtLifetimeRejectsNonPositive(t *testing.T) {
 				t.Fatalf("expected an error for lifetime %q", raw)
 			}
 		})
+	}
+}
+
+func TestResolveSlowMode(t *testing.T) {
+	t.Run("flag true wins over env", func(t *testing.T) {
+		t.Setenv("INTRACLUB_SLOW_MODE", "false")
+		got, err := resolveSlowMode(true, true)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !got {
+			t.Fatal("resolveSlowMode = false, want true")
+		}
+	})
+
+	t.Run("flag false wins over env", func(t *testing.T) {
+		t.Setenv("INTRACLUB_SLOW_MODE", "true")
+		got, err := resolveSlowMode(true, false)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got {
+			t.Fatal("resolveSlowMode = true, want false")
+		}
+	})
+
+	t.Run("falls back to env when flag unset", func(t *testing.T) {
+		t.Setenv("INTRACLUB_SLOW_MODE", "true")
+		got, err := resolveSlowMode(false, false)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !got {
+			t.Fatal("resolveSlowMode = false, want true")
+		}
+	})
+
+	t.Run("disabled when neither set", func(t *testing.T) {
+		t.Setenv("INTRACLUB_SLOW_MODE", "")
+		got, err := resolveSlowMode(false, false)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got {
+			t.Fatal("resolveSlowMode = true, want false")
+		}
+	})
+
+	t.Run("invalid env", func(t *testing.T) {
+		t.Setenv("INTRACLUB_SLOW_MODE", "not-a-bool")
+		if _, err := resolveSlowMode(false, false); err == nil {
+			t.Fatal("expected an error for an invalid INTRACLUB_SLOW_MODE")
+		}
+	})
+}
+
+func TestResolveSlowModeLatency(t *testing.T) {
+	t.Run("flag wins over env", func(t *testing.T) {
+		t.Setenv("INTRACLUB_SLOW_MODE_LATENCY", "2s")
+		got, err := resolveSlowModeLatency(true, 10*time.Millisecond)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != 10*time.Millisecond {
+			t.Fatalf("resolveSlowModeLatency = %v, want 10ms", got)
+		}
+	})
+
+	t.Run("falls back to env when flag unset", func(t *testing.T) {
+		t.Setenv("INTRACLUB_SLOW_MODE_LATENCY", "250ms")
+		got, err := resolveSlowModeLatency(false, 0)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != 250*time.Millisecond {
+			t.Fatalf("resolveSlowModeLatency = %v, want 250ms", got)
+		}
+	})
+
+	t.Run("default when neither set", func(t *testing.T) {
+		t.Setenv("INTRACLUB_SLOW_MODE_LATENCY", "")
+		got, err := resolveSlowModeLatency(false, 0)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != defaultSlowModeLatency {
+			t.Fatalf("resolveSlowModeLatency = %v, want default %v", got, defaultSlowModeLatency)
+		}
+	})
+
+	t.Run("invalid env", func(t *testing.T) {
+		t.Setenv("INTRACLUB_SLOW_MODE_LATENCY", "not-a-duration")
+		if _, err := resolveSlowModeLatency(false, 0); err == nil {
+			t.Fatal("expected an error for an invalid INTRACLUB_SLOW_MODE_LATENCY")
+		}
+	})
+
+	t.Run("rejects non-positive", func(t *testing.T) {
+		for _, raw := range []string{"0s", "-5s"} {
+			t.Run(raw, func(t *testing.T) {
+				t.Setenv("INTRACLUB_SLOW_MODE_LATENCY", raw)
+				if _, err := resolveSlowModeLatency(false, 0); err == nil {
+					t.Fatalf("expected an error for latency %q", raw)
+				}
+			})
+		}
+	})
+}
+
+func TestSlowModeMiddleware(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	delay := 75 * time.Millisecond
+	r := gin.New()
+	r.Use(slowModeMiddleware(delay))
+	r.GET("/ping", func(c *gin.Context) {
+		c.Status(200)
+	})
+
+	start := time.Now()
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("GET", "/ping", nil))
+	elapsed := time.Since(start)
+
+	if w.Code != 200 {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if elapsed < delay {
+		t.Fatalf("request completed in %v, want at least the %v injected latency", elapsed, delay)
 	}
 }


### PR DESCRIPTION
## Summary

Adds a `--slow-mode` flag (and `INTRACLUB_SLOW_MODE` env var) that injects artificial latency into every API request, simulating a slow / high-RTT edge-to-cloud connection. Useful for surfacing UX issues (missing skeletons/loading spinners), identifying query chains that should be composite endpoints, and shaking out timing assumptions in the e2e suite.

## Changes

- `main.go`: new `--slow-mode` (bool) and `--slow-mode-latency` (duration, default 500ms) flags, each falling back to an env var (`INTRACLUB_SLOW_MODE` / `INTRACLUB_SLOW_MODE_LATENCY`), matching the existing flag/env pattern (`--db-path`, `--jwt-lifetime`). A Gin middleware sleeps before the handler chain when enabled; a startup log line announces the injected latency.
- `main_test.go`: tests for flag/env resolution (flag precedence, env fallback, invalid values, non-positive latency) and a middleware test verifying a request takes at least the configured delay.
- `README.md`: documents slow mode with usage examples.

## Verification

- `go build ./...`, `go vet ./...`, `go test ./...` all pass.
- Smoke-tested the built binary: `./main --dev-token --slow-mode --slow-mode-latency 1s` makes `GET /api/users` take ~1.0s vs ~13ms without the flag.

Closes #185