### PR TITLE
UI: identity/roles store (Closes #192)

### DIFF
--- a/ui/src/lib/auth.ts
+++ b/ui/src/lib/auth.ts
@@ -1,6 +1,7 @@
 import { goto } from '$app/navigation';
 import { writable } from 'svelte/store';
 import { isSessionExpired } from './session';
+import { identity } from './identity.svelte';
 
 export { SESSION_EXPIRED_MESSAGE } from './session';
 
@@ -25,6 +26,8 @@ export function setToken(token: string): void {
 
 export function clearToken(): void {
 	localStorage.removeItem(TOKEN_KEY);
+	// Drop the cached identity so the next login on this browser starts clean.
+	identity.reset();
 }
 
 export function isLoggedIn(): boolean {

--- a/ui/src/lib/components/NavBar.svelte
+++ b/ui/src/lib/components/NavBar.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	import { isLoggedIn, clearToken } from '$lib/auth';
+	import { isLoggedIn, clearToken, sessionExpired } from '$lib/auth';
+	import { identity } from '$lib/identity.svelte';
 	import { goto } from '$app/navigation';
 	import { page } from '$app/state';
 	import { Button } from '$lib/components/ui/button/index.js';
@@ -8,9 +9,8 @@
 		PopoverContent,
 		PopoverTrigger
 	} from '$lib/components/ui/popover/index.js';
+	import ChevronDownIcon from '@lucide/svelte/icons/chevron-down';
 	import logo from '$lib/assets/favicon.svg';
-
-	let loggedIn = $state(isLoggedIn());
 
 	const settingsLinks = [
 		{ href: '/seasons', label: 'Seasons' },
@@ -36,9 +36,18 @@
 
 	const settingsActive = $derived(settingsLinks.some((link) => isActive(link.href)));
 
+	// Reads of `identity` state and the `sessionExpired` store are reactive, so
+	// this flips to true once the layout resolves the signed-in user (also after
+	// a client-side login redirect) and back to false on logout/expiry, when
+	// identity.reset() drops the cached user.
+	const showAccount = $derived(
+		identity.userId !== null ||
+			identity.user !== null ||
+			(isLoggedIn() && !$sessionExpired)
+	);
+
 	function logout() {
 		clearToken();
-		loggedIn = false;
 		goto('/');
 	}
 </script>
@@ -95,13 +104,35 @@
 			>
 		</nav>
 		<div class="ml-auto flex items-center">
-			{#if loggedIn}
-				<Button
-					variant="ghost"
-					class="h-9 rounded-md px-3 text-base font-medium hover:bg-foreground/15 hover:text-primary-foreground"
-					onclick={logout}
-					>Log out</Button
-				>
+			{#if showAccount}
+				<Popover>
+					<PopoverTrigger
+						class="flex h-9 items-center gap-2 rounded-md px-3 text-base font-medium text-primary-foreground transition-colors hover:bg-foreground/15 aria-expanded:bg-foreground/15"
+						aria-label="Account"
+					>
+						{#if identity.user}
+							<span
+								class="flex size-6 shrink-0 items-center justify-center rounded-full bg-foreground/15 text-xs font-semibold"
+								>{identity.initials}</span
+							>
+							<span class="max-w-40 truncate">{identity.displayName}</span>
+						{:else}
+							<span class="text-sm text-primary-foreground/80">Account</span>
+						{/if}
+						<ChevronDownIcon class="size-4 shrink-0 opacity-70" aria-hidden />
+					</PopoverTrigger>
+					<PopoverContent class="flex min-w-40 flex-col gap-0.5 p-1.5" align="end">
+						<div class="px-2.5 py-1.5 text-sm text-muted-foreground">
+							{identity.displayName || 'Signed in'}
+						</div>
+						<Button
+							variant="ghost"
+							class="justify-start rounded-md px-2.5 py-1.5 text-sm"
+							onclick={logout}
+							>Log out</Button
+						>
+					</PopoverContent>
+				</Popover>
 			{:else}
 				<a
 					href="/login"

--- a/ui/src/lib/identity.svelte.ts
+++ b/ui/src/lib/identity.svelte.ts
@@ -1,0 +1,120 @@
+// Identity store: the signed-in user's profile and role-bearing data. The
+// user id comes from the JWT's `sub` claim (getCurrentUserId), and the profile
+// is resolved via GET /api/user/:id — /api/whoami returns HTTP 400 and must
+// not be used (see issue #192).
+//
+// Commissioner-ness is per-season and only derivable from ScheduleDetail.
+// Rather than fetching schedules, the store is a **write-through cache**: pages
+// that already call GET /api/schedule?season_id= push the result in via
+// noteCommissioners(), so no extra requests are made.
+import { SvelteMap } from 'svelte/reactivity';
+import { getCurrentUserId } from '$lib/auth';
+import { getUser, fullName, type User } from '$lib/user';
+import { listTeams, type TeamRoster } from '$lib/team';
+
+class Identity {
+	userId = $state<string | null>(null);
+	user = $state<User | null>(null);
+	teams = $state<TeamRoster[]>([]);
+	loading = $state(false);
+	error = $state('');
+
+	// seasonId -> commissioner user ids, as reported by GET /api/schedule.
+	// A SvelteMap so writes are reactive. The raw list is stored (rather than a
+	// boolean) so isCommissionerOf stays correct even when a page's note
+	// arrives before identity.load() resolves — the check is re-derived from
+	// both the note and userId, whichever lands last.
+	private commissionersBySeason = new SvelteMap<string, string[]>();
+
+	get displayName(): string {
+		return this.user ? fullName(this.user) : '';
+	}
+
+	/** e.g. 'JA' — for the nav avatar chip. */
+	get initials(): string {
+		if (!this.user) return '';
+		const first = this.user.first_name.trim().charAt(0);
+		const last = this.user.last_name.trim().charAt(0);
+		return `${first}${last}`.toUpperCase();
+	}
+
+	/** Team ids where the current user is captain or co-captain. */
+	get captainOf(): string[] {
+		if (!this.userId) return [];
+		return this.teams
+			.filter((roster) =>
+				roster.assignments.some(
+					(a) =>
+						a.user_id === this.userId && (a.role === 'captain' || a.role === 'co_captain')
+				)
+			)
+			.map((roster) => roster.team.id);
+	}
+
+	get isCaptain(): boolean {
+		return this.captainOf.length > 0;
+	}
+
+	isCommissionerOf(seasonId: string): boolean {
+		const commissioners = this.commissionersBySeason.get(seasonId);
+		return (
+			this.userId !== null && commissioners !== undefined && commissioners.includes(this.userId)
+		);
+	}
+
+	/** Write-through cache: called by pages that already fetched the schedule. */
+	noteCommissioners(seasonId: string, commissioners: string[]): void {
+		this.commissionersBySeason.set(seasonId, commissioners);
+	}
+
+	/**
+	 * Loads the signed-in user's profile via GET /api/user/:id. Idempotent and
+	 * never rejects — errors are swallowed into `error` (an unhandled rejection
+	 * in the layout effect would surface on every route). No-op when there is
+	 * no decodable `sub` claim (no token, or a token without one), so it issues
+	 * zero requests in that case.
+	 */
+	async load(): Promise<void> {
+		const userId = getCurrentUserId();
+		if (userId === null) {
+			this.reset();
+			return;
+		}
+		// Already resolved, or a request is in flight, for this user.
+		if (this.userId === userId && (this.user !== null || this.loading)) return;
+		this.userId = userId;
+		this.loading = true;
+		this.error = '';
+		try {
+			this.user = await getUser(userId);
+		} catch (e) {
+			this.error = e instanceof Error ? e.message : 'Failed to load identity';
+		} finally {
+			this.loading = false;
+		}
+	}
+
+	/** Lazy: fetches the teams visible to the current user once. */
+	async loadTeams(): Promise<void> {
+		const userId = this.userId ?? getCurrentUserId();
+		if (!userId) return;
+		if (this.teams.length > 0) return;
+		try {
+			this.teams = await listTeams();
+		} catch (e) {
+			this.error = e instanceof Error ? e.message : 'Failed to load teams';
+		}
+	}
+
+	/** Clears all cached identity state (logout / session expiry). */
+	reset(): void {
+		this.userId = null;
+		this.user = null;
+		this.teams = [];
+		this.loading = false;
+		this.error = '';
+		this.commissionersBySeason.clear();
+	}
+}
+
+export const identity = new Identity();

--- a/ui/src/routes/+layout.svelte
+++ b/ui/src/routes/+layout.svelte
@@ -1,16 +1,22 @@
 <script lang="ts">
 	import './styles.css';
 	import favicon from '$lib/assets/favicon.svg';
-	import { startSessionMonitor } from '$lib/auth';
+	import { page } from '$app/state';
+	import { startSessionMonitor, getCurrentUserId } from '$lib/auth';
+	import { identity } from '$lib/identity.svelte';
 	import NavBar from '$lib/components/NavBar.svelte';
 
 	let { children } = $props();
 
-	// Start the background JWT-expiry ticker for the whole app. The layout
-	// persists across client-side navigations, so this runs once per page load
-	// and keeps watching until the page is torn down.
+	// Start the background JWT-expiry ticker for the whole app and resolve the
+	// signed-in user's identity. The layout persists across client-side
+	// navigations, so reading `page.url` re-runs this on every navigation —
+	// including the post-login redirect from /auth/callback, which is when the
+	// token (and thus getCurrentUserId) first becomes available.
 	$effect(() => {
+		void page.url;
 		const stop = startSessionMonitor();
+		if (getCurrentUserId()) void identity.load();
 		return () => stop();
 	});
 </script>

--- a/ui/src/routes/seasons/[id]/+page.svelte
+++ b/ui/src/routes/seasons/[id]/+page.svelte
@@ -12,6 +12,7 @@
 	import { listFacilities } from '$lib/facility';
 	import type { Facility } from '$lib/facility';
 	import { getCurrentUserId, getRoles } from '$lib/auth';
+	import { identity } from '$lib/identity.svelte';
 	import { listWeeksForSeason } from '$lib/week';
 	import type { Week } from '$lib/week';
 	import { listTeams } from '$lib/team';
@@ -141,9 +142,15 @@
 		bye: boolean;
 	}
 
-	const isCommissioner = $derived(
-		scheduleDetail !== null && scheduleDetail.commissioners.includes(getCurrentUserId() ?? '')
-	);
+	const isCommissioner = $derived(identity.isCommissionerOf(id()));
+
+	// Write-through cache: keep the shared identity store's commissioner data
+	// in sync with the schedule detail this page already fetches (see
+	// $lib/identity.svelte.ts), so commissioner-ness is never re-derived inline.
+	$effect(() => {
+		const detail = scheduleDetail;
+		if (detail) identity.noteCommissioners(id(), detail.commissioners);
+	});
 
 	async function load() {
 		loading = true;

--- a/ui/src/routes/seasons/[id]/proposals/+page.svelte
+++ b/ui/src/routes/seasons/[id]/proposals/+page.svelte
@@ -11,7 +11,7 @@
 		getProposalDetail
 	} from '$lib/commissionerProposal';
 	import type { CommissionerProposal, ProposalDetail } from '$lib/commissionerProposal';
-	import { getCurrentUserId } from '$lib/auth';
+	import { identity } from '$lib/identity.svelte';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import {
 		Card,
@@ -39,9 +39,15 @@
 	let creating = $state(false);
 	let createError = $state('');
 
-	const isCommissioner = $derived(
-		schedule !== null && schedule.commissioners.includes(getCurrentUserId() ?? '')
-	);
+	const isCommissioner = $derived(identity.isCommissionerOf(id()));
+
+	// Write-through cache: keep the shared identity store's commissioner data
+	// in sync with the schedule detail this page already fetches (see
+	// $lib/identity.svelte.ts), so commissioner-ness is never re-derived inline.
+	$effect(() => {
+		const s = schedule;
+		if (s) identity.noteCommissioners(id(), s.commissioners);
+	});
 
 	async function load() {
 		loading = true;


### PR DESCRIPTION
Closes #192

## What

Adds `ui/src/lib/identity.svelte.ts` — a reactive identity/roles store — and wires it through the app:

- **Identity resolution**: the JWT `sub` claim gives the user id; the profile is fetched via `GET /api/user/:id`. `/api/whoami` is NOT used (it returns HTTP 400; follow-up filed as #210).
- **`load()`** is a no-op when `getCurrentUserId()` is `null` (issues zero requests — protects the null-`sub` session-expiry e2e tokens) and never rejects (errors land in `identity.error`).
- **Cache clearing**: `clearToken()` now calls `identity.reset()`, which covers both logout (NavBar) and session expiry (`expireSession()` routes through `clearToken()`). Verified: log in as A, log out, log in as B → nav shows B.
- **Commissioner-ness**: write-through cache via `noteCommissioners()`. The seasons detail and proposals pages now push the `GET /api/schedule` commissioners they already fetch into the store and read `identity.isCommissionerOf(seasonId)` instead of re-deriving inline. Uses `SvelteMap` (from `svelte/reactivity`) rather than `SvelteSet` so the cache stays correct when a page's note lands before `identity.load()` resolves — `isCommissionerOf` is derived from both the note and `userId`, whichever arrives last.
- **NavBar**: shows the signed-in user's initials + full name (plain text, not a link — keeps `user.spec.ts` single-match assertions intact) in an account popover with a Log out action. The trigger appears after login without a full reload and reverts to "Log in" on logout/expiry.
- **Layout**: resolves identity on every navigation (including the post-login redirect from `/auth/callback`).

## Verification

- `npm run check` — 0 errors, 0 warnings
- `ui/e2e/session-expiry.spec.ts` (both tests) and `ui/e2e/user.spec.ts` — green
- `make e2e` — 40/40 green (one run had 2 unrelated parallel flakes — blurbs/draft-board — both pass in isolation and on the second full run)
- Frontend unit tests — 8/8 green

Follow-up: #210 (backend fix for the /api/whoami 400).