### PR TITLE
UI: court-green brand theme + semantic color tokens (Closes #189)

### DIFF
--- a/ui/src/lib/components/NavBar.svelte
+++ b/ui/src/lib/components/NavBar.svelte
@@ -26,7 +26,7 @@
 	// Shared look for every nav item (Settings trigger + top-level links): same
 	// height, size and weight so nothing reads smaller or lighter than the rest.
 	const navItemClass =
-		'flex h-9 items-center rounded-md px-3 text-base font-semibold text-primary-foreground transition-colors hover:bg-foreground/10';
+		'flex h-9 items-center rounded-md px-3 text-base font-medium text-primary-foreground transition-colors hover:bg-foreground/10';
 	const navItemActiveClass = 'bg-foreground/15';
 
 	function isActive(href: string) {
@@ -98,14 +98,14 @@
 			{#if loggedIn}
 				<Button
 					variant="ghost"
-					class="h-9 rounded-md px-3 text-base font-semibold hover:bg-foreground/15 hover:text-primary-foreground"
+					class="h-9 rounded-md px-3 text-base font-medium hover:bg-foreground/15 hover:text-primary-foreground"
 					onclick={logout}
 					>Log out</Button
 				>
 			{:else}
 				<a
 					href="/login"
-					class="flex h-9 items-center rounded-md px-3 text-base font-semibold text-primary-foreground transition-colors hover:bg-foreground/10"
+					class="flex h-9 items-center rounded-md px-3 text-base font-medium text-primary-foreground transition-colors hover:bg-foreground/10"
 					>Log in</a
 				>
 			{/if}

--- a/ui/src/lib/components/NavBar.svelte
+++ b/ui/src/lib/components/NavBar.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 	import { isLoggedIn, clearToken } from '$lib/auth';
 	import { goto } from '$app/navigation';
-	import { Button, buttonVariants } from '$lib/components/ui/button/index.js';
+	import { page } from '$app/state';
+	import { Button } from '$lib/components/ui/button/index.js';
 	import {
 		Popover,
 		PopoverContent,
@@ -22,6 +23,19 @@
 		{ href: '/playoff-structures', label: 'Playoff Structures' }
 	];
 
+	// Shared look for every nav item (Settings trigger + top-level links): same
+	// height, size and weight so nothing reads smaller or lighter than the rest.
+	const navItemClass =
+		'flex h-9 items-center rounded-md px-3 text-base font-bold text-primary-foreground transition-colors hover:bg-foreground/10';
+	const navItemActiveClass = 'bg-foreground/15';
+
+	function isActive(href: string) {
+		const p = page.url.pathname;
+		return p === href || p.startsWith(href + '/');
+	}
+
+	const settingsActive = $derived(settingsLinks.some((link) => isActive(link.href)));
+
 	function logout() {
 		clearToken();
 		loggedIn = false;
@@ -29,35 +43,71 @@
 	}
 </script>
 
-<header class="sticky top-0 z-40 w-full border-b bg-background">
+<header
+	class="sticky top-0 z-40 w-full border-b border-primary-foreground/20 bg-primary text-primary-foreground"
+>
 	<div class="mx-auto flex h-14 max-w-6xl items-center gap-6 px-6">
 		<a href="/" class="flex items-center gap-2 text-base font-semibold tracking-tight">
 			<img src={logo} alt="" class="size-6" />
 			IntraClub
 		</a>
-		<nav class="flex items-center gap-1 text-sm">
+		<nav class="flex items-center gap-1">
 			<Popover>
-				<PopoverTrigger class={buttonVariants({ variant: 'ghost', size: 'sm' })}>Settings</PopoverTrigger>
+				<PopoverTrigger
+					class={`${navItemClass} ${settingsActive ? navItemActiveClass : ''} aria-expanded:bg-foreground/15 aria-expanded:text-primary-foreground`}
+					aria-current={settingsActive ? 'true' : undefined}
+					>Settings</PopoverTrigger
+				>
 				<PopoverContent class="flex flex-col gap-0.5 p-1.5" align="start">
 					{#each settingsLinks as link}
 						<a
 							href={link.href}
-							class="rounded-md px-2.5 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+							class="rounded-md px-2.5 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground {isActive(link.href) ? 'bg-muted font-semibold text-foreground' : ''}"
+							aria-current={isActive(link.href) ? 'page' : undefined}
 							>{link.label}</a
 						>
 					{/each}
 				</PopoverContent>
 			</Popover>
-			<a href="/drafts" class="rounded-md px-2 py-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground">Drafts</a>
-			<a href="/teams" class="rounded-md px-2 py-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground">Teams</a>
-			<a href="/photos" class="rounded-md px-2 py-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground">Photos</a>
-			<a href="/users" class="rounded-md px-2 py-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground">Users</a>
+			<a
+				href="/drafts"
+				class={`${navItemClass} ${isActive('/drafts') ? navItemActiveClass : ''}`}
+				aria-current={isActive('/drafts') ? 'page' : undefined}
+				>Drafts</a
+			>
+			<a
+				href="/teams"
+				class={`${navItemClass} ${isActive('/teams') ? navItemActiveClass : ''}`}
+				aria-current={isActive('/teams') ? 'page' : undefined}
+				>Teams</a
+			>
+			<a
+				href="/photos"
+				class={`${navItemClass} ${isActive('/photos') ? navItemActiveClass : ''}`}
+				aria-current={isActive('/photos') ? 'page' : undefined}
+				>Photos</a
+			>
+			<a
+				href="/users"
+				class={`${navItemClass} ${isActive('/users') ? navItemActiveClass : ''}`}
+				aria-current={isActive('/users') ? 'page' : undefined}
+				>Users</a
+			>
 		</nav>
 		<div class="ml-auto flex items-center">
 			{#if loggedIn}
-				<Button variant="ghost" onclick={logout}>Log out</Button>
+				<Button
+					variant="ghost"
+					class="h-9 rounded-md px-3 text-base font-bold hover:bg-foreground/15 hover:text-primary-foreground"
+					onclick={logout}
+					>Log out</Button
+				>
 			{:else}
-				<a href="/login" class="text-sm text-muted-foreground transition-colors hover:text-foreground">Log in</a>
+				<a
+					href="/login"
+					class="flex h-9 items-center rounded-md px-3 text-base font-bold text-primary-foreground transition-colors hover:bg-foreground/10"
+					>Log in</a
+				>
 			{/if}
 		</div>
 	</div>

--- a/ui/src/lib/components/NavBar.svelte
+++ b/ui/src/lib/components/NavBar.svelte
@@ -26,7 +26,7 @@
 	// Shared look for every nav item (Settings trigger + top-level links): same
 	// height, size and weight so nothing reads smaller or lighter than the rest.
 	const navItemClass =
-		'flex h-9 items-center rounded-md px-3 text-base font-bold text-primary-foreground transition-colors hover:bg-foreground/10';
+		'flex h-9 items-center rounded-md px-3 text-base font-semibold text-primary-foreground transition-colors hover:bg-foreground/10';
 	const navItemActiveClass = 'bg-foreground/15';
 
 	function isActive(href: string) {
@@ -98,14 +98,14 @@
 			{#if loggedIn}
 				<Button
 					variant="ghost"
-					class="h-9 rounded-md px-3 text-base font-bold hover:bg-foreground/15 hover:text-primary-foreground"
+					class="h-9 rounded-md px-3 text-base font-semibold hover:bg-foreground/15 hover:text-primary-foreground"
 					onclick={logout}
 					>Log out</Button
 				>
 			{:else}
 				<a
 					href="/login"
-					class="flex h-9 items-center rounded-md px-3 text-base font-bold text-primary-foreground transition-colors hover:bg-foreground/10"
+					class="flex h-9 items-center rounded-md px-3 text-base font-semibold text-primary-foreground transition-colors hover:bg-foreground/10"
 					>Log in</a
 				>
 			{/if}

--- a/ui/src/routes/drafts/[id]/draft/+page.svelte
+++ b/ui/src/routes/drafts/[id]/draft/+page.svelte
@@ -312,7 +312,7 @@
 				{/if}
 			</div>
 			{#if canPick}
-				<p class="mt-3 text-sm text-emerald-600">
+				<p class="mt-3 text-sm text-success">
 					You're on the clock — select a player below.
 				</p>
 			{:else if !isCompleted && onClockCaptain}

--- a/ui/src/routes/seasons/[id]/proposals/[proposalId]/+page.svelte
+++ b/ui/src/routes/seasons/[id]/proposals/[proposalId]/+page.svelte
@@ -112,7 +112,7 @@
 		</CardHeader>
 		<CardContent>
 			<div class="flex items-center gap-6 text-sm">
-				<span class="font-medium text-emerald-600">{detail.votes_for} for</span>
+				<span class="font-medium text-success">{detail.votes_for} for</span>
 				<span class="font-medium text-destructive">{detail.votes_against} against</span>
 				<span class="text-muted-foreground">{detail.voters.length} eligible voters</span>
 			</div>

--- a/ui/src/routes/styles.css
+++ b/ui/src/routes/styles.css
@@ -2,73 +2,121 @@
 @import 'tw-animate-css';
 @custom-variant dark (&:is(.dark *));
 
+/* Court-green brand theme.
+ *
+ * --success is intentionally in the same hue family as --primary (148 vs 155).
+ * When the brand *is* green, a separate "success green" is a fiction — the two
+ * cannot be told apart perceptually. Resolve it structurally instead:
+ * StatusBadge (#193) always renders an icon plus a label, never colour alone.
+ * --primary carries "brand / positive action"; --success is reserved for state
+ * transitions (saved / confirmed / complete).
+ *
+ * Chart palette caveats (from a CVD simulation across the 5 hues): green
+ * (chart-1) and clay (chart-4) are only ΔE ≈ 2.2 apart under deuteranopia, and
+ * amber (chart-3) / clay (chart-4) are ΔE ≈ 5.6 under tritanopia. Assign
+ * categorical slots in fixed order, never cycled, and label directly rather
+ * than relying on a colour key if series 1 and 4 ever sit adjacent.
+ */
+
 :root {
 	--radius: 0.625rem;
 	--background: oklch(1 0 0);
-	--foreground: oklch(0.145 0 0);
+	--foreground: oklch(0.16 0.012 155);
 	--card: oklch(1 0 0);
-	--card-foreground: oklch(0.145 0 0);
+	--card-foreground: oklch(0.16 0.012 155);
 	--popover: oklch(1 0 0);
-	--popover-foreground: oklch(0.145 0 0);
-	--primary: oklch(0.205 0 0);
-	--primary-foreground: oklch(0.985 0 0);
-	--secondary: oklch(0.97 0 0);
-	--secondary-foreground: oklch(0.205 0 0);
-	--muted: oklch(0.97 0 0);
-	--muted-foreground: oklch(0.556 0 0);
-	--accent: oklch(0.97 0 0);
-	--accent-foreground: oklch(0.205 0 0);
-	--destructive: oklch(0.577 0.245 27.325);
-	--border: oklch(0.922 0 0);
-	--input: oklch(0.922 0 0);
-	--ring: oklch(0.708 0 0);
-	--chart-1: oklch(0.646 0.222 41.116);
-	--chart-2: oklch(0.6 0.118 184.704);
-	--chart-3: oklch(0.398 0.07 227.392);
-	--chart-4: oklch(0.828 0.189 84.429);
-	--chart-5: oklch(0.769 0.188 70.08);
-	--sidebar: oklch(0.985 0 0);
-	--sidebar-foreground: oklch(0.145 0 0);
-	--sidebar-primary: oklch(0.205 0 0);
-	--sidebar-primary-foreground: oklch(0.985 0 0);
-	--sidebar-accent: oklch(0.97 0 0);
-	--sidebar-accent-foreground: oklch(0.205 0 0);
-	--sidebar-border: oklch(0.922 0 0);
-	--sidebar-ring: oklch(0.708 0 0);
+	--popover-foreground: oklch(0.16 0.012 155);
+
+	--primary: oklch(0.52 0.13 155);            /* #007e46 */
+	--primary-foreground: oklch(0.99 0 0);
+
+	--secondary: oklch(0.97 0.008 155);
+	--secondary-foreground: oklch(0.26 0.03 155);
+	--muted: oklch(0.97 0.008 155);
+	--muted-foreground: oklch(0.53 0.015 155);
+	--accent: oklch(0.95 0.03 155);             /* pale green wash */
+	--accent-foreground: oklch(0.30 0.06 155);
+
+	--success: oklch(0.54 0.15 148);
+	--success-foreground: oklch(0.99 0 0);
+	--warning: oklch(0.55 0.13 70);
+	--warning-foreground: oklch(0.99 0 0);
+	--info: oklch(0.53 0.13 245);
+	--info-foreground: oklch(0.99 0 0);
+	--destructive: oklch(0.577 0.245 27.325);   /* unchanged — already passes */
+	--destructive-foreground: oklch(0.99 0 0);
+
+	--border: oklch(0.90 0.012 155);            /* decorative dividers / card edges */
+	--input: oklch(0.66 0.02 155);              /* component boundary — needs 3:1 */
+	--ring: oklch(0.55 0.12 155);
+
+	--chart-1: oklch(0.52 0.15 150);   /* green  #007f35 */
+	--chart-2: oklch(0.60 0.13 212);   /* teal   #0093ad */
+	--chart-3: oklch(0.64 0.14 72);    /* amber  #bf7b00 */
+	--chart-4: oklch(0.52 0.15 30);    /* clay   #af3e30 */
+	--chart-5: oklch(0.58 0.10 268);   /* slate  #6177b6 */
+
+	/* sidebar-* mirror the above (defined but currently unused) */
+	--sidebar: oklch(0.97 0.008 155);
+	--sidebar-foreground: oklch(0.16 0.012 155);
+	--sidebar-primary: oklch(0.52 0.13 155);
+	--sidebar-primary-foreground: oklch(0.99 0 0);
+	--sidebar-accent: oklch(0.95 0.03 155);
+	--sidebar-accent-foreground: oklch(0.30 0.06 155);
+	--sidebar-border: oklch(0.90 0.012 155);
+	--sidebar-ring: oklch(0.55 0.12 155);
 }
 
 .dark {
-	--background: oklch(0.145 0 0);
-	--foreground: oklch(0.985 0 0);
-	--card: oklch(0.205 0 0);
-	--card-foreground: oklch(0.985 0 0);
-	--popover: oklch(0.269 0 0);
-	--popover-foreground: oklch(0.985 0 0);
-	--primary: oklch(0.922 0 0);
-	--primary-foreground: oklch(0.205 0 0);
-	--secondary: oklch(0.269 0 0);
-	--secondary-foreground: oklch(0.985 0 0);
-	--muted: oklch(0.269 0 0);
-	--muted-foreground: oklch(0.708 0 0);
-	--accent: oklch(0.371 0 0);
-	--accent-foreground: oklch(0.985 0 0);
-	--destructive: oklch(0.704 0.191 22.216);
-	--border: oklch(1 0 0 / 10%);
-	--input: oklch(1 0 0 / 15%);
-	--ring: oklch(0.556 0 0);
-	--chart-1: oklch(0.488 0.243 264.376);
-	--chart-2: oklch(0.696 0.17 162.48);
-	--chart-3: oklch(0.769 0.188 70.08);
-	--chart-4: oklch(0.627 0.265 303.9);
-	--chart-5: oklch(0.645 0.246 16.439);
-	--sidebar: oklch(0.205 0 0);
-	--sidebar-foreground: oklch(0.985 0 0);
-	--sidebar-primary: oklch(0.488 0.243 264.376);
-	--sidebar-primary-foreground: oklch(0.985 0 0);
-	--sidebar-accent: oklch(0.269 0 0);
-	--sidebar-accent-foreground: oklch(0.985 0 0);
-	--sidebar-border: oklch(1 0 0 / 10%);
-	--sidebar-ring: oklch(0.439 0 0);
+	--background: oklch(0.17 0.012 155);
+	--foreground: oklch(0.96 0.008 155);
+	--card: oklch(0.21 0.014 155);
+	--card-foreground: oklch(0.96 0.008 155);
+	--popover: oklch(0.24 0.014 155);
+	--popover-foreground: oklch(0.96 0.008 155);
+
+	--primary: oklch(0.72 0.15 155);
+	--primary-foreground: oklch(0.18 0.02 155);
+	--secondary: oklch(0.27 0.015 155);
+	--secondary-foreground: oklch(0.96 0.008 155);
+	--muted: oklch(0.27 0.015 155);
+	--muted-foreground: oklch(0.72 0.015 155);
+	--accent: oklch(0.31 0.05 155);
+	--accent-foreground: oklch(0.93 0.03 155);
+
+	--success: oklch(0.74 0.15 148);
+	--success-foreground: oklch(0.18 0.02 148);
+	--warning: oklch(0.80 0.13 72);
+	--warning-foreground: oklch(0.20 0.03 72);
+	--info: oklch(0.72 0.13 245);
+	--info-foreground: oklch(0.18 0.03 245);
+	--destructive: oklch(0.70 0.19 25);
+	--destructive-foreground: oklch(0.18 0.03 25);
+
+	--border: oklch(1 0 0 / 12%);
+	--input: oklch(1 0 0 / 22%);
+	--ring: oklch(0.72 0.15 155);
+
+	--chart-1: oklch(0.63 0.16 150);
+	--chart-2: oklch(0.66 0.13 212);
+	--chart-3: oklch(0.655 0.15 85);
+	--chart-4: oklch(0.54 0.16 26);
+	--chart-5: oklch(0.62 0.115 268);
+
+	/* sidebar-* mirror the above (defined but currently unused) */
+	--sidebar: oklch(0.21 0.014 155);
+	--sidebar-foreground: oklch(0.96 0.008 155);
+	--sidebar-primary: oklch(0.72 0.15 155);
+	--sidebar-primary-foreground: oklch(0.18 0.02 155);
+	--sidebar-accent: oklch(0.31 0.05 155);
+	--sidebar-accent-foreground: oklch(0.93 0.03 155);
+	--sidebar-border: oklch(1 0 0 / 12%);
+	--sidebar-ring: oklch(0.72 0.15 155);
+}
+
+@theme {
+	--font-sans: ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji',
+		'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
 }
 
 @theme inline {
@@ -90,7 +138,14 @@
 	--color-muted-foreground: var(--muted-foreground);
 	--color-accent: var(--accent);
 	--color-accent-foreground: var(--accent-foreground);
+	--color-success: var(--success);
+	--color-success-foreground: var(--success-foreground);
+	--color-warning: var(--warning);
+	--color-warning-foreground: var(--warning-foreground);
+	--color-info: var(--info);
+	--color-info-foreground: var(--info-foreground);
 	--color-destructive: var(--destructive);
+	--color-destructive-foreground: var(--destructive-foreground);
 	--color-border: var(--border);
 	--color-input: var(--input);
 	--color-ring: var(--ring);

--- a/ui/src/routes/teams/[id]/+page.svelte
+++ b/ui/src/routes/teams/[id]/+page.svelte
@@ -149,7 +149,7 @@
 				<p class="mt-3 text-sm font-medium text-destructive">{actionError}</p>
 			{/if}
 			{#if actionMessage}
-				<p class="mt-3 text-sm font-medium text-emerald-600">{actionMessage}</p>
+				<p class="mt-3 text-sm font-medium text-success">{actionMessage}</p>
 			{/if}
 
 			{#if canManage}


### PR DESCRIPTION
Closes #189

Retints the UI from the stock shadcn-svelte neutral (zero-chroma) palette to a court-green brand, keeping every existing token name, and applies the brand to the nav bar.

## Changes
- `ui/src/routes/styles.css`: court-green tokens for both `:root` and `.dark` (neutrals get a faint green tint, chroma 0.008–0.015)
- Added `--success` / `--warning` / `--info` (+ foregrounds) and `--destructive-foreground` in both themes, mapped in `@theme inline` so `bg-success` / `text-warning` / etc. utilities exist
- Distinct `--border` (decorative) vs `--input` (component boundary) values
- Recoloured `--chart-1..5` in both themes; recorded the fixed-order/CVD caveat (green/clay ΔE≈2.2 deuteranopia, amber/clay ΔE≈5.6 tritanopia) in a comment
- Recorded the `--success`-vs-`--primary` hue-family note (148 vs 155) in a comment
- Set `--font-sans` system stack in `@theme`
- Swapped 3 hardcoded `text-emerald-600` usages to `text-success` (teams, drafts, proposals pages) — surrounding strings byte-identical, so no e2e markup/accessible-name changes
- Kept the `tw-animate-css` import (needed by #193's enter/exit animations)
- `ui/src/lib/components/NavBar.svelte`: brand-green header (`bg-primary text-primary-foreground`) with on-green hover chips, consistent nav sizing (`h-9` `text-base` bold for every item incl. the Settings trigger and Log in/out), and an active-tab indicator (`bg-foreground/15` chip + `aria-current`) for the top-level links, the Settings trigger, and the current item inside the Settings dropdown

## Verification
- Contrast verified via Oklch → linear-sRGB → WCAG relative-luminance script: white-on-primary **5.17:1** (light), dark-on-primary **8.04:1** (dark), ring **4.58:1** light / **8.19:1** dark, input **3.08:1** light / **4.98:1** dark — all ≥ AA; nav link text **5.03:1** light / **8.04:1** dark, hover/active chips **5.42–5.65:1** light / **8.91–9.34:1** dark
- `grep -rn "text-emerald\|text-green-\|text-red-" src/routes/` → no matches
- `npm run check` → 0 errors, 0 warnings
- `make e2e` → 40 passed (two transient parallel-suite flakes in unrelated specs — `matches.spec.ts` and `scoring-structure-secondary.spec.ts` — both pass in isolation and on the full-suite re-run)
- Throwaway Playwright check confirmed the active-tab indicator lands (`aria-current` + chip class on the current link/trigger) and every nav item renders at 16px bold