### PR TITLE
UI: refactor repeated list/detail pages onto shared primitives (Closes #199)

### DIFF
--- a/ui/src/lib/components/app/page-header.svelte
+++ b/ui/src/lib/components/app/page-header.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
-	import type { Snippet } from 'svelte';
+	import type { Component, Snippet } from 'svelte';
 	import { cn } from '$lib/utils.js';
 	import { Skeleton } from '$lib/components/ui/skeleton/index.js';
+	import ArrowLeftIcon from '@lucide/svelte/icons/arrow-left';
 
 	let {
 		title,
 		description,
+		icon,
 		backHref,
 		backLabel,
 		actions,
@@ -18,6 +20,8 @@
 		title?: string;
 		/** Optional subtitle under the heading. */
 		description?: string;
+		/** Optional Lucide icon component rendered beside the heading. */
+		icon?: Component;
 		/** When set, renders the normalised "← Back" affordance. */
 		backHref?: string;
 		/** Link text for the back affordance (defaults to "Back"). */
@@ -33,11 +37,17 @@
 <div class={cn('flex flex-wrap items-center justify-between gap-4', className)}>
 	<div class="flex min-w-0 items-center gap-4">
 		{#if title !== undefined}
-			<div class="min-w-0">
-				<h1 class="truncate text-2xl font-semibold tracking-tight">{title}</h1>
-				{#if description}
-					<p class="mt-0.5 text-sm text-muted-foreground">{description}</p>
+			<div class="flex min-w-0 items-center gap-3">
+				{#if icon}
+					{@const Icon = icon}
+					<Icon class="size-6 shrink-0 text-muted-foreground" />
 				{/if}
+				<div class="min-w-0">
+					<h1 class="truncate text-2xl font-semibold tracking-tight">{title}</h1>
+					{#if description}
+						<p class="mt-0.5 text-sm text-muted-foreground">{description}</p>
+					{/if}
+				</div>
 			</div>
 		{:else}
 			<Skeleton class="h-8 w-56" />
@@ -45,9 +55,10 @@
 		{#if backHref}
 			<a
 				href={backHref}
-				class="shrink-0 text-sm text-muted-foreground transition-colors hover:text-foreground"
+				class="flex shrink-0 items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
 			>
-				&larr; {backLabel ?? 'Back'}
+				<ArrowLeftIcon class="size-4" />
+				{backLabel ?? 'Back'}
 			</a>
 		{/if}
 	</div>

--- a/ui/src/routes/+layout.svelte
+++ b/ui/src/routes/+layout.svelte
@@ -32,7 +32,7 @@
 	>Skip to main content</a
 >
 <NavBar />
-<main id="main-content" class="mx-auto w-full max-w-6xl px-6 py-6">
+<main id="main-content" class="mx-auto w-full max-w-6xl px-4 py-6 md:px-6">
 	{@render children()}
 </main>
 <Toaster />

--- a/ui/src/routes/drafts/+page.svelte
+++ b/ui/src/routes/drafts/+page.svelte
@@ -1,25 +1,37 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
+	import { Async } from '$lib/async.svelte';
+	import {
+		AsyncSection,
+		DataTable,
+		EmptyState,
+		PageHeader,
+		StatusBadge
+	} from '$lib/components/app/index.js';
+	import type { Column } from '$lib/components/app/data-table.svelte';
 	import { listDrafts } from '$lib/draft';
 	import type { Draft } from '$lib/draft';
 	import { listFormats } from '$lib/format';
 	import { listUsers, fullName } from '$lib/user';
-	import { Badge } from '$lib/components/ui/badge/index.js';
 	import { Button } from '$lib/components/ui/button/index.js';
-	import {
-		Table,
-		TableBody,
-		TableCell,
-		TableHead,
-		TableHeader,
-		TableRow
-	} from '$lib/components/ui/table/index.js';
+	import ListOrderedIcon from '@lucide/svelte/icons/list-ordered';
 
-	let drafts = $state<Draft[]>([]);
 	let formats = $state<Record<string, string>>({});
 	let users = $state<Record<string, string>>({});
-	let loading = $state(true);
-	let error = $state('');
+
+	const drafts = new Async<Draft[]>();
+	onMount(() =>
+		drafts.run(async () => {
+			const [draftList, formatList, userList] = await Promise.all([
+				listDrafts(),
+				listFormats(),
+				listUsers()
+			]);
+			formats = Object.fromEntries(formatList.map((f) => [f.id, f.name]));
+			users = Object.fromEntries(userList.map((u) => [u.id, fullName(u)]));
+			return draftList;
+		})
+	);
 
 	// The zero Go time marshals to this literal; treat it as "not set".
 	const ZERO_TIME = '0001-01-01T00:00:00Z';
@@ -28,71 +40,62 @@
 		return !!draft.completed_at && draft.completed_at !== ZERO_TIME;
 	}
 
-	onMount(async () => {
-		try {
-			const [draftList, formatList, userList] = await Promise.all([
-				listDrafts(),
-				listFormats(),
-				listUsers()
-			]);
-			drafts = draftList;
-			formats = Object.fromEntries(formatList.map((f) => [f.id, f.name]));
-			users = Object.fromEntries(userList.map((u) => [u.id, fullName(u)]));
-		} catch (e) {
-			error = e instanceof Error ? e.message : 'Failed to load drafts';
-		} finally {
-			loading = false;
-		}
-	});
+	const columns: Column<Draft>[] = [
+		{ key: 'name', header: 'Name', sortable: true, cell: nameCell },
+		{
+			key: 'owner',
+			header: 'Owner',
+			hideBelow: 'sm',
+			value: (d) => users[d.owner] ?? d.owner
+		},
+		{
+			key: 'format',
+			header: 'Format',
+			hideBelow: 'md',
+			value: (d) => formats[d.format] ?? d.format
+		},
+		{ key: 'status', header: 'Status', cell: statusCell }
+	];
 </script>
+
+{#snippet nameCell(d: Draft)}
+	<a href={`/drafts/${d.id}`} class="font-medium text-primary underline-offset-4 hover:underline">
+		{d.name}
+	</a>
+{/snippet}
+
+{#snippet statusCell(d: Draft)}
+	<StatusBadge
+		status={isCompleted(d) ? 'complete' : 'open'}
+		label={isCompleted(d) ? 'Completed' : 'In progress'}
+	/>
+{/snippet}
 
 <svelte:head>
 	<title>Intraclub | Drafts</title>
 </svelte:head>
 
-<div class="flex items-center justify-between gap-4">
-	<h1 class="text-2xl font-semibold tracking-tight">Drafts</h1>
-	<Button href="/drafts/new">New draft</Button>
-</div>
+<PageHeader title="Drafts" description="Player drafts that build teams for a season" icon={ListOrderedIcon}>
+	{#snippet actions()}
+		<Button href="/drafts/new">New draft</Button>
+	{/snippet}
+</PageHeader>
 
-{#if loading}
-	<p class="text-muted-foreground">Loading...</p>
-{:else if error}
-	<p class="text-sm font-medium text-destructive">{error}</p>
-{:else if drafts.length === 0}
-	<p class="text-muted-foreground">No drafts yet.</p>
-{:else}
-	<div class="mt-4 overflow-hidden rounded-lg border">
-		<Table>
-			<TableHeader>
-				<TableRow>
-					<TableHead>Name</TableHead>
-					<TableHead>Owner</TableHead>
-					<TableHead>Format</TableHead>
-					<TableHead>Status</TableHead>
-				</TableRow>
-			</TableHeader>
-			<TableBody>
-				{#each drafts as draft}
-					<TableRow>
-						<TableCell>
-							<a
-								href={`/drafts/${draft.id}`}
-								class="font-medium text-primary underline-offset-4 hover:underline"
-							>
-								{draft.name}
-							</a>
-						</TableCell>
-						<TableCell>{users[draft.owner] ?? draft.owner}</TableCell>
-						<TableCell>{formats[draft.format] ?? draft.format}</TableCell>
-						<TableCell>
-							<Badge variant={isCompleted(draft) ? 'secondary' : 'default'}>
-								{isCompleted(draft) ? 'Completed' : 'In progress'}
-							</Badge>
-						</TableCell>
-					</TableRow>
-				{/each}
-			</TableBody>
-		</Table>
-	</div>
-{/if}
+<AsyncSection state={drafts} isEmpty={(d) => d.length === 0}>
+	{#snippet loading()}
+		<DataTable rows={[]} {columns} getKey={(d) => d.id} loading />
+	{/snippet}
+	{#snippet empty()}
+		<EmptyState title="No drafts yet." description="Create a draft to split players into teams." />
+	{/snippet}
+	{#snippet children(ds)}
+		<DataTable
+			rows={ds}
+			{columns}
+			getKey={(d) => d.id}
+			caption="Drafts"
+			filter
+			filterLabel="Filter drafts"
+		/>
+	{/snippet}
+</AsyncSection>

--- a/ui/src/routes/drafts/new/+page.svelte
+++ b/ui/src/routes/drafts/new/+page.svelte
@@ -5,6 +5,9 @@
 	import { listFormats } from '$lib/format';
 	import type { Format } from '$lib/format';
 	import { goto } from '$app/navigation';
+	import { Async } from '$lib/async.svelte';
+	import { AsyncSection, PageHeader } from '$lib/components/app/index.js';
+	import { Alert, AlertDescription } from '$lib/components/ui/alert/index.js';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
@@ -13,40 +16,38 @@
 		NativeSelect,
 		NativeSelectOption
 	} from '$lib/components/ui/native-select/index.js';
+	import { Skeleton } from '$lib/components/ui/skeleton/index.js';
+	import { toast } from '$lib/toast';
+	import ListOrderedIcon from '@lucide/svelte/icons/list-ordered';
 
-	let formats = $state<Format[]>([]);
-	let patterns = $state<DraftOrderPattern[]>([]);
-	let loadError = $state('');
-	let loading = $state(true);
+	type DraftOptions = { formats: Format[]; patterns: DraftOrderPattern[] };
 
+	const options = new Async<DraftOptions>();
 	let name = $state('');
 	let format = $state('');
 	let pattern = $state('');
 	let error = $state('');
 	let submitting = $state(false);
+	let attempted = $state(false);
 
 	// The backend defaults a new draft's pattern to Snake; only send the
 	// explicit pattern set when the user picks something else.
 	const DEFAULT_PATTERN = 'Snake';
 
-	onMount(async () => {
-		try {
+	onMount(() =>
+		options.run(async () => {
 			const [formatList, patternList] = await Promise.all([
 				listFormats(),
 				listDraftOrderPatterns()
 			]);
-			formats = formatList;
-			patterns = patternList;
 			pattern = DEFAULT_PATTERN;
-		} catch (e) {
-			loadError = e instanceof Error ? e.message : 'Failed to load draft options';
-		} finally {
-			loading = false;
-		}
-	});
+			return { formats: formatList, patterns: patternList };
+		})
+	);
 
 	async function handleSubmit(e: Event) {
 		e.preventDefault();
+		attempted = true;
 		error = '';
 		submitting = true;
 		try {
@@ -61,6 +62,7 @@
 					// pattern selection failed; proceed to the draft anyway
 				}
 			}
+			toast.success('Draft created');
 			await goto(`/drafts/${created.id}`);
 		} catch (err) {
 			error = err instanceof Error ? err.message : 'Failed to create draft';
@@ -74,51 +76,62 @@
 	<title>Intraclub | New draft</title>
 </svelte:head>
 
-<div class="flex items-center gap-4">
-	<h1 class="text-2xl font-semibold tracking-tight">New draft</h1>
-	<a href="/drafts" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to drafts</a>
-</div>
+<PageHeader title="New draft" icon={ListOrderedIcon} backHref="/drafts" backLabel="Back to drafts" />
 
-{#if loading}
-	<p class="mt-4 text-muted-foreground">Loading...</p>
-{:else if loadError}
-	<p class="mt-4 text-sm font-medium text-destructive">{loadError}</p>
-{:else}
-	<Card class="mt-6 max-w-md">
-		<CardHeader>
-			<CardTitle>Draft details</CardTitle>
-		</CardHeader>
-		<CardContent>
-			<form onsubmit={handleSubmit} class="flex flex-col gap-4">
-				<div class="flex flex-col gap-2">
-					<Label for="name">Name</Label>
-					<Input id="name" type="text" bind:value={name} required />
-				</div>
-				<div class="flex flex-col gap-2">
-					<Label for="format">Format</Label>
-					<NativeSelect id="format" bind:value={format} required class="w-full">
-						<NativeSelectOption value="" disabled>Select a format…</NativeSelectOption>
-						{#each formats as f}
-							<NativeSelectOption value={f.id}>{f.name}</NativeSelectOption>
-						{/each}
-					</NativeSelect>
-				</div>
-				<div class="flex flex-col gap-2">
-					<Label for="pattern">Draft order pattern</Label>
-					<NativeSelect id="pattern" bind:value={pattern} class="w-full">
-						{#each patterns as p}
-							<NativeSelectOption value={p.name}>{p.name}</NativeSelectOption>
-						{/each}
-					</NativeSelect>
-				</div>
-				<Button type="submit" disabled={submitting} class="w-fit">
-					{submitting ? 'Creating...' : 'Create draft'}
-				</Button>
-			</form>
-		</CardContent>
-	</Card>
-{/if}
-
-{#if error}
-	<p class="mt-4 text-sm font-medium text-destructive">{error}</p>
-{/if}
+<AsyncSection state={options}>
+	{#snippet loading()}
+		<Skeleton class="mt-6 h-64 w-full max-w-md" />
+	{/snippet}
+	{#snippet children(opts)}
+		<Card class="mt-6 max-w-md">
+			<CardHeader>
+				<CardTitle>Draft details</CardTitle>
+			</CardHeader>
+			<CardContent>
+				{#if error}
+					<Alert variant="destructive" class="mb-4">
+						<AlertDescription>{error}</AlertDescription>
+					</Alert>
+				{/if}
+				<form onsubmit={handleSubmit} class="flex flex-col gap-4">
+					<div class="flex flex-col gap-2">
+						<Label for="name">Name</Label>
+						<Input
+							id="name"
+							type="text"
+							bind:value={name}
+							required
+							aria-invalid={attempted && !name.trim()}
+						/>
+					</div>
+					<div class="flex flex-col gap-2">
+						<Label for="format">Format</Label>
+						<NativeSelect
+							id="format"
+							bind:value={format}
+							required
+							class="w-full"
+							aria-invalid={attempted && !format}
+						>
+							<NativeSelectOption value="" disabled>Select a format…</NativeSelectOption>
+							{#each opts.formats as f}
+								<NativeSelectOption value={f.id}>{f.name}</NativeSelectOption>
+							{/each}
+						</NativeSelect>
+					</div>
+					<div class="flex flex-col gap-2">
+						<Label for="pattern">Draft order pattern</Label>
+						<NativeSelect id="pattern" bind:value={pattern} class="w-full">
+							{#each opts.patterns as p}
+								<NativeSelectOption value={p.name}>{p.name}</NativeSelectOption>
+							{/each}
+						</NativeSelect>
+					</div>
+					<Button type="submit" disabled={submitting} class="w-fit">
+						{submitting ? 'Creating...' : 'Create draft'}
+					</Button>
+				</form>
+			</CardContent>
+		</Card>
+	{/snippet}
+</AsyncSection>

--- a/ui/src/routes/facilities/+page.svelte
+++ b/ui/src/routes/facilities/+page.svelte
@@ -1,70 +1,59 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
+	import { Async } from '$lib/async.svelte';
+	import {
+		AsyncSection,
+		DataTable,
+		EmptyState,
+		PageHeader
+	} from '$lib/components/app/index.js';
+	import type { Column } from '$lib/components/app/data-table.svelte';
 	import { listFacilities } from '$lib/facility';
 	import type { Facility } from '$lib/facility';
 	import { Button } from '$lib/components/ui/button/index.js';
-	import {
-		Table,
-		TableBody,
-		TableCell,
-		TableHead,
-		TableHeader,
-		TableRow
-	} from '$lib/components/ui/table/index.js';
+	import Building2Icon from '@lucide/svelte/icons/building-2';
 
-	let facilities = $state<Facility[]>([]);
-	let loading = $state(true);
-	let error = $state('');
+	const facilities = new Async<Facility[]>();
+	onMount(() => facilities.run(() => listFacilities()));
 
-	onMount(async () => {
-		try {
-			facilities = await listFacilities();
-		} catch (e) {
-			error = e instanceof Error ? e.message : 'Failed to load facilities';
-		} finally {
-			loading = false;
-		}
-	});
+	const columns: Column<Facility>[] = [
+		{ key: 'name', header: 'Name', sortable: true, cell: nameCell },
+		{ key: 'address', header: 'Address', hideBelow: 'sm', value: (f) => f.address },
+		{ key: 'courts', header: 'Courts', align: 'right', value: (f) => f.courts }
+	];
 </script>
+
+{#snippet nameCell(f: Facility)}
+	<a href={`/facilities/${f.id}`} class="font-medium text-primary underline-offset-4 hover:underline">
+		{f.name}
+	</a>
+{/snippet}
 
 <svelte:head>
 	<title>Intraclub | Facilities</title>
 </svelte:head>
 
-<div class="flex items-center justify-between gap-4">
-	<h1 class="text-2xl font-semibold tracking-tight">Facilities</h1>
-	<Button href="/facilities/new">New facility</Button>
-</div>
+<PageHeader title="Facilities" description="Courts and venues available to the league" icon={Building2Icon}>
+	{#snippet actions()}
+		<Button href="/facilities/new">New facility</Button>
+	{/snippet}
+</PageHeader>
 
-{#if loading}
-	<p class="text-muted-foreground">Loading...</p>
-{:else if error}
-	<p class="text-sm font-medium text-destructive">{error}</p>
-{:else if facilities.length === 0}
-	<p class="text-muted-foreground">No facilities yet.</p>
-{:else}
-	<div class="mt-4 overflow-hidden rounded-lg border">
-		<Table>
-			<TableHeader>
-				<TableRow>
-					<TableHead>Name</TableHead>
-					<TableHead>Address</TableHead>
-					<TableHead>Courts</TableHead>
-				</TableRow>
-			</TableHeader>
-			<TableBody>
-				{#each facilities as facility}
-					<TableRow>
-						<TableCell>
-							<a href={`/facilities/${facility.id}`} class="font-medium text-primary underline-offset-4 hover:underline">
-								{facility.name}
-							</a>
-						</TableCell>
-						<TableCell>{facility.address}</TableCell>
-						<TableCell>{facility.courts}</TableCell>
-					</TableRow>
-				{/each}
-			</TableBody>
-		</Table>
-	</div>
-{/if}
+<AsyncSection state={facilities} isEmpty={(f) => f.length === 0}>
+	{#snippet loading()}
+		<DataTable rows={[]} {columns} getKey={(f) => f.id} loading />
+	{/snippet}
+	{#snippet empty()}
+		<EmptyState title="No facilities yet." description="Add a venue so seasons have somewhere to play." />
+	{/snippet}
+	{#snippet children(fs)}
+		<DataTable
+			rows={fs}
+			{columns}
+			getKey={(f) => f.id}
+			caption="Facilities"
+			filter
+			filterLabel="Filter facilities"
+		/>
+	{/snippet}
+</AsyncSection>

--- a/ui/src/routes/facilities/[id]/+page.svelte
+++ b/ui/src/routes/facilities/[id]/+page.svelte
@@ -2,25 +2,32 @@
 	import { onMount } from 'svelte';
 	import { page } from '$app/state';
 	import { goto } from '$app/navigation';
-	import { getFacility, updateFacility, deleteFacility } from '$lib/facility';
-	import type { Facility } from '$lib/facility';
+	import { Async } from '$lib/async.svelte';
+	import { AsyncSection, PageHeader } from '$lib/components/app/index.js';
+	import { Alert, AlertDescription } from '$lib/components/ui/alert/index.js';
+	import {
+		AlertDialog,
+		AlertDialogAction,
+		AlertDialogCancel,
+		AlertDialogContent,
+		AlertDialogDescription,
+		AlertDialogFooter,
+		AlertDialogHeader,
+		AlertDialogTitle,
+		AlertDialogTrigger
+	} from '$lib/components/ui/alert-dialog/index.js';
 	import { Button, buttonVariants } from '$lib/components/ui/button/index.js';
 	import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
 	import { Label } from '$lib/components/ui/label/index.js';
-	import {
-		Popover,
-		PopoverClose,
-		PopoverContent,
-		PopoverHeader,
-		PopoverTitle,
-		PopoverTrigger
-	} from '$lib/components/ui/popover/index.js';
+	import { toast } from '$lib/toast';
+	import { getFacility, updateFacility, deleteFacility } from '$lib/facility';
+	import type { Facility } from '$lib/facility';
+	import Building2Icon from '@lucide/svelte/icons/building-2';
 
 	const id = () => page.params.id as string;
 
-	let facility = $state<Facility | null>(null);
-	let loadError = $state('');
+	const facility = new Async<Facility>();
 	let name = $state('');
 	let address = $state('');
 	let courts = $state(1);
@@ -30,20 +37,15 @@
 	let deleting = $state(false);
 	let deleteOpen = $state(false);
 
-	onMount(load);
+	onMount(() => facility.run(load));
 
-	async function load() {
-		loadError = '';
-		try {
-			const f = await getFacility(id());
-			facility = f;
-			name = f.name;
-			address = f.address;
-			courts = f.courts;
-			layoutPhoto = f.layout_photo;
-		} catch (e) {
-			loadError = e instanceof Error ? e.message : 'Failed to load facility';
-		}
+	async function load(): Promise<Facility> {
+		const f = await getFacility(id());
+		name = f.name;
+		address = f.address;
+		courts = f.courts;
+		layoutPhoto = f.layout_photo;
+		return f;
 	}
 
 	async function handleSave(e: Event) {
@@ -57,7 +59,8 @@
 				courts,
 				layout_photo: layoutPhoto.trim()
 			});
-			facility = updated;
+			facility.data = updated;
+			toast.success('Facility saved');
 		} catch (err) {
 			error = err instanceof Error ? err.message : 'Failed to update facility';
 		} finally {
@@ -71,6 +74,7 @@
 		deleting = true;
 		try {
 			await deleteFacility(id());
+			toast.success('Facility deleted');
 			await goto('/facilities');
 		} catch (err) {
 			// e.g. the facility is assigned to a Season and PreDelete blocks it
@@ -81,72 +85,81 @@
 </script>
 
 <svelte:head>
-	<title>Intraclub | {facility ? facility.name : 'Facility'}</title>
+	<title>Intraclub | {facility.data ? facility.data.name : 'Facility'}</title>
 </svelte:head>
 
-{#if loadError}
-	<h1 class="text-2xl font-semibold tracking-tight">Facility</h1>
-	<p class="text-sm font-medium text-destructive">{loadError}</p>
-	<a href="/facilities" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to facilities</a>
-{:else if !facility}
-	<h1 class="text-2xl font-semibold tracking-tight">Facility</h1>
-	<p class="text-muted-foreground">Loading...</p>
-{:else}
-	<div class="flex items-center gap-4">
-		<h1 class="text-2xl font-semibold tracking-tight">{facility.name}</h1>
-		<a href="/facilities" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to facilities</a>
-	</div>
+<PageHeader
+	title={facility.data?.name}
+	icon={Building2Icon}
+	backHref="/facilities"
+	backLabel="Back to facilities"
+/>
 
-	<Card class="mt-6 max-w-md">
-		<CardHeader>
-			<CardTitle>Facility details</CardTitle>
-		</CardHeader>
-		<CardContent>
-			<form onsubmit={handleSave} class="flex flex-col gap-4">
-				<div class="flex flex-col gap-2">
-					<Label for="name">Name</Label>
-					<Input id="name" type="text" bind:value={name} required />
-				</div>
-				<div class="flex flex-col gap-2">
-					<Label for="address">Address</Label>
-					<Input id="address" type="text" bind:value={address} required />
-				</div>
-				<div class="flex flex-col gap-2">
-					<Label for="courts">Number of courts</Label>
-					<Input id="courts" type="number" bind:value={courts} min="1" required />
-				</div>
-				<div class="flex flex-col gap-2">
-					<Label for="layoutPhoto">Layout photo ID (optional)</Label>
-					<Input id="layoutPhoto" type="text" bind:value={layoutPhoto} placeholder="16-char hex ID" />
-				</div>
-				<Button type="submit" disabled={saving} class="w-fit">
-					{saving ? 'Saving...' : 'Save changes'}
-				</Button>
-			</form>
-		</CardContent>
-	</Card>
+<AsyncSection state={facility}>
+	{#snippet children(f)}
+		<Card class="mt-6 max-w-md">
+			<CardHeader>
+				<CardTitle>Facility details</CardTitle>
+			</CardHeader>
+			<CardContent>
+				<form onsubmit={handleSave} class="flex flex-col gap-4">
+					<div class="flex flex-col gap-2">
+						<Label for="name">Name</Label>
+						<Input id="name" type="text" bind:value={name} required />
+					</div>
+					<div class="flex flex-col gap-2">
+						<Label for="address">Address</Label>
+						<Input id="address" type="text" bind:value={address} required />
+					</div>
+					<div class="flex flex-col gap-2">
+						<Label for="courts">Number of courts</Label>
+						<Input id="courts" type="number" bind:value={courts} min="1" required />
+					</div>
+					<div class="flex flex-col gap-2">
+						<Label for="layoutPhoto">Layout photo ID (optional)</Label>
+						<Input
+							id="layoutPhoto"
+							type="text"
+							bind:value={layoutPhoto}
+							placeholder="16-char hex ID"
+						/>
+					</div>
+					<Button type="submit" disabled={saving} class="w-fit">
+						{saving ? 'Saving...' : 'Save changes'}
+					</Button>
+				</form>
+			</CardContent>
+		</Card>
 
-	<div class="mt-4">
-		<Popover bind:open={deleteOpen}>
-			<PopoverTrigger disabled={deleting} class={buttonVariants({ variant: 'destructive' })}>
-				{deleting ? 'Deleting...' : 'Delete facility'}
-			</PopoverTrigger>
-			<PopoverContent class="w-80">
-				<PopoverHeader>
-					<PopoverTitle>Delete facility?</PopoverTitle>
-					<p class="text-sm text-muted-foreground">
-						This permanently removes this facility and cannot be undone.
-					</p>
-				</PopoverHeader>
-				<div class="flex justify-end gap-2">
-					<PopoverClose class={buttonVariants({ variant: 'outline', size: 'sm' })}>Cancel</PopoverClose>
-					<Button variant="destructive" size="sm" onclick={handleDelete}>Delete</Button>
-				</div>
-			</PopoverContent>
-		</Popover>
-	</div>
+		{#if error}
+			<Alert variant="destructive" class="mt-4 max-w-md">
+				<AlertDescription>{error}</AlertDescription>
+			</Alert>
+		{/if}
 
-	{#if error}
-		<p class="mt-4 text-sm font-medium text-destructive">{error}</p>
-	{/if}
-{/if}
+		<div class="mt-4">
+			<AlertDialog bind:open={deleteOpen}>
+				<AlertDialogTrigger
+					disabled={deleting}
+					class={buttonVariants({ variant: 'destructive' })}
+				>
+					{deleting ? 'Deleting...' : 'Delete facility'}
+				</AlertDialogTrigger>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Delete facility?</AlertDialogTitle>
+						<AlertDialogDescription>
+							This permanently removes this facility and cannot be undone.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel>Cancel</AlertDialogCancel>
+						<AlertDialogAction variant="destructive" onclick={handleDelete}>
+							Delete
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+		</div>
+	{/snippet}
+</AsyncSection>

--- a/ui/src/routes/facilities/new/+page.svelte
+++ b/ui/src/routes/facilities/new/+page.svelte
@@ -1,10 +1,14 @@
 <script lang="ts">
 	import { createFacility } from '$lib/facility';
 	import { goto } from '$app/navigation';
+	import { PageHeader } from '$lib/components/app/index.js';
+	import { Alert, AlertDescription } from '$lib/components/ui/alert/index.js';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
 	import { Label } from '$lib/components/ui/label/index.js';
+	import { toast } from '$lib/toast';
+	import Building2Icon from '@lucide/svelte/icons/building-2';
 
 	let name = $state('');
 	let address = $state('');
@@ -12,9 +16,11 @@
 	let layoutPhoto = $state('');
 	let error = $state('');
 	let submitting = $state(false);
+	let attempted = $state(false);
 
 	async function handleSubmit(e: Event) {
 		e.preventDefault();
+		attempted = true;
 		error = '';
 		submitting = true;
 		try {
@@ -24,6 +30,7 @@
 				courts,
 				layout_photo: layoutPhoto.trim()
 			});
+			toast.success('Facility created');
 			await goto(`/facilities/${created.id}`);
 		} catch (err) {
 			error = err instanceof Error ? err.message : 'Failed to create facility';
@@ -37,32 +44,58 @@
 	<title>Intraclub | New facility</title>
 </svelte:head>
 
-<div class="flex items-center gap-4">
-	<h1 class="text-2xl font-semibold tracking-tight">New facility</h1>
-	<a href="/facilities" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to facilities</a>
-</div>
+<PageHeader title="New facility" icon={Building2Icon} backHref="/facilities" backLabel="Back to facilities" />
 
 <Card class="mt-6 max-w-md">
 	<CardHeader>
 		<CardTitle>Facility details</CardTitle>
 	</CardHeader>
 	<CardContent>
+		{#if error}
+			<Alert variant="destructive" class="mb-4">
+				<AlertDescription>{error}</AlertDescription>
+			</Alert>
+		{/if}
 		<form onsubmit={handleSubmit} class="flex flex-col gap-4">
 			<div class="flex flex-col gap-2">
 				<Label for="name">Name</Label>
-				<Input id="name" type="text" bind:value={name} required />
+				<Input
+					id="name"
+					type="text"
+					bind:value={name}
+					required
+					aria-invalid={attempted && !name.trim()}
+				/>
 			</div>
 			<div class="flex flex-col gap-2">
 				<Label for="address">Address</Label>
-				<Input id="address" type="text" bind:value={address} required />
+				<Input
+					id="address"
+					type="text"
+					bind:value={address}
+					required
+					aria-invalid={attempted && !address.trim()}
+				/>
 			</div>
 			<div class="flex flex-col gap-2">
 				<Label for="courts">Number of courts</Label>
-				<Input id="courts" type="number" bind:value={courts} min="1" required />
+				<Input
+					id="courts"
+					type="number"
+					bind:value={courts}
+					min="1"
+					required
+					aria-invalid={attempted && !courts}
+				/>
 			</div>
 			<div class="flex flex-col gap-2">
 				<Label for="layoutPhoto">Layout photo ID (optional)</Label>
-				<Input id="layoutPhoto" type="text" bind:value={layoutPhoto} placeholder="16-char hex ID" />
+				<Input
+					id="layoutPhoto"
+					type="text"
+					bind:value={layoutPhoto}
+					placeholder="16-char hex ID"
+				/>
 			</div>
 			<Button type="submit" disabled={submitting} class="w-fit">
 				{submitting ? 'Creating...' : 'Create facility'}
@@ -70,7 +103,3 @@
 		</form>
 	</CardContent>
 </Card>
-
-{#if error}
-	<p class="mt-4 text-sm font-medium text-destructive">{error}</p>
-{/if}

--- a/ui/src/routes/formats/+page.svelte
+++ b/ui/src/routes/formats/+page.svelte
@@ -1,66 +1,57 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
+	import { Async } from '$lib/async.svelte';
+	import {
+		AsyncSection,
+		DataTable,
+		EmptyState,
+		PageHeader
+	} from '$lib/components/app/index.js';
+	import type { Column } from '$lib/components/app/data-table.svelte';
 	import { listFormats } from '$lib/format';
 	import type { Format } from '$lib/format';
 	import { Button } from '$lib/components/ui/button/index.js';
-	import {
-		Table,
-		TableBody,
-		TableCell,
-		TableHead,
-		TableHeader,
-		TableRow
-	} from '$lib/components/ui/table/index.js';
+	import ListTreeIcon from '@lucide/svelte/icons/list-tree';
 
-	let formats = $state<Format[]>([]);
-	let loading = $state(true);
-	let error = $state('');
+	const formats = new Async<Format[]>();
+	onMount(() => formats.run(() => listFormats()));
 
-	onMount(async () => {
-		try {
-			formats = await listFormats();
-		} catch (e) {
-			error = e instanceof Error ? e.message : 'Failed to load formats';
-		} finally {
-			loading = false;
-		}
-	});
+	const columns: Column<Format>[] = [
+		{ key: 'name', header: 'Name', sortable: true, cell: nameCell }
+	];
 </script>
+
+{#snippet nameCell(f: Format)}
+	<a href={`/formats/${f.id}`} class="font-medium text-primary underline-offset-4 hover:underline">
+		{f.name}
+	</a>
+{/snippet}
 
 <svelte:head>
 	<title>Intraclub | Formats</title>
 </svelte:head>
 
-<div class="flex items-center justify-between gap-4">
-	<h1 class="text-2xl font-semibold tracking-tight">Formats</h1>
-	<Button href="/formats/new">New format</Button>
-</div>
+<PageHeader title="Formats" description="How a season structures its ratings and play" icon={ListTreeIcon}>
+	{#snippet actions()}
+		<Button href="/formats/new">New format</Button>
+	{/snippet}
+</PageHeader>
 
-{#if loading}
-	<p class="text-muted-foreground">Loading...</p>
-{:else if error}
-	<p class="text-sm font-medium text-destructive">{error}</p>
-{:else if formats.length === 0}
-	<p class="text-muted-foreground">No formats yet.</p>
-{:else}
-	<div class="mt-4 overflow-hidden rounded-lg border">
-		<Table>
-			<TableHeader>
-				<TableRow>
-					<TableHead>Name</TableHead>
-				</TableRow>
-			</TableHeader>
-			<TableBody>
-				{#each formats as format}
-					<TableRow>
-						<TableCell>
-							<a href={`/formats/${format.id}`} class="font-medium text-primary underline-offset-4 hover:underline">
-								{format.name}
-							</a>
-						</TableCell>
-					</TableRow>
-				{/each}
-			</TableBody>
-		</Table>
-	</div>
-{/if}
+<AsyncSection state={formats} isEmpty={(f) => f.length === 0}>
+	{#snippet loading()}
+		<DataTable rows={[]} {columns} getKey={(f) => f.id} loading />
+	{/snippet}
+	{#snippet empty()}
+		<EmptyState title="No formats yet." description="Create a format to define how players are rated and matched." />
+	{/snippet}
+	{#snippet children(fs)}
+		<DataTable
+			rows={fs}
+			{columns}
+			getKey={(f) => f.id}
+			caption="Formats"
+			filter
+			filterLabel="Filter formats"
+		/>
+	{/snippet}
+</AsyncSection>

--- a/ui/src/routes/formats/[id]/+page.svelte
+++ b/ui/src/routes/formats/[id]/+page.svelte
@@ -2,6 +2,30 @@
 	import { onMount } from 'svelte';
 	import { page } from '$app/state';
 	import { goto } from '$app/navigation';
+	import { Async } from '$lib/async.svelte';
+	import { AsyncSection, PageHeader } from '$lib/components/app/index.js';
+	import { Alert, AlertDescription } from '$lib/components/ui/alert/index.js';
+	import {
+		AlertDialog,
+		AlertDialogAction,
+		AlertDialogCancel,
+		AlertDialogContent,
+		AlertDialogDescription,
+		AlertDialogFooter,
+		AlertDialogHeader,
+		AlertDialogTitle,
+		AlertDialogTrigger
+	} from '$lib/components/ui/alert-dialog/index.js';
+	import { Badge } from '$lib/components/ui/badge/index.js';
+	import { Button, buttonVariants } from '$lib/components/ui/button/index.js';
+	import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
+	import {
+		NativeSelect,
+		NativeSelectOption
+	} from '$lib/components/ui/native-select/index.js';
+	import { toast } from '$lib/toast';
 	import {
 		getFormat,
 		updateFormat,
@@ -12,28 +36,11 @@
 	import type { Format } from '$lib/format';
 	import { listRatings } from '$lib/rating';
 	import type { Rating } from '$lib/rating';
-	import { Badge } from '$lib/components/ui/badge/index.js';
-	import { Button, buttonVariants } from '$lib/components/ui/button/index.js';
-	import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card/index.js';
-	import { Input } from '$lib/components/ui/input/index.js';
-	import { Label } from '$lib/components/ui/label/index.js';
-	import {
-		NativeSelect,
-		NativeSelectOption
-	} from '$lib/components/ui/native-select/index.js';
-	import {
-		Popover,
-		PopoverClose,
-		PopoverContent,
-		PopoverHeader,
-		PopoverTitle,
-		PopoverTrigger
-	} from '$lib/components/ui/popover/index.js';
+	import ListTreeIcon from '@lucide/svelte/icons/list-tree';
 
 	const id = () => page.params.id as string;
 
-	let format = $state<Format | null>(null);
-	let loadError = $state('');
+	const format = new Async<Format>();
 	let name = $state('');
 	let error = $state('');
 	let saving = $state(false);
@@ -47,19 +54,13 @@
 	let ratingsError = $state('');
 	let ratingsSaving = $state(false);
 
-	onMount(load);
+	onMount(() => format.run(load));
 
-	async function load() {
-		loadError = '';
-		try {
-			const f = await getFormat(id());
-			format = f;
-			name = f.name;
-		} catch (e) {
-			loadError = e instanceof Error ? e.message : 'Failed to load format';
-			return;
-		}
+	async function load(): Promise<Format> {
+		const f = await getFormat(id());
+		name = f.name;
 		await loadRatings();
+		return f;
 	}
 
 	async function loadRatings() {
@@ -86,7 +87,8 @@
 		saving = true;
 		try {
 			const updated = await updateFormat(id(), { name: name.trim() });
-			format = updated;
+			format.data = updated;
+			toast.success('Format saved');
 		} catch (err) {
 			error = err instanceof Error ? err.message : 'Failed to update format';
 		} finally {
@@ -100,6 +102,7 @@
 		deleting = true;
 		try {
 			await deleteFormat(id());
+			toast.success('Format deleted');
 			await goto('/formats');
 		} catch (err) {
 			// e.g. the format is assigned to a Draft and PreDelete blocks it
@@ -135,119 +138,125 @@
 </script>
 
 <svelte:head>
-	<title>Intraclub | {format ? format.name : 'Format'}</title>
+	<title>Intraclub | {format.data ? format.data.name : 'Format'}</title>
 </svelte:head>
 
-{#if loadError}
-	<h1 class="text-2xl font-semibold tracking-tight">Format</h1>
-	<p class="text-sm font-medium text-destructive">{loadError}</p>
-	<a href="/formats" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to formats</a>
-{:else if !format}
-	<h1 class="text-2xl font-semibold tracking-tight">Format</h1>
-	<p class="text-muted-foreground">Loading...</p>
-{:else}
-	<div class="flex items-center gap-4">
-		<h1 class="text-2xl font-semibold tracking-tight">{format.name}</h1>
-		<a href="/formats" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to formats</a>
-	</div>
+<PageHeader
+	title={format.data?.name}
+	icon={ListTreeIcon}
+	backHref="/formats"
+	backLabel="Back to formats"
+/>
 
-	<Card class="mt-6 max-w-md">
-		<CardHeader>
-			<CardTitle>Format details</CardTitle>
-		</CardHeader>
-		<CardContent>
-			<form onsubmit={handleSave} class="flex flex-col gap-4">
-				<div class="flex flex-col gap-2">
-					<Label for="name">Name</Label>
-					<Input id="name" type="text" bind:value={name} required />
-				</div>
-				<Button type="submit" disabled={saving} class="w-fit">
-					{saving ? 'Saving...' : 'Save changes'}
-				</Button>
-			</form>
-		</CardContent>
-	</Card>
+<AsyncSection state={format}>
+	{#snippet children(f)}
+		<Card class="mt-6 max-w-md">
+			<CardHeader>
+				<CardTitle>Format details</CardTitle>
+			</CardHeader>
+			<CardContent>
+				<form onsubmit={handleSave} class="flex flex-col gap-4">
+					<div class="flex flex-col gap-2">
+						<Label for="name">Name</Label>
+						<Input id="name" type="text" bind:value={name} required />
+					</div>
+					<Button type="submit" disabled={saving} class="w-fit">
+						{saving ? 'Saving...' : 'Save changes'}
+					</Button>
+				</form>
+			</CardContent>
+		</Card>
 
-	<section class="mt-8 max-w-md">
-		<h2 class="text-xl font-semibold tracking-tight">Possible ratings</h2>
-		<p class="mt-1 text-sm text-muted-foreground">
-			The skill ratings that players can be assigned to in this format, ordered
-			highest-skill to lowest-skill.
-		</p>
+		<section class="mt-8 max-w-md">
+			<h2 class="text-xl font-semibold tracking-tight">Possible ratings</h2>
+			<p class="mt-1 text-sm text-muted-foreground">
+				The skill ratings that players can be assigned to in this format, ordered
+				highest-skill to lowest-skill.
+			</p>
 
-		{#if possibleRatings.length === 0}
-			<p class="mt-4 text-muted-foreground">No ratings assigned yet.</p>
-		{:else}
-			<ul class="mt-4 flex flex-col gap-2">
-				{#each possibleRatings as rating}
-					<li class="flex items-center justify-between gap-2 rounded-lg border p-2 pl-3">
-						<Badge variant="secondary" class="rating-name">{rating.name}</Badge>
-						<Button
-							type="button"
-							variant="outline"
-							size="sm"
-							onclick={() => handleRemoveRating(rating.id)}
-							disabled={ratingsSaving || possibleRatings.length === 1}
-							title={possibleRatings.length === 1
-								? 'A format must keep at least one rating'
-								: undefined}
-						>
-							Remove
-						</Button>
-					</li>
-				{/each}
-			</ul>
-			{#if possibleRatings.length === 1}
-				<p class="mt-2 text-sm text-muted-foreground">A format must keep at least one rating.</p>
-			{/if}
-		{/if}
-
-		{#if unassignedRatings.length > 0}
-			<form onsubmit={handleAddRating} class="mt-4 flex items-center gap-2">
-				<NativeSelect
-					bind:value={selectedRatingId}
-					aria-label="Rating to assign"
-					class="flex-1"
-				>
-					<NativeSelectOption value="" disabled>Select a rating…</NativeSelectOption>
-					{#each unassignedRatings as rating}
-						<NativeSelectOption value={rating.id}>{rating.name}</NativeSelectOption>
+			{#if possibleRatings.length === 0}
+				<p class="mt-4 text-muted-foreground">No ratings assigned yet.</p>
+			{:else}
+				<ul class="mt-4 flex flex-col gap-2">
+					{#each possibleRatings as rating}
+						<li class="flex items-center justify-between gap-2 rounded-lg border p-2 pl-3">
+							<Badge variant="secondary" class="rating-name">{rating.name}</Badge>
+							<Button
+								type="button"
+								variant="outline"
+								size="sm"
+								onclick={() => handleRemoveRating(rating.id)}
+								disabled={ratingsSaving || possibleRatings.length === 1}
+								title={possibleRatings.length === 1
+									? 'A format must keep at least one rating'
+									: undefined}
+							>
+								Remove
+							</Button>
+						</li>
 					{/each}
-				</NativeSelect>
-				<Button type="submit" disabled={ratingsSaving || !selectedRatingId}>
-					Add rating
-				</Button>
-			</form>
-		{:else if allRatings.length > 0}
-			<p class="mt-4 text-sm text-muted-foreground">All ratings are already assigned.</p>
+				</ul>
+				{#if possibleRatings.length === 1}
+					<p class="mt-2 text-sm text-muted-foreground">A format must keep at least one rating.</p>
+				{/if}
+			{/if}
+
+			{#if unassignedRatings.length > 0}
+				<form onsubmit={handleAddRating} class="mt-4 flex items-center gap-2">
+					<NativeSelect
+						bind:value={selectedRatingId}
+						aria-label="Rating to assign"
+						class="flex-1"
+					>
+						<NativeSelectOption value="" disabled>Select a rating…</NativeSelectOption>
+						{#each unassignedRatings as rating}
+							<NativeSelectOption value={rating.id}>{rating.name}</NativeSelectOption>
+						{/each}
+					</NativeSelect>
+					<Button type="submit" disabled={ratingsSaving || !selectedRatingId}>
+						Add rating
+					</Button>
+				</form>
+			{:else if allRatings.length > 0}
+				<p class="mt-4 text-sm text-muted-foreground">All ratings are already assigned.</p>
+			{/if}
+
+			{#if ratingsError}
+				<Alert variant="destructive" class="mt-3">
+					<AlertDescription>{ratingsError}</AlertDescription>
+				</Alert>
+			{/if}
+		</section>
+
+		{#if error}
+			<Alert variant="destructive" class="mt-4 max-w-md">
+				<AlertDescription>{error}</AlertDescription>
+			</Alert>
 		{/if}
 
-		{#if ratingsError}
-			<p class="mt-3 text-sm font-medium text-destructive">{ratingsError}</p>
-		{/if}
-	</section>
-
-	<div class="mt-8">
-		<Popover bind:open={deleteOpen}>
-			<PopoverTrigger disabled={deleting} class={buttonVariants({ variant: 'destructive' })}>
-				{deleting ? 'Deleting...' : 'Delete format'}
-			</PopoverTrigger>
-			<PopoverContent class="w-80">
-				<PopoverHeader>
-					<PopoverTitle>Delete format?</PopoverTitle>
-					<p class="text-sm text-muted-foreground">
-						This permanently removes this format and cannot be undone.
-					</p>
-				</PopoverHeader>
-				<div class="flex justify-end gap-2">
-					<PopoverClose class={buttonVariants({ variant: 'outline', size: 'sm' })}>Cancel</PopoverClose>
-					<Button variant="destructive" size="sm" onclick={handleDelete}>Delete</Button>
-				</div>
-			</PopoverContent>
-		</Popover>
-	</div>
-
-	{#if error}
-		<p class="mt-4 text-sm font-medium text-destructive">{error}</p>
-	{/if}
-{/if}
+		<div class="mt-8">
+			<AlertDialog bind:open={deleteOpen}>
+				<AlertDialogTrigger
+					disabled={deleting}
+					class={buttonVariants({ variant: 'destructive' })}
+				>
+					{deleting ? 'Deleting...' : 'Delete format'}
+				</AlertDialogTrigger>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Delete format?</AlertDialogTitle>
+						<AlertDialogDescription>
+							This permanently removes this format and cannot be undone.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel>Cancel</AlertDialogCancel>
+						<AlertDialogAction variant="destructive" onclick={handleDelete}>
+							Delete
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+		</div>
+	{/snippet}
+</AsyncSection>

--- a/ui/src/routes/formats/new/+page.svelte
+++ b/ui/src/routes/formats/new/+page.svelte
@@ -1,21 +1,28 @@
 <script lang="ts">
 	import { createFormat } from '$lib/format';
 	import { goto } from '$app/navigation';
+	import { PageHeader } from '$lib/components/app/index.js';
+	import { Alert, AlertDescription } from '$lib/components/ui/alert/index.js';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
 	import { Label } from '$lib/components/ui/label/index.js';
+	import { toast } from '$lib/toast';
+	import ListTreeIcon from '@lucide/svelte/icons/list-tree';
 
 	let name = $state('');
 	let error = $state('');
 	let submitting = $state(false);
+	let attempted = $state(false);
 
 	async function handleSubmit(e: Event) {
 		e.preventDefault();
+		attempted = true;
 		error = '';
 		submitting = true;
 		try {
 			const created = await createFormat({ name: name.trim() });
+			toast.success('Format created');
 			await goto(`/formats/${created.id}`);
 		} catch (err) {
 			error = err instanceof Error ? err.message : 'Failed to create format';
@@ -29,20 +36,28 @@
 	<title>Intraclub | New format</title>
 </svelte:head>
 
-<div class="flex items-center gap-4">
-	<h1 class="text-2xl font-semibold tracking-tight">New format</h1>
-	<a href="/formats" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to formats</a>
-</div>
+<PageHeader title="New format" icon={ListTreeIcon} backHref="/formats" backLabel="Back to formats" />
 
 <Card class="mt-6 max-w-md">
 	<CardHeader>
 		<CardTitle>Format details</CardTitle>
 	</CardHeader>
 	<CardContent>
+		{#if error}
+			<Alert variant="destructive" class="mb-4">
+				<AlertDescription>{error}</AlertDescription>
+			</Alert>
+		{/if}
 		<form onsubmit={handleSubmit} class="flex flex-col gap-4">
 			<div class="flex flex-col gap-2">
 				<Label for="name">Name</Label>
-				<Input id="name" type="text" bind:value={name} required />
+				<Input
+					id="name"
+					type="text"
+					bind:value={name}
+					required
+					aria-invalid={attempted && !name.trim()}
+				/>
 			</div>
 			<Button type="submit" disabled={submitting} class="w-fit">
 				{submitting ? 'Creating...' : 'Create format'}
@@ -50,7 +65,3 @@
 		</form>
 	</CardContent>
 </Card>
-
-{#if error}
-	<p class="mt-4 text-sm font-medium text-destructive">{error}</p>
-{/if}

--- a/ui/src/routes/organizations/+page.svelte
+++ b/ui/src/routes/organizations/+page.svelte
@@ -1,66 +1,57 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
+	import { Async } from '$lib/async.svelte';
+	import {
+		AsyncSection,
+		DataTable,
+		EmptyState,
+		PageHeader
+	} from '$lib/components/app/index.js';
+	import type { Column } from '$lib/components/app/data-table.svelte';
 	import { listOrganizations } from '$lib/organization';
 	import type { Organization } from '$lib/organization';
 	import { Button } from '$lib/components/ui/button/index.js';
-	import {
-		Table,
-		TableBody,
-		TableCell,
-		TableHead,
-		TableHeader,
-		TableRow
-	} from '$lib/components/ui/table/index.js';
+	import BuildingIcon from '@lucide/svelte/icons/building';
 
-	let organizations = $state<Organization[]>([]);
-	let loading = $state(true);
-	let error = $state('');
+	const organizations = new Async<Organization[]>();
+	onMount(() => organizations.run(() => listOrganizations()));
 
-	onMount(async () => {
-		try {
-			organizations = await listOrganizations();
-		} catch (e) {
-			error = e instanceof Error ? e.message : 'Failed to load organizations';
-		} finally {
-			loading = false;
-		}
-	});
+	const columns: Column<Organization>[] = [
+		{ key: 'name', header: 'Name', sortable: true, cell: nameCell }
+	];
 </script>
+
+{#snippet nameCell(o: Organization)}
+	<a href={`/organizations/${o.id}`} class="font-medium text-primary underline-offset-4 hover:underline">
+		{o.name}
+	</a>
+{/snippet}
 
 <svelte:head>
 	<title>Intraclub | Organizations</title>
 </svelte:head>
 
-<div class="flex items-center justify-between gap-4">
-	<h1 class="text-2xl font-semibold tracking-tight">Organizations</h1>
-	<Button href="/organizations/new">New organization</Button>
-</div>
+<PageHeader title="Organizations" description="Clubs and groups that play in the league" icon={BuildingIcon}>
+	{#snippet actions()}
+		<Button href="/organizations/new">New organization</Button>
+	{/snippet}
+</PageHeader>
 
-{#if loading}
-	<p class="text-muted-foreground">Loading...</p>
-{:else if error}
-	<p class="text-sm font-medium text-destructive">{error}</p>
-{:else if organizations.length === 0}
-	<p class="text-muted-foreground">No organizations yet.</p>
-{:else}
-	<div class="mt-4 overflow-hidden rounded-lg border">
-		<Table>
-			<TableHeader>
-				<TableRow>
-					<TableHead>Name</TableHead>
-				</TableRow>
-			</TableHeader>
-			<TableBody>
-				{#each organizations as organization}
-					<TableRow>
-						<TableCell>
-							<a href={`/organizations/${organization.id}`} class="font-medium text-primary underline-offset-4 hover:underline">
-								{organization.name}
-							</a>
-						</TableCell>
-					</TableRow>
-				{/each}
-			</TableBody>
-		</Table>
-	</div>
-{/if}
+<AsyncSection state={organizations} isEmpty={(o) => o.length === 0}>
+	{#snippet loading()}
+		<DataTable rows={[]} {columns} getKey={(o) => o.id} loading />
+	{/snippet}
+	{#snippet empty()}
+		<EmptyState title="No organizations yet." description="Create an organization to group members and manage rosters." />
+	{/snippet}
+	{#snippet children(os)}
+		<DataTable
+			rows={os}
+			{columns}
+			getKey={(o) => o.id}
+			caption="Organizations"
+			filter
+			filterLabel="Filter organizations"
+		/>
+	{/snippet}
+</AsyncSection>

--- a/ui/src/routes/organizations/[id]/+page.svelte
+++ b/ui/src/routes/organizations/[id]/+page.svelte
@@ -2,6 +2,20 @@
 	import { onMount } from 'svelte';
 	import { page } from '$app/state';
 	import { goto } from '$app/navigation';
+	import { Async } from '$lib/async.svelte';
+	import { AsyncSection, PageHeader } from '$lib/components/app/index.js';
+	import { Alert, AlertDescription } from '$lib/components/ui/alert/index.js';
+	import {
+		AlertDialog,
+		AlertDialogAction,
+		AlertDialogCancel,
+		AlertDialogContent,
+		AlertDialogDescription,
+		AlertDialogFooter,
+		AlertDialogHeader,
+		AlertDialogTitle,
+		AlertDialogTrigger
+	} from '$lib/components/ui/alert-dialog/index.js';
 	import { getCurrentUserId } from '$lib/auth';
 	import {
 		getOrganization,
@@ -19,25 +33,18 @@
 	import { Input } from '$lib/components/ui/input/index.js';
 	import { Label } from '$lib/components/ui/label/index.js';
 	import {
-		Popover,
-		PopoverClose,
-		PopoverContent,
-		PopoverHeader,
-		PopoverTitle,
-		PopoverTrigger
-	} from '$lib/components/ui/popover/index.js';
-	import {
 		Tabs,
 		TabsContent,
 		TabsList,
 		TabsTrigger
 	} from '$lib/components/ui/tabs/index.js';
 	import * as TransferList from '$lib/components/ui/transfer-list/index.js';
+	import { toast } from '$lib/toast';
+	import BuildingIcon from '@lucide/svelte/icons/building';
 
 	const id = () => page.params.id as string;
 
-	let organization = $state<Organization | null>(null);
-	let loadError = $state('');
+	const organization = new Async<Organization>();
 	let name = $state('');
 	let error = $state('');
 	let saving = $state(false);
@@ -58,19 +65,12 @@
 	// Which section is shown in the sidebar at a time.
 	let activeTab = $state('details');
 
-	onMount(load);
+	onMount(() => organization.run(load));
 
-	async function load() {
-		loadError = '';
-		try {
-			const org = await getOrganization(id());
-			organization = org;
-			name = org.name;
-			isOwner = getCurrentUserId() === org.user_id;
-		} catch (e) {
-			loadError = e instanceof Error ? e.message : 'Failed to load organization';
-			return;
-		}
+	async function load(): Promise<Organization> {
+		const org = await getOrganization(id());
+		name = org.name;
+		isOwner = getCurrentUserId() === org.user_id;
 
 		try {
 			members = await listMembers(id());
@@ -93,6 +93,7 @@
 					fullName(u).toLowerCase().includes(search.toLowerCase())
 			});
 		}
+		return org;
 	}
 
 	async function handleSave(e: Event) {
@@ -101,8 +102,9 @@
 		saving = true;
 		try {
 			const updated = await updateOrganization(id(), { name: name.trim() });
-			organization = updated;
+			organization.data = updated;
 			name = updated.name;
+			toast.success('Organization saved');
 		} catch (err) {
 			error = err instanceof Error ? err.message : 'Failed to update organization';
 		} finally {
@@ -132,6 +134,7 @@
 				await removeMember(id(), member.id);
 			}
 			await load();
+			toast.success('Members saved');
 		} catch (err) {
 			membersError = err instanceof Error ? err.message : 'Failed to save members';
 		} finally {
@@ -145,6 +148,7 @@
 		deleting = true;
 		try {
 			await deleteOrganization(id());
+			toast.success('Organization deleted');
 			await goto('/organizations');
 		} catch (err) {
 			error = err instanceof Error ? err.message : 'Failed to delete organization';
@@ -154,189 +158,193 @@
 </script>
 
 <svelte:head>
-	<title>Intraclub | {organization ? organization.name : 'Organization'}</title>
+	<title>Intraclub | {organization.data ? organization.data.name : 'Organization'}</title>
 </svelte:head>
 
-{#if loadError}
-	<h1 class="text-2xl font-semibold tracking-tight">Organization</h1>
-	<p class="text-sm font-medium text-destructive">{loadError}</p>
-	<a href="/organizations" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to organizations</a>
-{:else if !organization}
-	<h1 class="text-2xl font-semibold tracking-tight">Organization</h1>
-	<p class="text-muted-foreground">Loading...</p>
-{:else}
-	<div class="flex items-center gap-4">
-		<h1 class="text-2xl font-semibold tracking-tight">{organization.name}</h1>
-		<div class="ml-auto">
-			<a href="/organizations" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to organizations</a>
-		</div>
-	</div>
+<PageHeader
+	title={organization.data?.name}
+	icon={BuildingIcon}
+	backHref="/organizations"
+	backLabel="Back to organizations"
+/>
 
-	{#if error}
-		<p class="mt-4 text-sm font-medium text-destructive">{error}</p>
-	{/if}
+<AsyncSection state={organization}>
+	{#snippet children(org)}
+		{#if error}
+			<Alert variant="destructive" class="mt-4">
+				<AlertDescription>{error}</AlertDescription>
+			</Alert>
+		{/if}
 
-	<Tabs bind:value={activeTab} orientation="vertical" class="mt-6 flex gap-6">
-		<TabsList class="h-fit w-56 shrink-0 items-stretch">
-			<TabsTrigger
-				value="details"
-				class="group justify-start gap-2.5 px-3 py-2 text-base data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:font-semibold data-[state=active]:shadow-sm dark:data-[state=active]:bg-input/30"
-			>
-				<span
-					class="size-1.5 shrink-0 rounded-full bg-primary opacity-0 transition-opacity group-data-[state=active]:opacity-100"
-					aria-hidden="true"
-				></span>
-				Details
-			</TabsTrigger>
-			<TabsTrigger
-				value="members"
-				class="group justify-start gap-2.5 px-3 py-2 text-base data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:font-semibold data-[state=active]:shadow-sm dark:data-[state=active]:bg-input/30"
-			>
-				<span
-					class="size-1.5 shrink-0 rounded-full bg-primary opacity-0 transition-opacity group-data-[state=active]:opacity-100"
-					aria-hidden="true"
-				></span>
-				Members
-			</TabsTrigger>
-		</TabsList>
+		<Tabs bind:value={activeTab} orientation="vertical" class="mt-6 flex gap-6">
+			<TabsList class="h-fit w-56 shrink-0 items-stretch">
+				<TabsTrigger
+					value="details"
+					class="group justify-start gap-2.5 px-3 py-2 text-base data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:font-semibold data-[state=active]:shadow-sm dark:data-[state=active]:bg-input/30"
+				>
+					<span
+						class="size-1.5 shrink-0 rounded-full bg-primary opacity-0 transition-opacity group-data-[state=active]:opacity-100"
+						aria-hidden="true"
+					></span>
+					Details
+				</TabsTrigger>
+				<TabsTrigger
+					value="members"
+					class="group justify-start gap-2.5 px-3 py-2 text-base data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:font-semibold data-[state=active]:shadow-sm dark:data-[state=active]:bg-input/30"
+				>
+					<span
+						class="size-1.5 shrink-0 rounded-full bg-primary opacity-0 transition-opacity group-data-[state=active]:opacity-100"
+						aria-hidden="true"
+					></span>
+					Members
+				</TabsTrigger>
+			</TabsList>
 
-		<TabsContent value="details" class="flex-1">
-			{#if isOwner}
-				<Card class="max-w-md">
-					<CardHeader>
-						<CardTitle>Organization details</CardTitle>
-					</CardHeader>
-					<CardContent>
-						<form onsubmit={handleSave} class="flex flex-col gap-4">
-							<div class="flex flex-col gap-2">
-								<Label for="name">Name</Label>
-								<Input id="name" type="text" bind:value={name} required />
-							</div>
-							<Button type="submit" disabled={saving} class="w-fit">
-								{saving ? 'Saving...' : 'Save changes'}
-							</Button>
-						</form>
-					</CardContent>
-				</Card>
+			<TabsContent value="details" class="flex-1">
+				{#if isOwner}
+					<Card class="max-w-md">
+						<CardHeader>
+							<CardTitle>Organization details</CardTitle>
+						</CardHeader>
+						<CardContent>
+							<form onsubmit={handleSave} class="flex flex-col gap-4">
+								<div class="flex flex-col gap-2">
+									<Label for="name">Name</Label>
+									<Input id="name" type="text" bind:value={name} required />
+								</div>
+								<Button type="submit" disabled={saving} class="w-fit">
+									{saving ? 'Saving...' : 'Save changes'}
+								</Button>
+							</form>
+						</CardContent>
+					</Card>
 
-				<div class="mt-4">
-					<Popover bind:open={deleteOpen}>
-						<PopoverTrigger disabled={deleting} class={buttonVariants({ variant: 'destructive' })}>
-							{deleting ? 'Deleting...' : 'Delete organization'}
-						</PopoverTrigger>
-						<PopoverContent class="w-80">
-							<PopoverHeader>
-								<PopoverTitle>Delete organization?</PopoverTitle>
+					<div class="mt-4">
+						<AlertDialog bind:open={deleteOpen}>
+							<AlertDialogTrigger
+								disabled={deleting}
+								class={buttonVariants({ variant: 'destructive' })}
+							>
+								{deleting ? 'Deleting...' : 'Delete organization'}
+							</AlertDialogTrigger>
+							<AlertDialogContent>
+								<AlertDialogHeader>
+									<AlertDialogTitle>Delete organization?</AlertDialogTitle>
+									<AlertDialogDescription>
+										This permanently removes this organization and cannot be undone.
+									</AlertDialogDescription>
+								</AlertDialogHeader>
+								<AlertDialogFooter>
+									<AlertDialogCancel>Cancel</AlertDialogCancel>
+									<AlertDialogAction variant="destructive" onclick={handleDelete}>
+										Delete
+									</AlertDialogAction>
+								</AlertDialogFooter>
+							</AlertDialogContent>
+						</AlertDialog>
+					</div>
+				{:else}
+					<Card class="max-w-md">
+						<CardHeader>
+							<CardTitle>Organization</CardTitle>
+						</CardHeader>
+						<CardContent>
+							<p class="text-sm text-muted-foreground">
+								Only the owner can edit this organization's details.
+							</p>
+						</CardContent>
+					</Card>
+				{/if}
+			</TabsContent>
+
+			<TabsContent value="members" class="flex-1">
+				{#if membersError}
+					<Alert variant="destructive">
+						<AlertDescription>{membersError}</AlertDescription>
+					</Alert>
+				{/if}
+
+				{#if isOwner}
+					{#if transferCore}
+						<Card class="max-w-2xl">
+							<CardHeader>
+								<CardTitle>Members</CardTitle>
+							</CardHeader>
+							<CardContent>
 								<p class="text-sm text-muted-foreground">
-									This permanently removes this organization and cannot be undone.
+									Move users into the roster to make them members of this organization.
+									Changes apply when you save.
 								</p>
-							</PopoverHeader>
-							<div class="flex justify-end gap-2">
-								<PopoverClose class={buttonVariants({ variant: 'outline', size: 'sm' })}>Cancel</PopoverClose>
-								<Button variant="destructive" size="sm" onclick={handleDelete}>Delete</Button>
-							</div>
-						</PopoverContent>
-					</Popover>
-				</div>
-			{:else}
-				<Card class="max-w-md">
-					<CardHeader>
-						<CardTitle>Organization</CardTitle>
-					</CardHeader>
-					<CardContent>
-						<p class="text-sm text-muted-foreground">
-							Only the owner can edit this organization's details.
-						</p>
-					</CardContent>
-				</Card>
-			{/if}
-		</TabsContent>
-
-		<TabsContent value="members" class="flex-1">
-			{#if membersError}
-				<p class="text-sm font-medium text-destructive">{membersError}</p>
-			{/if}
-
-			{#if isOwner}
-				{#if transferCore}
-					<Card class="max-w-2xl">
+								<div class="mt-4">
+									<TransferList.Root direction="horizontal">
+										<TransferList.Container>
+											<TransferList.Title title="All users" />
+											<TransferList.Toolbar
+												variant="source"
+												core={transferCore}
+												inputPlaceholder="Search users..."
+											/>
+											<TransferList.Body>
+												{#each transferCore.filteredSource as row (row.id)}
+													<TransferList.Item side="source" {row} core={transferCore}>
+														{fullName(row)}
+													</TransferList.Item>
+												{/each}
+											</TransferList.Body>
+										</TransferList.Container>
+										<TransferList.Container>
+											<TransferList.Title title="Members" />
+											<TransferList.Toolbar
+												variant="target"
+												core={transferCore}
+												inputPlaceholder="Search members..."
+											/>
+											<TransferList.Body>
+												{#each transferCore.filteredTarget as row (row.id)}
+													<TransferList.Item side="target" {row} core={transferCore}>
+														{fullName(row)}
+													</TransferList.Item>
+												{/each}
+											</TransferList.Body>
+										</TransferList.Container>
+									</TransferList.Root>
+									<div class="mt-4 flex items-center gap-3">
+										<Button
+											type="button"
+											onclick={handleSaveMembers}
+											disabled={savingMembers}
+										>
+											{savingMembers ? 'Saving...' : 'Save members'}
+										</Button>
+										<span class="text-sm text-muted-foreground">
+											{transferCore.target.length} member{transferCore.target.length === 1 ? '' : 's'}
+										</span>
+									</div>
+								</div>
+							</CardContent>
+						</Card>
+					{:else}
+						<p class="text-sm text-muted-foreground">Loading members...</p>
+					{/if}
+				{:else}
+					<Card class="max-w-md">
 						<CardHeader>
 							<CardTitle>Members</CardTitle>
 						</CardHeader>
 						<CardContent>
-							<p class="text-sm text-muted-foreground">
-								Move users into the roster to make them members of this organization.
-								Changes apply when you save.
-							</p>
-							<div class="mt-4">
-								<TransferList.Root direction="horizontal">
-									<TransferList.Container>
-										<TransferList.Title title="All users" />
-										<TransferList.Toolbar
-											variant="source"
-											core={transferCore}
-											inputPlaceholder="Search users..."
-										/>
-										<TransferList.Body>
-											{#each transferCore.filteredSource as row (row.id)}
-												<TransferList.Item side="source" {row} core={transferCore}>
-													{fullName(row)}
-												</TransferList.Item>
-											{/each}
-										</TransferList.Body>
-									</TransferList.Container>
-									<TransferList.Container>
-										<TransferList.Title title="Members" />
-										<TransferList.Toolbar
-											variant="target"
-											core={transferCore}
-											inputPlaceholder="Search members..."
-										/>
-										<TransferList.Body>
-											{#each transferCore.filteredTarget as row (row.id)}
-												<TransferList.Item side="target" {row} core={transferCore}>
-													{fullName(row)}
-												</TransferList.Item>
-											{/each}
-										</TransferList.Body>
-									</TransferList.Container>
-								</TransferList.Root>
-								<div class="mt-4 flex items-center gap-3">
-									<Button
-										type="button"
-										onclick={handleSaveMembers}
-										disabled={savingMembers}
-									>
-										{savingMembers ? 'Saving...' : 'Save members'}
-									</Button>
-									<span class="text-sm text-muted-foreground">
-										{transferCore.target.length} member{transferCore.target.length === 1 ? '' : 's'}
-									</span>
-								</div>
-							</div>
+							{#if members.length === 0}
+								<p class="text-sm text-muted-foreground">No members yet.</p>
+							{:else}
+								<ul class="flex flex-col gap-2">
+									{#each members as member}
+										<li class="text-sm">{fullName(member)} ({member.email})</li>
+									{/each}
+								</ul>
+							{/if}
 						</CardContent>
 					</Card>
-				{:else}
-					<p class="text-sm text-muted-foreground">Loading members...</p>
 				{/if}
-			{:else}
-				<Card class="max-w-md">
-					<CardHeader>
-						<CardTitle>Members</CardTitle>
-					</CardHeader>
-					<CardContent>
-						{#if members.length === 0}
-							<p class="text-sm text-muted-foreground">No members yet.</p>
-						{:else}
-							<ul class="flex flex-col gap-2">
-								{#each members as member}
-									<li class="text-sm">{fullName(member)} ({member.email})</li>
-								{/each}
-							</ul>
-						{/if}
-					</CardContent>
-				</Card>
-			{/if}
-		</TabsContent>
-	</Tabs>
-{/if}
+			</TabsContent>
+		</Tabs>
+	{/snippet}
+</AsyncSection>

--- a/ui/src/routes/organizations/new/+page.svelte
+++ b/ui/src/routes/organizations/new/+page.svelte
@@ -1,21 +1,28 @@
 <script lang="ts">
 	import { createOrganization } from '$lib/organization';
 	import { goto } from '$app/navigation';
+	import { PageHeader } from '$lib/components/app/index.js';
+	import { Alert, AlertDescription } from '$lib/components/ui/alert/index.js';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
 	import { Label } from '$lib/components/ui/label/index.js';
+	import { toast } from '$lib/toast';
+	import BuildingIcon from '@lucide/svelte/icons/building';
 
 	let name = $state('');
 	let error = $state('');
 	let submitting = $state(false);
+	let attempted = $state(false);
 
 	async function handleSubmit(e: Event) {
 		e.preventDefault();
+		attempted = true;
 		error = '';
 		submitting = true;
 		try {
 			const created = await createOrganization({ name: name.trim() });
+			toast.success('Organization created');
 			await goto(`/organizations/${created.id}`);
 		} catch (err) {
 			error = err instanceof Error ? err.message : 'Failed to create organization';
@@ -29,20 +36,33 @@
 	<title>Intraclub | New organization</title>
 </svelte:head>
 
-<div class="flex items-center gap-4">
-	<h1 class="text-2xl font-semibold tracking-tight">New organization</h1>
-	<a href="/organizations" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to organizations</a>
-</div>
+<PageHeader
+	title="New organization"
+	icon={BuildingIcon}
+	backHref="/organizations"
+	backLabel="Back to organizations"
+/>
 
 <Card class="mt-6 max-w-md">
 	<CardHeader>
 		<CardTitle>Organization details</CardTitle>
 	</CardHeader>
 	<CardContent>
+		{#if error}
+			<Alert variant="destructive" class="mb-4">
+				<AlertDescription>{error}</AlertDescription>
+			</Alert>
+		{/if}
 		<form onsubmit={handleSubmit} class="flex flex-col gap-4">
 			<div class="flex flex-col gap-2">
 				<Label for="name">Name</Label>
-				<Input id="name" type="text" bind:value={name} required />
+				<Input
+					id="name"
+					type="text"
+					bind:value={name}
+					required
+					aria-invalid={attempted && !name.trim()}
+				/>
 			</div>
 			<Button type="submit" disabled={submitting} class="w-fit">
 				{submitting ? 'Creating...' : 'Create organization'}
@@ -50,7 +70,3 @@
 		</form>
 	</CardContent>
 </Card>
-
-{#if error}
-	<p class="mt-4 text-sm font-medium text-destructive">{error}</p>
-{/if}

--- a/ui/src/routes/photos/+page.svelte
+++ b/ui/src/routes/photos/+page.svelte
@@ -1,84 +1,75 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
+	import { Async } from '$lib/async.svelte';
+	import {
+		AsyncSection,
+		DataTable,
+		EmptyState,
+		PageHeader
+	} from '$lib/components/app/index.js';
+	import type { Column } from '$lib/components/app/data-table.svelte';
 	import { listPhotos, dataUrlFor, photoTypeLabels } from '$lib/photo';
 	import type { Photo } from '$lib/photo';
 	import { Button } from '$lib/components/ui/button/index.js';
-	import {
-		Table,
-		TableBody,
-		TableCell,
-		TableHead,
-		TableHeader,
-		TableRow
-	} from '$lib/components/ui/table/index.js';
+	import ImageIcon from '@lucide/svelte/icons/image';
 
-	let photos = $state<Photo[]>([]);
-	let loading = $state(true);
-	let error = $state('');
+	const photos = new Async<Photo[]>();
+	onMount(() => photos.run(() => listPhotos()));
 
 	function photoTypeLabel(type: number): string {
 		return photoTypeLabels[type] ?? 'unknown';
 	}
 
-	onMount(async () => {
-		try {
-			photos = await listPhotos();
-		} catch (e) {
-			error = e instanceof Error ? e.message : 'Failed to load photos';
-		} finally {
-			loading = false;
-		}
-	});
+	const columns: Column<Photo>[] = [
+		{ key: 'thumb', header: 'Thumbnail', cell: thumbCell },
+		{ key: 'alt', header: 'Alt text', sortable: true, cell: altCell },
+		{ key: 'type', header: 'Type', value: (p) => photoTypeLabel(p.file_type) }
+	];
 </script>
+
+{#snippet thumbCell(p: Photo)}
+	<a href={`/photos/${p.id}`}>
+		<img class="thumb-img" src={dataUrlFor(p)} alt={p.alt_text || 'Photo thumbnail'} />
+	</a>
+{/snippet}
+
+{#snippet altCell(p: Photo)}
+	<a
+		href={`/photos/${p.id}`}
+		class="font-medium text-primary underline-offset-4 hover:underline"
+	>
+		{p.alt_text || '(no alt text)'}
+	</a>
+{/snippet}
 
 <svelte:head>
 	<title>Intraclub | Photos</title>
 </svelte:head>
 
-<div class="flex items-center justify-between gap-4">
-	<h1 class="text-2xl font-semibold tracking-tight">Photos</h1>
-	<Button href="/photos/new">New photo</Button>
-</div>
+<PageHeader title="Photos" description="Images uploaded to the league" icon={ImageIcon}>
+	{#snippet actions()}
+		<Button href="/photos/new">New photo</Button>
+	{/snippet}
+</PageHeader>
 
-{#if loading}
-	<p class="text-muted-foreground">Loading...</p>
-{:else if error}
-	<p class="text-sm font-medium text-destructive">{error}</p>
-{:else if photos.length === 0}
-	<p class="text-muted-foreground">No photos yet.</p>
-{:else}
-	<div class="mt-4 overflow-hidden rounded-lg border">
-		<Table>
-			<TableHeader>
-				<TableRow>
-					<TableHead>Thumbnail</TableHead>
-					<TableHead>Alt text</TableHead>
-					<TableHead>Type</TableHead>
-				</TableRow>
-			</TableHeader>
-			<TableBody>
-				{#each photos as photo}
-					<TableRow>
-						<TableCell>
-							<a href={`/photos/${photo.id}`}>
-								<img class="thumb-img" src={dataUrlFor(photo)} alt={photo.alt_text || 'Photo thumbnail'} />
-							</a>
-						</TableCell>
-						<TableCell>
-							<a
-								href={`/photos/${photo.id}`}
-								class="font-medium text-primary underline-offset-4 hover:underline"
-							>
-								{photo.alt_text || '(no alt text)'}
-							</a>
-						</TableCell>
-						<TableCell>{photoTypeLabel(photo.file_type)}</TableCell>
-					</TableRow>
-				{/each}
-			</TableBody>
-		</Table>
-	</div>
-{/if}
+<AsyncSection state={photos} isEmpty={(p) => p.length === 0}>
+	{#snippet loading()}
+		<DataTable rows={[]} {columns} getKey={(p) => p.id} loading />
+	{/snippet}
+	{#snippet empty()}
+		<EmptyState title="No photos yet." description="Upload a photo to share with the league." />
+	{/snippet}
+	{#snippet children(ps)}
+		<DataTable
+			rows={ps}
+			{columns}
+			getKey={(p) => p.id}
+			caption="Photos"
+			filter
+			filterLabel="Filter photos"
+		/>
+	{/snippet}
+</AsyncSection>
 
 <style>
 	.thumb-img {

--- a/ui/src/routes/photos/[id]/+page.svelte
+++ b/ui/src/routes/photos/[id]/+page.svelte
@@ -2,6 +2,20 @@
 	import { onMount } from 'svelte';
 	import { page } from '$app/state';
 	import { goto } from '$app/navigation';
+	import { Async } from '$lib/async.svelte';
+	import { AsyncSection, PageHeader } from '$lib/components/app/index.js';
+	import { Alert, AlertDescription } from '$lib/components/ui/alert/index.js';
+	import {
+		AlertDialog,
+		AlertDialogAction,
+		AlertDialogCancel,
+		AlertDialogContent,
+		AlertDialogDescription,
+		AlertDialogFooter,
+		AlertDialogHeader,
+		AlertDialogTitle,
+		AlertDialogTrigger
+	} from '$lib/components/ui/alert-dialog/index.js';
 	import {
 		getPhoto,
 		updatePhoto,
@@ -17,19 +31,12 @@
 	import { Input } from '$lib/components/ui/input/index.js';
 	import { Label } from '$lib/components/ui/label/index.js';
 	import { NativeSelect, NativeSelectOption } from '$lib/components/ui/native-select/index.js';
-	import {
-		Popover,
-		PopoverClose,
-		PopoverContent,
-		PopoverHeader,
-		PopoverTitle,
-		PopoverTrigger
-	} from '$lib/components/ui/popover/index.js';
+	import { toast } from '$lib/toast';
+	import ImageIcon from '@lucide/svelte/icons/image';
 
 	const id = () => page.params.id as string;
 
-	let photo = $state<Photo | null>(null);
-	let loadError = $state('');
+	const photo = new Async<Photo>();
 	let altText = $state('');
 	let fileType = $state<PhotoType>(0);
 	let contents = $state('');
@@ -38,19 +45,14 @@
 	let deleting = $state(false);
 	let deleteOpen = $state(false);
 
-	onMount(load);
+	onMount(() => photo.run(load));
 
-	async function load() {
-		loadError = '';
-		try {
-			const p = await getPhoto(id());
-			photo = p;
-			altText = p.alt_text;
-			fileType = p.file_type;
-			contents = p.contents;
-		} catch (e) {
-			loadError = e instanceof Error ? e.message : 'Failed to load photo';
-		}
+	async function load(): Promise<Photo> {
+		const p = await getPhoto(id());
+		altText = p.alt_text;
+		fileType = p.file_type;
+		contents = p.contents;
+		return p;
 	}
 
 	function onFileChange(e: Event) {
@@ -82,10 +84,11 @@
 				contents,
 				file_type: fileType
 			});
-			photo = updated;
+			photo.data = updated;
 			altText = updated.alt_text;
 			fileType = updated.file_type;
 			contents = updated.contents;
+			toast.success('Photo saved');
 		} catch (err) {
 			error = err instanceof Error ? err.message : 'Failed to update photo';
 		} finally {
@@ -99,6 +102,7 @@
 		deleting = true;
 		try {
 			await deletePhoto(id());
+			toast.success('Photo deleted');
 			await goto('/photos');
 		} catch (err) {
 			error = err instanceof Error ? err.message : 'Failed to delete photo';
@@ -111,91 +115,90 @@
 	<title>Intraclub | Photo</title>
 </svelte:head>
 
-{#if loadError}
-	<h1 class="text-2xl font-semibold tracking-tight">Photo</h1>
-	<p class="text-sm font-medium text-destructive">{loadError}</p>
-	<a href="/photos" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to photos</a>
-{:else if !photo}
-	<h1 class="text-2xl font-semibold tracking-tight">Photo</h1>
-	<p class="text-muted-foreground">Loading...</p>
-{:else}
-	<div class="flex items-center gap-4">
-		<h1 class="text-2xl font-semibold tracking-tight">Photo</h1>
-		<a href="/photos" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to photos</a>
-	</div>
+<PageHeader title="Photo" icon={ImageIcon} backHref="/photos" backLabel="Back to photos" />
 
-	<img class="detail" src={dataUrlFor(photo)} alt={photo.alt_text || 'Photo'} />
+<AsyncSection state={photo}>
+	{#snippet children(p)}
+		<img class="detail" src={dataUrlFor(p)} alt={p.alt_text || 'Photo'} />
 
-	<dl class="meta">
-		<div>
-			<dt>Alt text</dt>
-			<dd>{photo.alt_text || '(none)'}</dd>
+		<dl class="meta">
+			<div>
+				<dt>Alt text</dt>
+				<dd>{p.alt_text || '(none)'}</dd>
+			</div>
+			<div>
+				<dt>File type</dt>
+				<dd>{photoTypeLabels[p.file_type] ?? 'unknown'}</dd>
+			</div>
+			<div>
+				<dt>Owner</dt>
+				<dd>{p.owner}</dd>
+			</div>
+		</dl>
+
+		<Card class="mt-6 max-w-md">
+			<CardHeader>
+				<CardTitle>Edit photo</CardTitle>
+			</CardHeader>
+			<CardContent>
+				<form onsubmit={handleSave} class="flex flex-col gap-4">
+					<div class="flex flex-col gap-2">
+						<Label for="altText">Alt text</Label>
+						<Input id="altText" type="text" bind:value={altText} />
+					</div>
+					<div class="flex flex-col gap-2">
+						<Label for="file">File</Label>
+						<Input id="file" type="file" accept="image/*" onchange={onFileChange} />
+					</div>
+					<div class="flex flex-col gap-2">
+						<Label for="fileType">File type</Label>
+						<NativeSelect id="fileType" bind:value={fileType} class="w-full">
+							<NativeSelectOption value={0}>png</NativeSelectOption>
+							<NativeSelectOption value={1}>jpg</NativeSelectOption>
+							<NativeSelectOption value={2}>jpeg</NativeSelectOption>
+							<NativeSelectOption value={3}>gif</NativeSelectOption>
+							<NativeSelectOption value={4}>webp</NativeSelectOption>
+						</NativeSelect>
+					</div>
+					<Button type="submit" disabled={saving} class="w-fit">
+						{saving ? 'Saving...' : 'Save changes'}
+					</Button>
+				</form>
+			</CardContent>
+		</Card>
+
+		{#if error}
+			<Alert variant="destructive" class="mt-4 max-w-md">
+				<AlertDescription>{error}</AlertDescription>
+			</Alert>
+		{/if}
+
+		<div class="mt-4">
+			<AlertDialog bind:open={deleteOpen}>
+				<AlertDialogTrigger
+					disabled={deleting}
+					class={buttonVariants({ variant: 'destructive' })}
+				>
+					{deleting ? 'Deleting...' : 'Delete photo'}
+				</AlertDialogTrigger>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Delete photo?</AlertDialogTitle>
+						<AlertDialogDescription>
+							This permanently removes this photo and cannot be undone.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel>Cancel</AlertDialogCancel>
+						<AlertDialogAction variant="destructive" onclick={handleDelete}>
+							Delete
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
 		</div>
-		<div>
-			<dt>File type</dt>
-			<dd>{photoTypeLabels[photo.file_type] ?? 'unknown'}</dd>
-		</div>
-		<div>
-			<dt>Owner</dt>
-			<dd>{photo.owner}</dd>
-		</div>
-	</dl>
-
-	<Card class="mt-6 max-w-md">
-		<CardHeader>
-			<CardTitle>Edit photo</CardTitle>
-		</CardHeader>
-		<CardContent>
-			<form onsubmit={handleSave} class="flex flex-col gap-4">
-				<div class="flex flex-col gap-2">
-					<Label for="altText">Alt text</Label>
-					<Input id="altText" type="text" bind:value={altText} />
-				</div>
-				<div class="flex flex-col gap-2">
-					<Label for="file">File</Label>
-					<Input id="file" type="file" accept="image/*" onchange={onFileChange} />
-				</div>
-				<div class="flex flex-col gap-2">
-					<Label for="fileType">File type</Label>
-					<NativeSelect id="fileType" bind:value={fileType} class="w-full">
-						<NativeSelectOption value={0}>png</NativeSelectOption>
-						<NativeSelectOption value={1}>jpg</NativeSelectOption>
-						<NativeSelectOption value={2}>jpeg</NativeSelectOption>
-						<NativeSelectOption value={3}>gif</NativeSelectOption>
-						<NativeSelectOption value={4}>webp</NativeSelectOption>
-					</NativeSelect>
-				</div>
-				<Button type="submit" disabled={saving} class="w-fit">
-					{saving ? 'Saving...' : 'Save changes'}
-				</Button>
-			</form>
-		</CardContent>
-	</Card>
-
-	<div class="mt-4">
-		<Popover bind:open={deleteOpen}>
-			<PopoverTrigger disabled={deleting} class={buttonVariants({ variant: 'destructive' })}>
-				{deleting ? 'Deleting...' : 'Delete photo'}
-			</PopoverTrigger>
-			<PopoverContent class="w-80">
-				<PopoverHeader>
-					<PopoverTitle>Delete photo?</PopoverTitle>
-					<p class="text-sm text-muted-foreground">
-						This permanently removes this photo and cannot be undone.
-					</p>
-				</PopoverHeader>
-				<div class="flex justify-end gap-2">
-					<PopoverClose class={buttonVariants({ variant: 'outline', size: 'sm' })}>Cancel</PopoverClose>
-					<Button variant="destructive" size="sm" onclick={handleDelete}>Delete</Button>
-				</div>
-			</PopoverContent>
-		</Popover>
-	</div>
-
-	{#if error}
-		<p class="mt-4 text-sm font-medium text-destructive">{error}</p>
-	{/if}
-{/if}
+	{/snippet}
+</AsyncSection>
 
 <style>
 	.detail {

--- a/ui/src/routes/photos/new/+page.svelte
+++ b/ui/src/routes/photos/new/+page.svelte
@@ -2,17 +2,22 @@
 	import { createPhoto, photoTypeFromExtension, photoTypeLabels } from '$lib/photo';
 	import { goto } from '$app/navigation';
 	import type { PhotoType } from '$lib/photo';
+	import { PageHeader } from '$lib/components/app/index.js';
+	import { Alert, AlertDescription } from '$lib/components/ui/alert/index.js';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
 	import { Label } from '$lib/components/ui/label/index.js';
 	import { NativeSelect, NativeSelectOption } from '$lib/components/ui/native-select/index.js';
+	import { toast } from '$lib/toast';
+	import ImageIcon from '@lucide/svelte/icons/image';
 
 	let altText = $state('');
 	let contents = $state('');
 	let fileType = $state<PhotoType>(0);
 	let error = $state('');
 	let submitting = $state(false);
+	let attempted = $state(false);
 
 	function onFileChange(e: Event) {
 		const input = e.target as HTMLInputElement;
@@ -35,6 +40,7 @@
 
 	async function handleSubmit(e: Event) {
 		e.preventDefault();
+		attempted = true;
 		error = '';
 		if (!contents) {
 			error = 'Please choose an image file to upload.';
@@ -43,6 +49,7 @@
 		submitting = true;
 		try {
 			const created = await createPhoto({ alt_text: altText, contents, file_type: fileType });
+			toast.success('Photo created');
 			await goto(`/photos/${created.id}`);
 		} catch (err) {
 			error = err instanceof Error ? err.message : 'Failed to create photo';
@@ -56,20 +63,29 @@
 	<title>Intraclub | New photo</title>
 </svelte:head>
 
-<div class="flex items-center gap-4">
-	<h1 class="text-2xl font-semibold tracking-tight">New photo</h1>
-	<a href="/photos" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to photos</a>
-</div>
+<PageHeader title="New photo" icon={ImageIcon} backHref="/photos" backLabel="Back to photos" />
 
 <Card class="mt-6 max-w-md">
 	<CardHeader>
 		<CardTitle>Upload a photo</CardTitle>
 	</CardHeader>
 	<CardContent>
+		{#if error}
+			<Alert variant="destructive" class="mb-4">
+				<AlertDescription>{error}</AlertDescription>
+			</Alert>
+		{/if}
 		<form onsubmit={handleSubmit} class="flex flex-col gap-4">
 			<div class="flex flex-col gap-2">
 				<Label for="file">File</Label>
-				<Input id="file" type="file" accept="image/*" onchange={onFileChange} required />
+				<Input
+					id="file"
+					type="file"
+					accept="image/*"
+					onchange={onFileChange}
+					required
+					aria-invalid={attempted && !contents}
+				/>
 			</div>
 			<div class="flex flex-col gap-2">
 				<Label for="altText">Alt text</Label>
@@ -91,7 +107,3 @@
 		</form>
 	</CardContent>
 </Card>
-
-{#if error}
-	<p class="mt-4 text-sm font-medium text-destructive">{error}</p>
-{/if}

--- a/ui/src/routes/playoff-structures/+page.svelte
+++ b/ui/src/routes/playoff-structures/+page.svelte
@@ -1,69 +1,67 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
+	import { Async } from '$lib/async.svelte';
+	import {
+		AsyncSection,
+		DataTable,
+		EmptyState,
+		PageHeader
+	} from '$lib/components/app/index.js';
+	import type { Column } from '$lib/components/app/data-table.svelte';
 	import { listPlayoffStructures } from '$lib/playoffStructure';
 	import type { PlayoffStructure } from '$lib/playoffStructure';
 	import { Button } from '$lib/components/ui/button/index.js';
-	import {
-		Table,
-		TableBody,
-		TableCell,
-		TableHead,
-		TableHeader,
-		TableRow
-	} from '$lib/components/ui/table/index.js';
+	import TrophyIcon from '@lucide/svelte/icons/trophy';
 
-	let structures = $state<PlayoffStructure[]>([]);
-	let loading = $state(true);
-	let error = $state('');
+	const structures = new Async<PlayoffStructure[]>();
+	onMount(() => structures.run(() => listPlayoffStructures()));
 
-	onMount(async () => {
-		try {
-			structures = await listPlayoffStructures();
-		} catch (e) {
-			error = e instanceof Error ? e.message : 'Failed to load playoff structures';
-		} finally {
-			loading = false;
-		}
-	});
+	const columns: Column<PlayoffStructure>[] = [
+		{ key: 'name', header: 'Playoff structure', sortable: true, cell: nameCell }
+	];
 </script>
+
+{#snippet nameCell(s: PlayoffStructure)}
+	<a
+		href={`/playoff-structures/${s.id}`}
+		class="font-medium text-primary underline-offset-4 hover:underline"
+	>
+		{s.byes} byes / {s.number_of_teams} teams
+	</a>
+{/snippet}
 
 <svelte:head>
 	<title>Intraclub | Playoff Structures</title>
 </svelte:head>
 
-<div class="flex items-center justify-between gap-4">
-	<h1 class="text-2xl font-semibold tracking-tight">Playoff Structures</h1>
-	<Button href="/playoff-structures/new">New playoff structure</Button>
-</div>
+<PageHeader
+	title="Playoff Structures"
+	description="Bracket shapes for the end-of-season tournament"
+	icon={TrophyIcon}
+>
+	{#snippet actions()}
+		<Button href="/playoff-structures/new">New playoff structure</Button>
+	{/snippet}
+</PageHeader>
 
-{#if loading}
-	<p class="text-muted-foreground">Loading...</p>
-{:else if error}
-	<p class="text-sm font-medium text-destructive">{error}</p>
-{:else if structures.length === 0}
-	<p class="text-muted-foreground">No playoff structures yet.</p>
-{:else}
-	<div class="mt-4 overflow-hidden rounded-lg border">
-		<Table>
-			<TableHeader>
-				<TableRow>
-					<TableHead>Playoff structure</TableHead>
-				</TableRow>
-			</TableHeader>
-			<TableBody>
-				{#each structures as structure}
-					<TableRow>
-						<TableCell>
-							<a
-								href={`/playoff-structures/${structure.id}`}
-								class="font-medium text-primary underline-offset-4 hover:underline"
-							>
-								{structure.byes} byes / {structure.number_of_teams} teams
-							</a>
-						</TableCell>
-					</TableRow>
-				{/each}
-			</TableBody>
-		</Table>
-	</div>
-{/if}
+<AsyncSection state={structures} isEmpty={(s) => s.length === 0}>
+	{#snippet loading()}
+		<DataTable rows={[]} {columns} getKey={(s) => s.id} loading />
+	{/snippet}
+	{#snippet empty()}
+		<EmptyState
+			title="No playoff structures yet."
+			description="Create a playoff structure to define how the post-season bracket is seeded."
+		/>
+	{/snippet}
+	{#snippet children(ss)}
+		<DataTable
+			rows={ss}
+			{columns}
+			getKey={(s) => s.id}
+			caption="Playoff structures"
+			filter
+			filterLabel="Filter playoff structures"
+		/>
+	{/snippet}
+</AsyncSection>

--- a/ui/src/routes/playoff-structures/[id]/+page.svelte
+++ b/ui/src/routes/playoff-structures/[id]/+page.svelte
@@ -2,6 +2,20 @@
 	import { onMount } from 'svelte';
 	import { page } from '$app/state';
 	import { goto } from '$app/navigation';
+	import { Async } from '$lib/async.svelte';
+	import { AsyncSection, PageHeader } from '$lib/components/app/index.js';
+	import { Alert, AlertDescription } from '$lib/components/ui/alert/index.js';
+	import {
+		AlertDialog,
+		AlertDialogAction,
+		AlertDialogCancel,
+		AlertDialogContent,
+		AlertDialogDescription,
+		AlertDialogFooter,
+		AlertDialogHeader,
+		AlertDialogTitle,
+		AlertDialogTrigger
+	} from '$lib/components/ui/alert-dialog/index.js';
 	import {
 		getPlayoffStructure,
 		updatePlayoffStructure,
@@ -12,19 +26,12 @@
 	import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
 	import { Label } from '$lib/components/ui/label/index.js';
-	import {
-		Popover,
-		PopoverClose,
-		PopoverContent,
-		PopoverHeader,
-		PopoverTitle,
-		PopoverTrigger
-	} from '$lib/components/ui/popover/index.js';
+	import { toast } from '$lib/toast';
+	import TrophyIcon from '@lucide/svelte/icons/trophy';
 
 	const id = () => page.params.id as string;
 
-	let structure = $state<PlayoffStructure | null>(null);
-	let loadError = $state('');
+	const structure = new Async<PlayoffStructure>();
 	let byes = $state<string>('');
 	let numberOfTeams = $state<string>('');
 	let error = $state('');
@@ -32,18 +39,13 @@
 	let deleting = $state(false);
 	let deleteOpen = $state(false);
 
-	onMount(load);
+	onMount(() => structure.run(load));
 
-	async function load() {
-		loadError = '';
-		try {
-			const s = await getPlayoffStructure(id());
-			structure = s;
-			byes = String(s.byes);
-			numberOfTeams = String(s.number_of_teams);
-		} catch (e) {
-			loadError = e instanceof Error ? e.message : 'Failed to load playoff structure';
-		}
+	async function load(): Promise<PlayoffStructure> {
+		const s = await getPlayoffStructure(id());
+		byes = String(s.byes);
+		numberOfTeams = String(s.number_of_teams);
+		return s;
 	}
 
 	async function handleSave(e: Event) {
@@ -55,9 +57,10 @@
 				byes: parseInt(byes || '0', 10),
 				number_of_teams: parseInt(numberOfTeams, 10)
 			});
-			structure = updated;
+			structure.data = updated;
 			byes = String(updated.byes);
 			numberOfTeams = String(updated.number_of_teams);
+			toast.success('Playoff structure saved');
 		} catch (err) {
 			error = err instanceof Error ? err.message : 'Failed to update playoff structure';
 		} finally {
@@ -71,6 +74,7 @@
 		deleting = true;
 		try {
 			await deletePlayoffStructure(id());
+			toast.success('Playoff structure deleted');
 			await goto('/playoff-structures');
 		} catch (err) {
 			// e.g. the structure is referenced by a Season and PreDelete blocks it
@@ -84,67 +88,71 @@
 	<title>Intraclub | Playoff Structure</title>
 </svelte:head>
 
-{#if loadError}
-	<h1 class="text-2xl font-semibold tracking-tight">Playoff Structure</h1>
-	<p class="text-sm font-medium text-destructive">{loadError}</p>
-	<a
-		href="/playoff-structures"
-		class="text-sm text-muted-foreground hover:text-foreground"
-	>&larr; Back to playoff structures</a>
-{:else if !structure}
-	<h1 class="text-2xl font-semibold tracking-tight">Playoff Structure</h1>
-	<p class="text-muted-foreground">Loading...</p>
-{:else}
-	<div class="flex items-center gap-4">
-		<h1 class="text-2xl font-semibold tracking-tight">Playoff Structure</h1>
-		<a
-			href="/playoff-structures"
-			class="text-sm text-muted-foreground hover:text-foreground"
-		>&larr; Back to playoff structures</a>
-	</div>
+<PageHeader
+	title="Playoff Structure"
+	icon={TrophyIcon}
+	backHref="/playoff-structures"
+	backLabel="Back to playoff structures"
+/>
 
-	<Card class="mt-6 max-w-md">
-		<CardHeader>
-			<CardTitle>Playoff structure details</CardTitle>
-		</CardHeader>
-		<CardContent>
-			<form onsubmit={handleSave} class="flex flex-col gap-4">
-				<div class="flex flex-col gap-2">
-					<Label for="byes">Byes</Label>
-					<Input id="byes" type="number" min="0" bind:value={byes} required />
-				</div>
-				<div class="flex flex-col gap-2">
-					<Label for="numberOfTeams">Number of teams</Label>
-					<Input id="numberOfTeams" type="number" min="2" bind:value={numberOfTeams} required />
-				</div>
-				<Button type="submit" disabled={saving} class="w-fit">
-					{saving ? 'Saving...' : 'Save changes'}
-				</Button>
-			</form>
-		</CardContent>
-	</Card>
+<AsyncSection state={structure}>
+	{#snippet children(s)}
+		<Card class="mt-6 max-w-md">
+			<CardHeader>
+				<CardTitle>Playoff structure details</CardTitle>
+			</CardHeader>
+			<CardContent>
+				<form onsubmit={handleSave} class="flex flex-col gap-4">
+					<div class="flex flex-col gap-2">
+						<Label for="byes">Byes</Label>
+						<Input id="byes" type="number" min="0" bind:value={byes} required />
+					</div>
+					<div class="flex flex-col gap-2">
+						<Label for="numberOfTeams">Number of teams</Label>
+						<Input
+							id="numberOfTeams"
+							type="number"
+							min="2"
+							bind:value={numberOfTeams}
+							required
+						/>
+					</div>
+					<Button type="submit" disabled={saving} class="w-fit">
+						{saving ? 'Saving...' : 'Save changes'}
+					</Button>
+				</form>
+			</CardContent>
+		</Card>
 
-	<div class="mt-4">
-		<Popover bind:open={deleteOpen}>
-			<PopoverTrigger disabled={deleting} class={buttonVariants({ variant: 'destructive' })}>
-				{deleting ? 'Deleting...' : 'Delete playoff structure'}
-			</PopoverTrigger>
-			<PopoverContent class="w-80">
-				<PopoverHeader>
-					<PopoverTitle>Delete playoff structure?</PopoverTitle>
-					<p class="text-sm text-muted-foreground">
-						This permanently removes this playoff structure and cannot be undone.
-					</p>
-				</PopoverHeader>
-				<div class="flex justify-end gap-2">
-					<PopoverClose class={buttonVariants({ variant: 'outline', size: 'sm' })}>Cancel</PopoverClose>
-					<Button variant="destructive" size="sm" onclick={handleDelete}>Delete</Button>
-				</div>
-			</PopoverContent>
-		</Popover>
-	</div>
+		{#if error}
+			<Alert variant="destructive" class="mt-4 max-w-md">
+				<AlertDescription>{error}</AlertDescription>
+			</Alert>
+		{/if}
 
-	{#if error}
-		<p class="mt-4 text-sm font-medium text-destructive">{error}</p>
-	{/if}
-{/if}
+		<div class="mt-4">
+			<AlertDialog bind:open={deleteOpen}>
+				<AlertDialogTrigger
+					disabled={deleting}
+					class={buttonVariants({ variant: 'destructive' })}
+				>
+					{deleting ? 'Deleting...' : 'Delete playoff structure'}
+				</AlertDialogTrigger>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Delete playoff structure?</AlertDialogTitle>
+						<AlertDialogDescription>
+							This permanently removes this playoff structure and cannot be undone.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel>Cancel</AlertDialogCancel>
+						<AlertDialogAction variant="destructive" onclick={handleDelete}>
+							Delete
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+		</div>
+	{/snippet}
+</AsyncSection>

--- a/ui/src/routes/playoff-structures/new/+page.svelte
+++ b/ui/src/routes/playoff-structures/new/+page.svelte
@@ -1,18 +1,24 @@
 <script lang="ts">
 	import { createPlayoffStructure } from '$lib/playoffStructure';
 	import { goto } from '$app/navigation';
+	import { PageHeader } from '$lib/components/app/index.js';
+	import { Alert, AlertDescription } from '$lib/components/ui/alert/index.js';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
 	import { Label } from '$lib/components/ui/label/index.js';
+	import { toast } from '$lib/toast';
+	import TrophyIcon from '@lucide/svelte/icons/trophy';
 
 	let byes = $state<string>('0');
 	let numberOfTeams = $state<string>('8');
 	let error = $state('');
 	let submitting = $state(false);
+	let attempted = $state(false);
 
 	async function handleSubmit(e: Event) {
 		e.preventDefault();
+		attempted = true;
 		error = '';
 		submitting = true;
 		try {
@@ -20,6 +26,7 @@
 				byes: parseInt(byes || '0', 10),
 				number_of_teams: parseInt(numberOfTeams, 10)
 			});
+			toast.success('Playoff structure created');
 			await goto(`/playoff-structures/${created.id}`);
 		} catch (err) {
 			error = err instanceof Error ? err.message : 'Failed to create playoff structure';
@@ -33,27 +40,45 @@
 	<title>Intraclub | New playoff structure</title>
 </svelte:head>
 
-<div class="flex items-center gap-4">
-	<h1 class="text-2xl font-semibold tracking-tight">New playoff structure</h1>
-	<a
-		href="/playoff-structures"
-		class="text-sm text-muted-foreground hover:text-foreground"
-	>&larr; Back to playoff structures</a>
-</div>
+<PageHeader
+	title="New playoff structure"
+	icon={TrophyIcon}
+	backHref="/playoff-structures"
+	backLabel="Back to playoff structures"
+/>
 
 <Card class="mt-6 max-w-md">
 	<CardHeader>
 		<CardTitle>Playoff structure details</CardTitle>
 	</CardHeader>
 	<CardContent>
+		{#if error}
+			<Alert variant="destructive" class="mb-4">
+				<AlertDescription>{error}</AlertDescription>
+			</Alert>
+		{/if}
 		<form onsubmit={handleSubmit} class="flex flex-col gap-4">
 			<div class="flex flex-col gap-2">
 				<Label for="byes">Byes</Label>
-				<Input id="byes" type="number" min="0" bind:value={byes} required />
+				<Input
+					id="byes"
+					type="number"
+					min="0"
+					bind:value={byes}
+					required
+					aria-invalid={attempted && !byes}
+				/>
 			</div>
 			<div class="flex flex-col gap-2">
 				<Label for="numberOfTeams">Number of teams</Label>
-				<Input id="numberOfTeams" type="number" min="2" bind:value={numberOfTeams} required />
+				<Input
+					id="numberOfTeams"
+					type="number"
+					min="2"
+					bind:value={numberOfTeams}
+					required
+					aria-invalid={attempted && !numberOfTeams}
+				/>
 			</div>
 			<Button type="submit" disabled={submitting} class="w-fit">
 				{submitting ? 'Creating...' : 'Create playoff structure'}
@@ -61,7 +86,3 @@
 		</form>
 	</CardContent>
 </Card>
-
-{#if error}
-	<p class="mt-4 text-sm font-medium text-destructive">{error}</p>
-{/if}

--- a/ui/src/routes/ratings/+page.svelte
+++ b/ui/src/routes/ratings/+page.svelte
@@ -1,68 +1,58 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
+	import { Async } from '$lib/async.svelte';
+	import {
+		AsyncSection,
+		DataTable,
+		EmptyState,
+		PageHeader
+	} from '$lib/components/app/index.js';
+	import type { Column } from '$lib/components/app/data-table.svelte';
 	import { listRatings } from '$lib/rating';
 	import type { Rating } from '$lib/rating';
 	import { Button } from '$lib/components/ui/button/index.js';
-	import {
-		Table,
-		TableBody,
-		TableCell,
-		TableHead,
-		TableHeader,
-		TableRow
-	} from '$lib/components/ui/table/index.js';
+	import StarIcon from '@lucide/svelte/icons/star';
 
-	let ratings = $state<Rating[]>([]);
-	let loading = $state(true);
-	let error = $state('');
+	const ratings = new Async<Rating[]>();
+	onMount(() => ratings.run(() => listRatings()));
 
-	onMount(async () => {
-		try {
-			ratings = await listRatings();
-		} catch (e) {
-			error = e instanceof Error ? e.message : 'Failed to load ratings';
-		} finally {
-			loading = false;
-		}
-	});
+	const columns: Column<Rating>[] = [
+		{ key: 'name', header: 'Name', sortable: true, cell: nameCell },
+		{ key: 'description', header: 'Description', hideBelow: 'sm', value: (r) => r.description }
+	];
 </script>
+
+{#snippet nameCell(r: Rating)}
+	<a href={`/ratings/${r.id}`} class="font-medium text-primary underline-offset-4 hover:underline">
+		{r.name}
+	</a>
+{/snippet}
 
 <svelte:head>
 	<title>Intraclub | Ratings</title>
 </svelte:head>
 
-<div class="flex items-center justify-between gap-4">
-	<h1 class="text-2xl font-semibold tracking-tight">Ratings</h1>
-	<Button href="/ratings/new">New rating</Button>
-</div>
+<PageHeader title="Ratings" description="The skill levels players can be assigned" icon={StarIcon}>
+	{#snippet actions()}
+		<Button href="/ratings/new">New rating</Button>
+	{/snippet}
+</PageHeader>
 
-{#if loading}
-	<p class="text-muted-foreground">Loading...</p>
-{:else if error}
-	<p class="text-sm font-medium text-destructive">{error}</p>
-{:else if ratings.length === 0}
-	<p class="text-muted-foreground">No ratings yet.</p>
-{:else}
-	<div class="mt-4 overflow-hidden rounded-lg border">
-		<Table>
-			<TableHeader>
-				<TableRow>
-					<TableHead>Name</TableHead>
-					<TableHead>Description</TableHead>
-				</TableRow>
-			</TableHeader>
-			<TableBody>
-				{#each ratings as rating}
-					<TableRow>
-						<TableCell>
-							<a href={`/ratings/${rating.id}`} class="font-medium text-primary underline-offset-4 hover:underline">
-								{rating.name}
-							</a>
-						</TableCell>
-						<TableCell>{rating.description}</TableCell>
-					</TableRow>
-				{/each}
-			</TableBody>
-		</Table>
-	</div>
-{/if}
+<AsyncSection state={ratings} isEmpty={(r) => r.length === 0}>
+	{#snippet loading()}
+		<DataTable rows={[]} {columns} getKey={(r) => r.id} loading />
+	{/snippet}
+	{#snippet empty()}
+		<EmptyState title="No ratings yet." description="Create ratings so formats can define player skill levels." />
+	{/snippet}
+	{#snippet children(rs)}
+		<DataTable
+			rows={rs}
+			{columns}
+			getKey={(r) => r.id}
+			caption="Ratings"
+			filter
+			filterLabel="Filter ratings"
+		/>
+	{/snippet}
+</AsyncSection>

--- a/ui/src/routes/ratings/[id]/+page.svelte
+++ b/ui/src/routes/ratings/[id]/+page.svelte
@@ -2,6 +2,20 @@
 	import { onMount } from 'svelte';
 	import { page } from '$app/state';
 	import { goto } from '$app/navigation';
+	import { Async } from '$lib/async.svelte';
+	import { AsyncSection, PageHeader } from '$lib/components/app/index.js';
+	import { Alert, AlertDescription } from '$lib/components/ui/alert/index.js';
+	import {
+		AlertDialog,
+		AlertDialogAction,
+		AlertDialogCancel,
+		AlertDialogContent,
+		AlertDialogDescription,
+		AlertDialogFooter,
+		AlertDialogHeader,
+		AlertDialogTitle,
+		AlertDialogTrigger
+	} from '$lib/components/ui/alert-dialog/index.js';
 	import { getRating, updateRating, deleteRating } from '$lib/rating';
 	import type { Rating } from '$lib/rating';
 	import { Button, buttonVariants } from '$lib/components/ui/button/index.js';
@@ -9,19 +23,12 @@
 	import { Input } from '$lib/components/ui/input/index.js';
 	import { Label } from '$lib/components/ui/label/index.js';
 	import { Textarea } from '$lib/components/ui/textarea/index.js';
-	import {
-		Popover,
-		PopoverClose,
-		PopoverContent,
-		PopoverHeader,
-		PopoverTitle,
-		PopoverTrigger
-	} from '$lib/components/ui/popover/index.js';
+	import { toast } from '$lib/toast';
+	import StarIcon from '@lucide/svelte/icons/star';
 
 	const id = () => page.params.id as string;
 
-	let rating = $state<Rating | null>(null);
-	let loadError = $state('');
+	const rating = new Async<Rating>();
 	let name = $state('');
 	let description = $state('');
 	let error = $state('');
@@ -29,18 +36,13 @@
 	let deleting = $state(false);
 	let deleteOpen = $state(false);
 
-	onMount(load);
+	onMount(() => rating.run(load));
 
-	async function load() {
-		loadError = '';
-		try {
-			const r = await getRating(id());
-			rating = r;
-			name = r.name;
-			description = r.description;
-		} catch (e) {
-			loadError = e instanceof Error ? e.message : 'Failed to load rating';
-		}
+	async function load(): Promise<Rating> {
+		const r = await getRating(id());
+		name = r.name;
+		description = r.description;
+		return r;
 	}
 
 	async function handleSave(e: Event) {
@@ -48,8 +50,12 @@
 		error = '';
 		saving = true;
 		try {
-			const updated = await updateRating(id(), { name: name.trim(), description: description.trim() });
-			rating = updated;
+			const updated = await updateRating(id(), {
+				name: name.trim(),
+				description: description.trim()
+			});
+			rating.data = updated;
+			toast.success('Rating saved');
 		} catch (err) {
 			error = err instanceof Error ? err.message : 'Failed to update rating';
 		} finally {
@@ -63,6 +69,7 @@
 		deleting = true;
 		try {
 			await deleteRating(id());
+			toast.success('Rating deleted');
 			await goto('/ratings');
 		} catch (err) {
 			// e.g. the rating is assigned to a Format and PreDelete blocks it
@@ -73,64 +80,68 @@
 </script>
 
 <svelte:head>
-	<title>Intraclub | {rating ? rating.name : 'Rating'}</title>
+	<title>Intraclub | {rating.data ? rating.data.name : 'Rating'}</title>
 </svelte:head>
 
-{#if loadError}
-	<h1 class="text-2xl font-semibold tracking-tight">Rating</h1>
-	<p class="text-sm font-medium text-destructive">{loadError}</p>
-	<a href="/ratings" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to ratings</a>
-{:else if !rating}
-	<h1 class="text-2xl font-semibold tracking-tight">Rating</h1>
-	<p class="text-muted-foreground">Loading...</p>
-{:else}
-	<div class="flex items-center gap-4">
-		<h1 class="text-2xl font-semibold tracking-tight">{rating.name}</h1>
-		<a href="/ratings" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to ratings</a>
-	</div>
+<PageHeader
+	title={rating.data?.name}
+	icon={StarIcon}
+	backHref="/ratings"
+	backLabel="Back to ratings"
+/>
 
-	<Card class="mt-6 max-w-md">
-		<CardHeader>
-			<CardTitle>Rating details</CardTitle>
-		</CardHeader>
-		<CardContent>
-			<form onsubmit={handleSave} class="flex flex-col gap-4">
-				<div class="flex flex-col gap-2">
-					<Label for="name">Name</Label>
-					<Input id="name" type="text" bind:value={name} required />
-				</div>
-				<div class="flex flex-col gap-2">
-					<Label for="description">Description</Label>
-					<Textarea id="description" bind:value={description} required />
-				</div>
-				<Button type="submit" disabled={saving} class="w-fit">
-					{saving ? 'Saving...' : 'Save changes'}
-				</Button>
-			</form>
-		</CardContent>
-	</Card>
+<AsyncSection state={rating}>
+	{#snippet children(r)}
+		<Card class="mt-6 max-w-md">
+			<CardHeader>
+				<CardTitle>Rating details</CardTitle>
+			</CardHeader>
+			<CardContent>
+				<form onsubmit={handleSave} class="flex flex-col gap-4">
+					<div class="flex flex-col gap-2">
+						<Label for="name">Name</Label>
+						<Input id="name" type="text" bind:value={name} required />
+					</div>
+					<div class="flex flex-col gap-2">
+						<Label for="description">Description</Label>
+						<Textarea id="description" bind:value={description} required />
+					</div>
+					<Button type="submit" disabled={saving} class="w-fit">
+						{saving ? 'Saving...' : 'Save changes'}
+					</Button>
+				</form>
+			</CardContent>
+		</Card>
 
-	<div class="mt-8">
-		<Popover bind:open={deleteOpen}>
-			<PopoverTrigger disabled={deleting} class={buttonVariants({ variant: 'destructive' })}>
-				{deleting ? 'Deleting...' : 'Delete rating'}
-			</PopoverTrigger>
-			<PopoverContent class="w-80">
-				<PopoverHeader>
-					<PopoverTitle>Delete rating?</PopoverTitle>
-					<p class="text-sm text-muted-foreground">
-						This permanently removes this rating and cannot be undone.
-					</p>
-				</PopoverHeader>
-				<div class="flex justify-end gap-2">
-					<PopoverClose class={buttonVariants({ variant: 'outline', size: 'sm' })}>Cancel</PopoverClose>
-					<Button variant="destructive" size="sm" onclick={handleDelete}>Delete</Button>
-				</div>
-			</PopoverContent>
-		</Popover>
-	</div>
+		{#if error}
+			<Alert variant="destructive" class="mt-4 max-w-md">
+				<AlertDescription>{error}</AlertDescription>
+			</Alert>
+		{/if}
 
-	{#if error}
-		<p class="mt-4 text-sm font-medium text-destructive">{error}</p>
-	{/if}
-{/if}
+		<div class="mt-8">
+			<AlertDialog bind:open={deleteOpen}>
+				<AlertDialogTrigger
+					disabled={deleting}
+					class={buttonVariants({ variant: 'destructive' })}
+				>
+					{deleting ? 'Deleting...' : 'Delete rating'}
+				</AlertDialogTrigger>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Delete rating?</AlertDialogTitle>
+						<AlertDialogDescription>
+							This permanently removes this rating and cannot be undone.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel>Cancel</AlertDialogCancel>
+						<AlertDialogAction variant="destructive" onclick={handleDelete}>
+							Delete
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+		</div>
+	{/snippet}
+</AsyncSection>

--- a/ui/src/routes/ratings/new/+page.svelte
+++ b/ui/src/routes/ratings/new/+page.svelte
@@ -1,23 +1,30 @@
 <script lang="ts">
 	import { createRating } from '$lib/rating';
 	import { goto } from '$app/navigation';
+	import { PageHeader } from '$lib/components/app/index.js';
+	import { Alert, AlertDescription } from '$lib/components/ui/alert/index.js';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
 	import { Label } from '$lib/components/ui/label/index.js';
 	import { Textarea } from '$lib/components/ui/textarea/index.js';
+	import { toast } from '$lib/toast';
+	import StarIcon from '@lucide/svelte/icons/star';
 
 	let name = $state('');
 	let description = $state('');
 	let error = $state('');
 	let submitting = $state(false);
+	let attempted = $state(false);
 
 	async function handleSubmit(e: Event) {
 		e.preventDefault();
+		attempted = true;
 		error = '';
 		submitting = true;
 		try {
 			const created = await createRating({ name: name.trim(), description: description.trim() });
+			toast.success('Rating created');
 			await goto(`/ratings/${created.id}`);
 		} catch (err) {
 			error = err instanceof Error ? err.message : 'Failed to create rating';
@@ -31,24 +38,37 @@
 	<title>Intraclub | New rating</title>
 </svelte:head>
 
-<div class="flex items-center gap-4">
-	<h1 class="text-2xl font-semibold tracking-tight">New rating</h1>
-	<a href="/ratings" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to ratings</a>
-</div>
+<PageHeader title="New rating" icon={StarIcon} backHref="/ratings" backLabel="Back to ratings" />
 
 <Card class="mt-6 max-w-md">
 	<CardHeader>
 		<CardTitle>Rating details</CardTitle>
 	</CardHeader>
 	<CardContent>
+		{#if error}
+			<Alert variant="destructive" class="mb-4">
+				<AlertDescription>{error}</AlertDescription>
+			</Alert>
+		{/if}
 		<form onsubmit={handleSubmit} class="flex flex-col gap-4">
 			<div class="flex flex-col gap-2">
 				<Label for="name">Name</Label>
-				<Input id="name" type="text" bind:value={name} required />
+				<Input
+					id="name"
+					type="text"
+					bind:value={name}
+					required
+					aria-invalid={attempted && !name.trim()}
+				/>
 			</div>
 			<div class="flex flex-col gap-2">
 				<Label for="description">Description</Label>
-				<Textarea id="description" bind:value={description} required />
+				<Textarea
+					id="description"
+					bind:value={description}
+					required
+					aria-invalid={attempted && !description.trim()}
+				/>
 			</div>
 			<Button type="submit" disabled={submitting} class="w-fit">
 				{submitting ? 'Creating...' : 'Create rating'}
@@ -56,7 +76,3 @@
 		</form>
 	</CardContent>
 </Card>
-
-{#if error}
-	<p class="mt-4 text-sm font-medium text-destructive">{error}</p>
-{/if}

--- a/ui/src/routes/rulesets/+page.svelte
+++ b/ui/src/routes/rulesets/+page.svelte
@@ -1,68 +1,58 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
+	import { Async } from '$lib/async.svelte';
+	import {
+		AsyncSection,
+		DataTable,
+		EmptyState,
+		PageHeader
+	} from '$lib/components/app/index.js';
+	import type { Column } from '$lib/components/app/data-table.svelte';
 	import { listRulesets } from '$lib/ruleset';
 	import type { Ruleset } from '$lib/ruleset';
 	import { Button } from '$lib/components/ui/button/index.js';
-	import {
-		Table,
-		TableBody,
-		TableCell,
-		TableHead,
-		TableHeader,
-		TableRow
-	} from '$lib/components/ui/table/index.js';
+	import ScrollTextIcon from '@lucide/svelte/icons/scroll-text';
 
-	let rulesets = $state<Ruleset[]>([]);
-	let loading = $state(true);
-	let error = $state('');
+	const rulesets = new Async<Ruleset[]>();
+	onMount(() => rulesets.run(() => listRulesets()));
 
-	onMount(async () => {
-		try {
-			rulesets = await listRulesets();
-		} catch (e) {
-			error = e instanceof Error ? e.message : 'Failed to load rulesets';
-		} finally {
-			loading = false;
-		}
-	});
+	const columns: Column<Ruleset>[] = [
+		{ key: 'name', header: 'Name', sortable: true, cell: nameCell },
+		{ key: 'revision', header: 'Revision', value: (r) => r.revision }
+	];
 </script>
+
+{#snippet nameCell(r: Ruleset)}
+	<a href={`/rulesets/${r.id}`} class="font-medium text-primary underline-offset-4 hover:underline">
+		{r.name}
+	</a>
+{/snippet}
 
 <svelte:head>
 	<title>Intraclub | Rulesets</title>
 </svelte:head>
 
-<div class="flex items-center justify-between gap-4">
-	<h1 class="text-2xl font-semibold tracking-tight">Rulesets</h1>
-	<Button href="/rulesets/new">New ruleset</Button>
-</div>
+<PageHeader title="Rulesets" description="The club's house rules, versioned by amendment" icon={ScrollTextIcon}>
+	{#snippet actions()}
+		<Button href="/rulesets/new">New ruleset</Button>
+	{/snippet}
+</PageHeader>
 
-{#if loading}
-	<p class="text-muted-foreground">Loading...</p>
-{:else if error}
-	<p class="text-sm font-medium text-destructive">{error}</p>
-{:else if rulesets.length === 0}
-	<p class="text-muted-foreground">No rulesets yet.</p>
-{:else}
-	<div class="mt-4 overflow-hidden rounded-lg border">
-		<Table>
-			<TableHeader>
-				<TableRow>
-					<TableHead>Name</TableHead>
-					<TableHead>Revision</TableHead>
-				</TableRow>
-			</TableHeader>
-			<TableBody>
-				{#each rulesets as ruleset}
-					<TableRow>
-						<TableCell>
-							<a href={`/rulesets/${ruleset.id}`} class="font-medium text-primary underline-offset-4 hover:underline">
-								{ruleset.name}
-							</a>
-						</TableCell>
-						<TableCell>{ruleset.revision}</TableCell>
-					</TableRow>
-				{/each}
-			</TableBody>
-		</Table>
-	</div>
-{/if}
+<AsyncSection state={rulesets} isEmpty={(r) => r.length === 0}>
+	{#snippet loading()}
+		<DataTable rows={[]} {columns} getKey={(r) => r.id} loading />
+	{/snippet}
+	{#snippet empty()}
+		<EmptyState title="No rulesets yet." description="Create a ruleset to codify the club's rules." />
+	{/snippet}
+	{#snippet children(rs)}
+		<DataTable
+			rows={rs}
+			{columns}
+			getKey={(r) => r.id}
+			caption="Rulesets"
+			filter
+			filterLabel="Filter rulesets"
+		/>
+	{/snippet}
+</AsyncSection>

--- a/ui/src/routes/rulesets/[id]/+page.svelte
+++ b/ui/src/routes/rulesets/[id]/+page.svelte
@@ -1,6 +1,20 @@
 <script lang="ts">
 	import { page } from '$app/state';
 	import { goto } from '$app/navigation';
+	import { Async } from '$lib/async.svelte';
+	import { AsyncSection, PageHeader } from '$lib/components/app/index.js';
+	import { Alert, AlertDescription } from '$lib/components/ui/alert/index.js';
+	import {
+		AlertDialog,
+		AlertDialogAction,
+		AlertDialogCancel,
+		AlertDialogContent,
+		AlertDialogDescription,
+		AlertDialogFooter,
+		AlertDialogHeader,
+		AlertDialogTitle,
+		AlertDialogTrigger
+	} from '$lib/components/ui/alert-dialog/index.js';
 	import {
 		getRuleset,
 		amendRulesetName,
@@ -19,21 +33,14 @@
 	import { Input } from '$lib/components/ui/input/index.js';
 	import { Label } from '$lib/components/ui/label/index.js';
 	import { Textarea } from '$lib/components/ui/textarea/index.js';
-	import {
-		Popover,
-		PopoverClose,
-		PopoverContent,
-		PopoverHeader,
-		PopoverTitle,
-		PopoverTrigger
-	} from '$lib/components/ui/popover/index.js';
+	import { toast } from '$lib/toast';
+	import ScrollTextIcon from '@lucide/svelte/icons/scroll-text';
 
 	// Derived from the route param so the page re-loads when navigating between
 	// ruleset revisions (same [id] route, different id).
 	const currentId = $derived(page.params.id as string);
 
-	let ruleset = $state<Ruleset | null>(null);
-	let loadError = $state('');
+	const ruleset = new Async<Ruleset>();
 	let name = $state('');
 	let error = $state('');
 	let saving = $state(false);
@@ -51,20 +58,15 @@
 	let editMarkdown = $state('');
 
 	$effect(() => {
-		load(currentId);
+		ruleset.run(() => load(currentId));
 	});
 
-	async function load(idToLoad: string) {
-		loadError = '';
-		ruleset = null;
-		try {
-			const r = await getRuleset(idToLoad);
-			ruleset = r;
-			name = r.name;
-			await loadSections(idToLoad);
-		} catch (e) {
-			loadError = e instanceof Error ? e.message : 'Failed to load ruleset';
-		}
+	async function load(idToLoad: string): Promise<Ruleset> {
+		ruleset.data = undefined;
+		const r = await getRuleset(idToLoad);
+		name = r.name;
+		await loadSections(idToLoad);
+		return r;
 	}
 
 	async function loadSections(idToLoad: string) {
@@ -95,6 +97,7 @@
 		saving = true;
 		try {
 			const amended = await amendRulesetName(currentId, name.trim());
+			toast.success('Ruleset saved');
 			await goto(`/rulesets/${amended.id}`);
 		} catch (err) {
 			error = err instanceof Error ? err.message : 'Failed to update ruleset';
@@ -109,6 +112,7 @@
 		deleting = true;
 		try {
 			await deleteRuleset(currentId);
+			toast.success('Ruleset deleted');
 			await goto('/rulesets');
 		} catch (err) {
 			error = err instanceof Error ? err.message : 'Failed to delete ruleset';
@@ -220,203 +224,214 @@
 </script>
 
 <svelte:head>
-	<title>Intraclub | {ruleset ? ruleset.name : 'Ruleset'}</title>
+	<title>Intraclub | {ruleset.data ? ruleset.data.name : 'Ruleset'}</title>
 </svelte:head>
 
-{#if loadError}
-	<h1 class="text-2xl font-semibold tracking-tight">Ruleset</h1>
-	<p class="text-sm font-medium text-destructive">{loadError}</p>
-	<a href="/rulesets" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to rulesets</a>
-{:else if !ruleset}
-	<h1 class="text-2xl font-semibold tracking-tight">Ruleset</h1>
-	<p class="text-muted-foreground">Loading...</p>
-{:else}
-	<div class="flex items-center gap-4">
-		<h1 class="text-2xl font-semibold tracking-tight">{ruleset.name}</h1>
-		<a href="/rulesets" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to rulesets</a>
-	</div>
+<PageHeader
+	title={ruleset.data?.name}
+	icon={ScrollTextIcon}
+	backHref="/rulesets"
+	backLabel="Back to rulesets"
+/>
 
-	<dl class="meta">
-		<div>
-			<dt>Revision</dt>
-			<dd>{ruleset.revision}</dd>
-		</div>
-		<div>
-			<dt>Date</dt>
-			<dd>{new Date(ruleset.date).toLocaleString()}</dd>
-		</div>
-		<div>
-			<dt>Superseded by</dt>
-			<dd>
-				{#if ruleset.superseded_by}
-					<a href={`/rulesets/${ruleset.superseded_by}`}>{ruleset.superseded_by}</a>
+<AsyncSection state={ruleset}>
+	{#snippet children(r)}
+		<dl class="meta">
+			<div>
+				<dt>Revision</dt>
+				<dd>{r.revision}</dd>
+			</div>
+			<div>
+				<dt>Date</dt>
+				<dd>{new Date(r.date).toLocaleString()}</dd>
+			</div>
+			<div>
+				<dt>Superseded by</dt>
+				<dd>
+					{#if r.superseded_by}
+						<a href={`/rulesets/${r.superseded_by}`}>{r.superseded_by}</a>
+					{:else}
+						— (current revision)
+					{/if}
+				</dd>
+			</div>
+		</dl>
+
+		<Card class="mt-6 max-w-md">
+			<CardHeader>
+				<CardTitle>Edit</CardTitle>
+			</CardHeader>
+			<CardContent>
+				<p class="hint text-sm text-muted-foreground">
+					Saving edits amends this ruleset and creates a new revision.
+				</p>
+				<form onsubmit={handleSave} class="flex flex-col gap-4">
+					<div class="flex flex-col gap-2">
+						<Label for="name">Name</Label>
+						<Input id="name" type="text" bind:value={name} required />
+					</div>
+					<Button type="submit" disabled={saving} class="w-fit">
+						{saving ? 'Saving...' : 'Save changes'}
+					</Button>
+				</form>
+			</CardContent>
+		</Card>
+
+		<Card class="mt-6">
+			<CardHeader>
+				<CardTitle>Sections</CardTitle>
+			</CardHeader>
+			<CardContent class="flex flex-col gap-4">
+				{#if sections.length === 0}
+					<p class="text-sm text-muted-foreground">This ruleset has no sections yet.</p>
 				{:else}
-					— (current revision)
-				{/if}
-			</dd>
-		</div>
-	</dl>
-
-	<Card class="mt-6 max-w-md">
-		<CardHeader>
-			<CardTitle>Edit</CardTitle>
-		</CardHeader>
-		<CardContent>
-			<p class="hint text-sm text-muted-foreground">
-				Saving edits amends this ruleset and creates a new revision.
-			</p>
-			<form onsubmit={handleSave} class="flex flex-col gap-4">
-				<div class="flex flex-col gap-2">
-					<Label for="name">Name</Label>
-					<Input id="name" type="text" bind:value={name} required />
-				</div>
-				<Button type="submit" disabled={saving} class="w-fit">
-					{saving ? 'Saving...' : 'Save changes'}
-				</Button>
-			</form>
-		</CardContent>
-	</Card>
-
-	<Card class="mt-6">
-		<CardHeader>
-			<CardTitle>Sections</CardTitle>
-		</CardHeader>
-		<CardContent class="flex flex-col gap-4">
-			{#if sections.length === 0}
-				<p class="text-sm text-muted-foreground">This ruleset has no sections yet.</p>
-			{:else}
-				<ol class="flex flex-col gap-3">
-					{#each sections as section, i (section.section_id)}
-						<li class="section-card">
-							<div class="flex items-center justify-between gap-2">
-								<span class="font-medium">
-									{i + 1}. {section.title || '(untitled)'}
-								</span>
-								<div class="flex items-center gap-1">
-									<Button
-										variant="outline"
-										size="sm"
-										disabled={sectionSaving || i === 0}
-										onclick={() => moveUp(section)}
-									>
-										&uarr;
-									</Button>
-									<Button
-										variant="outline"
-										size="sm"
-										disabled={sectionSaving || i === sections.length - 1}
-										onclick={() => moveDown(section)}
-									>
-										&darr;
-									</Button>
-									<Button variant="outline" size="sm" onclick={() => startEdit(section)}>
-										Edit
-									</Button>
-									<Button
-										variant="destructive"
-										size="sm"
-										disabled={sectionSaving}
-										onclick={() => handleRemove(section)}
-									>
-										Remove
-									</Button>
+					<ol class="flex flex-col gap-3">
+						{#each sections as section, i (section.section_id)}
+							<li class="section-card">
+								<div class="flex items-center justify-between gap-2">
+									<span class="font-medium">
+										{i + 1}. {section.title || '(untitled)'}
+									</span>
+									<div class="flex items-center gap-1">
+										<Button
+											variant="outline"
+											size="sm"
+											disabled={sectionSaving || i === 0}
+											onclick={() => moveUp(section)}
+										>
+											&uarr;
+										</Button>
+										<Button
+											variant="outline"
+											size="sm"
+											disabled={sectionSaving || i === sections.length - 1}
+											onclick={() => moveDown(section)}
+										>
+											&darr;
+										</Button>
+										<Button variant="outline" size="sm" onclick={() => startEdit(section)}>
+											Edit
+										</Button>
+										<Button
+											variant="destructive"
+											size="sm"
+											disabled={sectionSaving}
+											onclick={() => handleRemove(section)}
+										>
+											Remove
+										</Button>
+									</div>
 								</div>
-							</div>
 
-							{#if editingId === section.section_id}
-								<form
-									onsubmit={(e) => {
-										e.preventDefault();
-										handleEditSave();
-									}}
-									class="mt-3 flex flex-col gap-3"
-								>
-									<div class="flex flex-col gap-2">
-										<Label for={`edit-title-${section.section_id}`}>Title</Label>
-										<Input
-											id={`edit-title-${section.section_id}`}
-											type="text"
-											bind:value={editTitle}
-										/>
-									</div>
-									<div class="flex flex-col gap-2">
-										<Label for={`edit-markdown-${section.section_id}`}>Contents</Label>
-										<Textarea
-											id={`edit-markdown-${section.section_id}`}
-											bind:value={editMarkdown}
-											rows={4}
-										/>
-									</div>
-									<div class="flex gap-2">
-										<Button type="submit" size="sm" disabled={sectionSaving}>
-											Save section
-										</Button>
-										<Button variant="outline" size="sm" type="button" onclick={cancelEdit}>
-											Cancel
-										</Button>
-									</div>
-								</form>
-							{:else}
-								{#if section.markdown}
-									<p class="section-contents">{section.markdown}</p>
+								{#if editingId === section.section_id}
+									<form
+										onsubmit={(e) => {
+											e.preventDefault();
+											handleEditSave();
+										}}
+										class="mt-3 flex flex-col gap-3"
+									>
+										<div class="flex flex-col gap-2">
+											<Label for={`edit-title-${section.section_id}`}>Title</Label>
+											<Input
+												id={`edit-title-${section.section_id}`}
+												type="text"
+												bind:value={editTitle}
+											/>
+										</div>
+										<div class="flex flex-col gap-2">
+											<Label for={`edit-markdown-${section.section_id}`}>Contents</Label>
+											<Textarea
+												id={`edit-markdown-${section.section_id}`}
+												bind:value={editMarkdown}
+												rows={4}
+											/>
+										</div>
+										<div class="flex gap-2">
+											<Button type="submit" size="sm" disabled={sectionSaving}>
+												Save section
+											</Button>
+											<Button variant="outline" size="sm" type="button" onclick={cancelEdit}>
+												Cancel
+											</Button>
+										</div>
+									</form>
+								{:else}
+									{#if section.markdown}
+										<p class="section-contents">{section.markdown}</p>
+									{/if}
 								{/if}
-							{/if}
-						</li>
-					{/each}
-				</ol>
-			{/if}
+							</li>
+						{/each}
+					</ol>
+				{/if}
 
-			<form onsubmit={handleAdd} class="flex flex-col gap-3 border-t pt-4">
-				<p class="text-sm font-medium">Add a section</p>
-				<div class="flex flex-col gap-2">
-					<Label for="add-title">Title</Label>
-					<Input id="add-title" type="text" bind:value={addTitle} placeholder="e.g. Eligibility" />
-				</div>
-				<div class="flex flex-col gap-2">
-					<Label for="add-markdown">Contents</Label>
-					<Textarea
-						id="add-markdown"
-						bind:value={addMarkdown}
-						rows={4}
-						placeholder="Rule text"
-						required
-					/>
-				</div>
-				<Button type="submit" class="w-fit" disabled={sectionSaving}>
-					{sectionSaving ? 'Saving...' : 'Add section'}
-				</Button>
-			</form>
+				<form onsubmit={handleAdd} class="flex flex-col gap-3 border-t pt-4">
+					<p class="text-sm font-medium">Add a section</p>
+					<div class="flex flex-col gap-2">
+						<Label for="add-title">Title</Label>
+						<Input
+							id="add-title"
+							type="text"
+							bind:value={addTitle}
+							placeholder="e.g. Eligibility"
+						/>
+					</div>
+					<div class="flex flex-col gap-2">
+						<Label for="add-markdown">Contents</Label>
+						<Textarea
+							id="add-markdown"
+							bind:value={addMarkdown}
+							rows={4}
+							placeholder="Rule text"
+							required
+						/>
+					</div>
+					<Button type="submit" class="w-fit" disabled={sectionSaving}>
+						{sectionSaving ? 'Saving...' : 'Add section'}
+					</Button>
+				</form>
 
-			{#if sectionError}
-				<p class="text-sm font-medium text-destructive">{sectionError}</p>
-			{/if}
-		</CardContent>
-	</Card>
+				{#if sectionError}
+					<Alert variant="destructive">
+						<AlertDescription>{sectionError}</AlertDescription>
+					</Alert>
+				{/if}
+			</CardContent>
+		</Card>
 
-	<div class="mt-4">
-		<Popover bind:open={deleteOpen}>
-			<PopoverTrigger disabled={deleting} class={buttonVariants({ variant: 'destructive' })}>
-				{deleting ? 'Deleting...' : 'Delete ruleset'}
-			</PopoverTrigger>
-			<PopoverContent class="w-80">
-				<PopoverHeader>
-					<PopoverTitle>Delete ruleset?</PopoverTitle>
-					<p class="text-sm text-muted-foreground">
-						This permanently removes this ruleset and cannot be undone.
-					</p>
-				</PopoverHeader>
-				<div class="flex justify-end gap-2">
-					<PopoverClose class={buttonVariants({ variant: 'outline', size: 'sm' })}>Cancel</PopoverClose>
-					<Button variant="destructive" size="sm" onclick={handleDelete}>Delete</Button>
-				</div>
-			</PopoverContent>
-		</Popover>
-	</div>
+		{#if error}
+			<Alert variant="destructive" class="mt-4 max-w-md">
+				<AlertDescription>{error}</AlertDescription>
+			</Alert>
+		{/if}
 
-	{#if error}
-		<p class="mt-4 text-sm font-medium text-destructive">{error}</p>
-	{/if}
-{/if}
+		<div class="mt-4">
+			<AlertDialog bind:open={deleteOpen}>
+				<AlertDialogTrigger
+					disabled={deleting}
+					class={buttonVariants({ variant: 'destructive' })}
+				>
+					{deleting ? 'Deleting...' : 'Delete ruleset'}
+				</AlertDialogTrigger>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Delete ruleset?</AlertDialogTitle>
+						<AlertDialogDescription>
+							This permanently removes this ruleset and cannot be undone.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel>Cancel</AlertDialogCancel>
+						<AlertDialogAction variant="destructive" onclick={handleDelete}>
+							Delete
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+		</div>
+	{/snippet}
+</AsyncSection>
 
 <style>
 	.meta {

--- a/ui/src/routes/rulesets/new/+page.svelte
+++ b/ui/src/routes/rulesets/new/+page.svelte
@@ -1,21 +1,28 @@
 <script lang="ts">
 	import { createRuleset } from '$lib/ruleset';
 	import { goto } from '$app/navigation';
+	import { PageHeader } from '$lib/components/app/index.js';
+	import { Alert, AlertDescription } from '$lib/components/ui/alert/index.js';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
 	import { Label } from '$lib/components/ui/label/index.js';
+	import { toast } from '$lib/toast';
+	import ScrollTextIcon from '@lucide/svelte/icons/scroll-text';
 
 	let name = $state('');
 	let error = $state('');
 	let submitting = $state(false);
+	let attempted = $state(false);
 
 	async function handleSubmit(e: Event) {
 		e.preventDefault();
+		attempted = true;
 		error = '';
 		submitting = true;
 		try {
 			const created = await createRuleset(name.trim());
+			toast.success('Ruleset created');
 			await goto(`/rulesets/${created.id}`);
 		} catch (err) {
 			error = err instanceof Error ? err.message : 'Failed to create ruleset';
@@ -29,20 +36,28 @@
 	<title>Intraclub | New ruleset</title>
 </svelte:head>
 
-<div class="flex items-center gap-4">
-	<h1 class="text-2xl font-semibold tracking-tight">New ruleset</h1>
-	<a href="/rulesets" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to rulesets</a>
-</div>
+<PageHeader title="New ruleset" icon={ScrollTextIcon} backHref="/rulesets" backLabel="Back to rulesets" />
 
 <Card class="mt-6 max-w-md">
 	<CardHeader>
 		<CardTitle>Ruleset details</CardTitle>
 	</CardHeader>
 	<CardContent>
+		{#if error}
+			<Alert variant="destructive" class="mb-4">
+				<AlertDescription>{error}</AlertDescription>
+			</Alert>
+		{/if}
 		<form onsubmit={handleSubmit} class="flex flex-col gap-4">
 			<div class="flex flex-col gap-2">
 				<Label for="name">Name</Label>
-				<Input id="name" type="text" bind:value={name} required />
+				<Input
+					id="name"
+					type="text"
+					bind:value={name}
+					required
+					aria-invalid={attempted && !name.trim()}
+				/>
 			</div>
 			<Button type="submit" disabled={submitting} class="w-fit">
 				{submitting ? 'Creating...' : 'Create ruleset'}
@@ -50,7 +65,3 @@
 		</form>
 	</CardContent>
 </Card>
-
-{#if error}
-	<p class="mt-4 text-sm font-medium text-destructive">{error}</p>
-{/if}

--- a/ui/src/routes/scoring-structures/+page.svelte
+++ b/ui/src/routes/scoring-structures/+page.svelte
@@ -1,81 +1,87 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
+	import { Async } from '$lib/async.svelte';
+	import {
+		AsyncSection,
+		DataTable,
+		EmptyState,
+		PageHeader
+	} from '$lib/components/app/index.js';
+	import type { Column } from '$lib/components/app/data-table.svelte';
 	import { listScoringStructures, getScoreCountingTypes } from '$lib/scoringStructure';
 	import type { ScoringStructure, ScoreCountingType } from '$lib/scoringStructure';
 	import { Button } from '$lib/components/ui/button/index.js';
-	import {
-		Table,
-		TableBody,
-		TableCell,
-		TableHead,
-		TableHeader,
-		TableRow
-	} from '$lib/components/ui/table/index.js';
+	import GaugeIcon from '@lucide/svelte/icons/gauge';
 
-	let structures = $state<ScoringStructure[]>([]);
 	let countingTypes = $state<ScoreCountingType[]>([]);
-	let loading = $state(true);
-	let error = $state('');
+	const structures = new Async<ScoringStructure[]>();
+	onMount(() =>
+		structures.run(async () => {
+			const [ss, cts] = await Promise.all([listScoringStructures(), getScoreCountingTypes()]);
+			countingTypes = cts;
+			return ss;
+		})
+	);
 
 	function countingTypeName(type: number): string {
 		return countingTypes.find((t) => t.type === type)?.name ?? String(type);
 	}
 
-	onMount(async () => {
-		try {
-			[structures, countingTypes] = await Promise.all([
-				listScoringStructures(),
-				getScoreCountingTypes()
-			]);
-		} catch (e) {
-			error = e instanceof Error ? e.message : 'Failed to load scoring structures';
-		} finally {
-			loading = false;
+	const columns: Column<ScoringStructure>[] = [
+		{ key: 'name', header: 'Name', sortable: true, cell: nameCell },
+		{
+			key: 'counting_type',
+			header: 'Counting type',
+			hideBelow: 'sm',
+			value: (s) => countingTypeName(s.win_condition_counting_type)
+		},
+		{
+			key: 'win_threshold',
+			header: 'Win threshold',
+			align: 'right',
+			value: (s) => s.win_condition.win_threshold
 		}
-	});
+	];
 </script>
+
+{#snippet nameCell(s: ScoringStructure)}
+	<a href={`/scoring-structures/${s.id}`} class="font-medium text-primary underline-offset-4 hover:underline">
+		{s.name}
+	</a>
+{/snippet}
 
 <svelte:head>
 	<title>Intraclub | Scoring Structures</title>
 </svelte:head>
 
-<div class="flex items-center justify-between gap-4">
-	<h1 class="text-2xl font-semibold tracking-tight">Scoring Structures</h1>
-	<Button href="/scoring-structures/new">New scoring structure</Button>
-</div>
+<PageHeader
+	title="Scoring Structures"
+	description="How matches are scored and won"
+	icon={GaugeIcon}
+>
+	{#snippet actions()}
+		<Button href="/scoring-structures/new">New scoring structure</Button>
+	{/snippet}
+</PageHeader>
 
-{#if loading}
-	<p class="text-muted-foreground">Loading...</p>
-{:else if error}
-	<p class="text-sm font-medium text-destructive">{error}</p>
-{:else if structures.length === 0}
-	<p class="text-muted-foreground">No scoring structures yet.</p>
-{:else}
-	<div class="mt-4 overflow-hidden rounded-lg border">
-		<Table>
-			<TableHeader>
-				<TableRow>
-					<TableHead>Name</TableHead>
-					<TableHead>Counting type</TableHead>
-					<TableHead>Win threshold</TableHead>
-				</TableRow>
-			</TableHeader>
-			<TableBody>
-				{#each structures as structure}
-					<TableRow>
-						<TableCell>
-							<a
-								href={`/scoring-structures/${structure.id}`}
-								class="font-medium text-primary underline-offset-4 hover:underline"
-							>
-								{structure.name}
-							</a>
-						</TableCell>
-						<TableCell>{countingTypeName(structure.win_condition_counting_type)}</TableCell>
-						<TableCell>{structure.win_condition.win_threshold}</TableCell>
-					</TableRow>
-				{/each}
-			</TableBody>
-		</Table>
-	</div>
-{/if}
+<AsyncSection state={structures} isEmpty={(s) => s.length === 0}>
+	{#snippet loading()}
+		<DataTable rows={[]} {columns} getKey={(s) => s.id} loading />
+	{/snippet}
+	{#snippet empty()}
+		<EmptyState
+			title="No scoring structures yet."
+			description="Create a scoring structure to define how matches are won."
+		/>
+	{/snippet}
+	{#snippet children(ss)}
+		<DataTable
+			rows={ss}
+			{columns}
+			getKey={(s) => s.id}
+			caption="Scoring structures"
+			filter
+			filterLabel="Filter scoring structures"
+		/>
+	{/snippet}
+</AsyncSection>

--- a/ui/src/routes/scoring-structures/[id]/+page.svelte
+++ b/ui/src/routes/scoring-structures/[id]/+page.svelte
@@ -2,6 +2,20 @@
 	import { onMount } from 'svelte';
 	import { page } from '$app/state';
 	import { goto } from '$app/navigation';
+	import { Async } from '$lib/async.svelte';
+	import { AsyncSection, PageHeader } from '$lib/components/app/index.js';
+	import { Alert, AlertDescription } from '$lib/components/ui/alert/index.js';
+	import {
+		AlertDialog,
+		AlertDialogAction,
+		AlertDialogCancel,
+		AlertDialogContent,
+		AlertDialogDescription,
+		AlertDialogFooter,
+		AlertDialogHeader,
+		AlertDialogTitle,
+		AlertDialogTrigger
+	} from '$lib/components/ui/alert-dialog/index.js';
 	import {
 		getScoringStructure,
 		getScoreCountingTypes,
@@ -21,20 +35,13 @@
 	import { Input } from '$lib/components/ui/input/index.js';
 	import { Label } from '$lib/components/ui/label/index.js';
 	import { NativeSelect, NativeSelectOption } from '$lib/components/ui/native-select/index.js';
-	import {
-		Popover,
-		PopoverClose,
-		PopoverContent,
-		PopoverHeader,
-		PopoverTitle,
-		PopoverTrigger
-	} from '$lib/components/ui/popover/index.js';
+	import { toast } from '$lib/toast';
+	import GaugeIcon from '@lucide/svelte/icons/gauge';
 
 	const id = () => page.params.id as string;
 
-	let structure = $state<ScoringStructure | null>(null);
+	const structure = new Async<ScoringStructure>();
 	let countingTypes = $state<ScoreCountingType[]>([]);
-	let loadError = $state('');
 	let name = $state('');
 	let countingType = $state<number>(0);
 	let winThreshold = $state<string>('');
@@ -106,27 +113,22 @@
 		try {
 			countingTypes = await getScoreCountingTypes();
 		} catch (e) {
-			loadError = e instanceof Error ? e.message : 'Failed to load score counting types';
+			structure.error = e instanceof Error ? e.message : 'Failed to load score counting types';
+			structure.status = 'error';
 			return;
 		}
-		load();
+		structure.run(load);
 	});
 
-	async function load() {
-		loadError = '';
-		try {
-			const s = await getScoringStructure(id());
-			structure = s;
-			name = s.name;
-			countingType = s.win_condition_counting_type;
-			winThreshold = String(s.win_condition.win_threshold);
-			mustWinBy = String(s.win_condition.must_win_by);
-			instantWinThreshold = String(s.win_condition.instant_win_threshold);
-		} catch (e) {
-			loadError = e instanceof Error ? e.message : 'Failed to load scoring structure';
-			return;
-		}
+	async function load(): Promise<ScoringStructure> {
+		const s = await getScoringStructure(id());
+		name = s.name;
+		countingType = s.win_condition_counting_type;
+		winThreshold = String(s.win_condition.win_threshold);
+		mustWinBy = String(s.win_condition.must_win_by);
+		instantWinThreshold = String(s.win_condition.instant_win_threshold);
 		await loadSecondaries();
+		return s;
 	}
 
 	async function loadSecondaries() {
@@ -153,6 +155,7 @@
 				draftSecondaries.map((s) => s.id)
 			);
 			draftSecondaries = secondaries;
+			toast.success('Secondaries saved');
 		} catch (err) {
 			secondariesError = err instanceof Error ? err.message : 'Failed to update secondary scoring structures';
 		} finally {
@@ -193,7 +196,8 @@
 					instant_win_threshold: parseInt(instantWinThreshold || '0', 10)
 				}
 			});
-			structure = updated;
+			structure.data = updated;
+			toast.success('Scoring structure saved');
 		} catch (err) {
 			error = err instanceof Error ? err.message : 'Failed to update scoring structure';
 		} finally {
@@ -207,6 +211,7 @@
 		deleting = true;
 		try {
 			await deleteScoringStructure(id());
+			toast.success('Scoring structure deleted');
 			await goto('/scoring-structures');
 		} catch (err) {
 			// e.g. the structure is referenced by a Schedule/PlayoffStructure and PreDelete blocks it
@@ -217,248 +222,250 @@
 </script>
 
 <svelte:head>
-	<title>Intraclub | {structure ? structure.name : 'Scoring Structure'}</title>
+	<title>Intraclub | {structure.data ? structure.data.name : 'Scoring Structure'}</title>
 </svelte:head>
 
-{#if loadError}
-	<h1 class="text-2xl font-semibold tracking-tight">Scoring Structure</h1>
-	<p class="text-sm font-medium text-destructive">{loadError}</p>
-	<a href="/scoring-structures" class="text-sm text-muted-foreground hover:text-foreground"
-		>&larr; Back to scoring structures</a
-	>
-{:else if !structure}
-	<h1 class="text-2xl font-semibold tracking-tight">Scoring Structure</h1>
-	<p class="text-muted-foreground">Loading...</p>
-{:else}
-	<div class="flex items-center gap-4">
-		<h1 class="text-2xl font-semibold tracking-tight">{structure.name}</h1>
-		<a href="/scoring-structures" class="text-sm text-muted-foreground hover:text-foreground"
-			>&larr; Back to scoring structures</a
-		>
-	</div>
+<PageHeader
+	title={structure.data?.name}
+	icon={GaugeIcon}
+	backHref="/scoring-structures"
+	backLabel="Back to scoring structures"
+/>
 
-	<Card class="mt-6 max-w-md">
-		<CardHeader>
-			<CardTitle>Scoring structure details</CardTitle>
-		</CardHeader>
-		<CardContent>
-			<dl class="flex flex-col gap-3">
-				<div class="flex flex-col gap-1">
-					<dt class="text-sm text-muted-foreground">Counting type</dt>
-					<dd>{countingTypeName(structure.win_condition_counting_type)}</dd>
-				</div>
-				<div class="flex flex-col gap-1">
-					<dt class="text-sm text-muted-foreground">Win threshold</dt>
-					<dd>{structure.win_condition.win_threshold}</dd>
-				</div>
-				<div class="flex flex-col gap-1">
-					<dt class="text-sm text-muted-foreground">Must win by</dt>
-					<dd>{structure.win_condition.must_win_by}</dd>
-				</div>
-				<div class="flex flex-col gap-1">
-					<dt class="text-sm text-muted-foreground">Instant win threshold</dt>
-					<dd>{structure.win_condition.instant_win_threshold}</dd>
-				</div>
-			</dl>
-		</CardContent>
-	</Card>
+<AsyncSection state={structure}>
+	{#snippet children(s)}
+		<Card class="mt-6 max-w-md">
+			<CardHeader>
+				<CardTitle>Scoring structure details</CardTitle>
+			</CardHeader>
+			<CardContent>
+				<dl class="flex flex-col gap-3">
+					<div class="flex flex-col gap-1">
+						<dt class="text-sm text-muted-foreground">Counting type</dt>
+						<dd>{countingTypeName(s.win_condition_counting_type)}</dd>
+					</div>
+					<div class="flex flex-col gap-1">
+						<dt class="text-sm text-muted-foreground">Win threshold</dt>
+						<dd>{s.win_condition.win_threshold}</dd>
+					</div>
+					<div class="flex flex-col gap-1">
+						<dt class="text-sm text-muted-foreground">Must win by</dt>
+						<dd>{s.win_condition.must_win_by}</dd>
+					</div>
+					<div class="flex flex-col gap-1">
+						<dt class="text-sm text-muted-foreground">Instant win threshold</dt>
+						<dd>{s.win_condition.instant_win_threshold}</dd>
+					</div>
+				</dl>
+			</CardContent>
+		</Card>
 
-	<Card class="mt-6 max-w-md">
-		<CardHeader>
-			<CardTitle>Edit scoring structure</CardTitle>
-		</CardHeader>
-		<CardContent>
-			<form onsubmit={handleSave} class="flex flex-col gap-4">
-				<div class="flex flex-col gap-2">
-					<Label for="name">Name</Label>
-					<Input id="name" type="text" bind:value={name} required />
-				</div>
-				<div class="flex flex-col gap-2">
-					<Label for="countingType">Score counting type</Label>
-					<NativeSelect id="countingType" bind:value={countingType} class="w-full">
-						{#each countingTypes as ct}
-							<NativeSelectOption value={ct.type}>{ct.name}</NativeSelectOption>
-						{/each}
-					</NativeSelect>
-				</div>
-				<div class="flex flex-col gap-2">
-					<Label for="winThreshold">Win threshold</Label>
-					<Input id="winThreshold" type="number" min="1" bind:value={winThreshold} required />
-				</div>
-				<div class="flex flex-col gap-2">
-					<Label for="mustWinBy">Must win by</Label>
-					<Input id="mustWinBy" type="number" min="1" bind:value={mustWinBy} required />
-				</div>
-				<div class="flex flex-col gap-2">
-					<Label for="instantWinThreshold">Instant win threshold</Label>
-					<Input
-						id="instantWinThreshold"
-						type="number"
-						min="0"
-						bind:value={instantWinThreshold}
-						placeholder="0 (disabled)"
-					/>
-				</div>
-				<Button type="submit" disabled={saving} class="w-fit">
-					{saving ? 'Saving...' : 'Save changes'}
-				</Button>
-			</form>
-		</CardContent>
-	</Card>
-
-	<section class="mt-6 max-w-md">
-		<h2 class="text-xl font-semibold tracking-tight">Secondary scoring structures</h2>
-
-		{#if draftSecondaries.length > 0}
-			<ul class="mt-4 flex flex-col gap-2">
-				{#each draftSecondaries as secondary, i}
-					<li class="flex items-center justify-between gap-2 rounded-lg border p-2 pl-3">
-						<span class="flex items-center gap-2">
-							<span class="text-sm text-muted-foreground">{i + 1}.</span>
-							<Badge variant="secondary" class="secondary-name">{secondary.name}</Badge>
-						</span>
-						<span class="flex items-center gap-1">
-							<Button
-								type="button"
-								variant="outline"
-								size="sm"
-								onclick={() => moveDraft(i, -1)}
-								disabled={i === 0}
-							>
-								↑
-							</Button>
-							<Button
-								type="button"
-								variant="outline"
-								size="sm"
-								onclick={() => moveDraft(i, 1)}
-								disabled={i === draftSecondaries.length - 1}
-							>
-								↓
-							</Button>
-							<Button
-								type="button"
-								variant="outline"
-								size="sm"
-								onclick={() => removeFromDraft(i)}
-							>
-								Remove
-							</Button>
-						</span>
-					</li>
-				{/each}
-			</ul>
-		{/if}
-
-		{#if secondaryType === null}
-			<p class="mt-2 text-sm text-muted-foreground">
-				Point-based scoring structures cannot have secondary (tie-breaker) scoring structures
-				{#if draftSecondaries.length > 0}
-					— remove the {draftSecondaries.length} assigned secondaries (or change the counting type)
-					before saving.
-				{/if}
-			</p>
-		{:else if requiredSecondaryCount === null}
-			<p class="mt-2 text-sm text-muted-foreground">
-				Win conditions that require winning by 2 or more without an instant-win threshold cannot
-				be composite
-				{#if draftSecondaries.length > 0}
-					— remove the {draftSecondaries.length} assigned secondaries (or change the win condition)
-					before saving.
-				{/if}
-			</p>
-		{:else}
-			<p class="mt-1 text-sm text-muted-foreground">
-				The {secondaryTypeName}-based structures used to score each {unitNoun} in this structure,
-				in tie-breaker order.
-			</p>
-
-			{#if draftSecondaries.length === 0}
-				<p class="mt-4 text-muted-foreground">No secondary scoring structures assigned yet.</p>
-			{/if}
-
-			{#if draftSecondaries.length !== requiredSecondaryCount}
-				<p class="mt-2 text-sm text-muted-foreground">
-					This win condition can play at most {requiredSecondaryCount} {unitNoun}s, so a
-					composite structure needs exactly {requiredSecondaryCount} secondary scoring
-					structures ({draftSecondaries.length} currently assigned).
-				</p>
-			{:else if draftSecondaries.length > 0}
-				<p class="mt-2 text-sm text-muted-foreground">
-					All {requiredSecondaryCount} required secondary scoring structures assigned.
-				</p>
-			{/if}
-
-			{#if eligibleStructures.length > 0}
-				<div class="mt-4 flex items-center gap-2">
-					<NativeSelect
-						bind:value={selectedSecondaryId}
-						aria-label="Secondary structure to assign"
-						class="flex-1"
-					>
-						<NativeSelectOption value="" disabled
-							>Select a {secondaryTypeName} structure…</NativeSelectOption
-						>
-						{#each eligibleStructures as s}
-							<NativeSelectOption value={s.id}>{s.name}</NativeSelectOption>
-						{/each}
-					</NativeSelect>
-					<Button
-						type="button"
-						onclick={addToDraft}
-						disabled={
-							!selectedSecondaryId || draftSecondaries.length >= requiredSecondaryCount
-						}
-					>
-						Add secondary
+		<Card class="mt-6 max-w-md">
+			<CardHeader>
+				<CardTitle>Edit scoring structure</CardTitle>
+			</CardHeader>
+			<CardContent>
+				<form onsubmit={handleSave} class="flex flex-col gap-4">
+					<div class="flex flex-col gap-2">
+						<Label for="name">Name</Label>
+						<Input id="name" type="text" bind:value={name} required />
+					</div>
+					<div class="flex flex-col gap-2">
+						<Label for="countingType">Score counting type</Label>
+						<NativeSelect id="countingType" bind:value={countingType} class="w-full">
+							{#each countingTypes as ct}
+								<NativeSelectOption value={ct.type}>{ct.name}</NativeSelectOption>
+							{/each}
+						</NativeSelect>
+					</div>
+					<div class="flex flex-col gap-2">
+						<Label for="winThreshold">Win threshold</Label>
+						<Input id="winThreshold" type="number" min="1" bind:value={winThreshold} required />
+					</div>
+					<div class="flex flex-col gap-2">
+						<Label for="mustWinBy">Must win by</Label>
+						<Input id="mustWinBy" type="number" min="1" bind:value={mustWinBy} required />
+					</div>
+					<div class="flex flex-col gap-2">
+						<Label for="instantWinThreshold">Instant win threshold</Label>
+						<Input
+							id="instantWinThreshold"
+							type="number"
+							min="0"
+							bind:value={instantWinThreshold}
+							placeholder="0 (disabled)"
+						/>
+					</div>
+					<Button type="submit" disabled={saving} class="w-fit">
+						{saving ? 'Saving...' : 'Save changes'}
 					</Button>
-				</div>
-			{:else}
-				<p class="mt-4 text-sm text-muted-foreground">
-					No {secondaryTypeName}-based scoring structures available to assign.
-				</p>
+				</form>
+			</CardContent>
+		</Card>
+
+		<section class="mt-6 max-w-md">
+			<h2 class="text-xl font-semibold tracking-tight">Secondary scoring structures</h2>
+
+			{#if draftSecondaries.length > 0}
+				<ul class="mt-4 flex flex-col gap-2">
+					{#each draftSecondaries as secondary, i}
+						<li class="flex items-center justify-between gap-2 rounded-lg border p-2 pl-3">
+							<span class="flex items-center gap-2">
+								<span class="text-sm text-muted-foreground">{i + 1}.</span>
+								<Badge variant="secondary" class="secondary-name">{secondary.name}</Badge>
+							</span>
+							<span class="flex items-center gap-1">
+								<Button
+									type="button"
+									variant="outline"
+									size="sm"
+									onclick={() => moveDraft(i, -1)}
+									disabled={i === 0}
+								>
+									↑
+								</Button>
+								<Button
+									type="button"
+									variant="outline"
+									size="sm"
+									onclick={() => moveDraft(i, 1)}
+									disabled={i === draftSecondaries.length - 1}
+								>
+									↓
+								</Button>
+								<Button
+									type="button"
+									variant="outline"
+									size="sm"
+									onclick={() => removeFromDraft(i)}
+								>
+									Remove
+								</Button>
+							</span>
+						</li>
+					{/each}
+				</ul>
 			{/if}
 
-			<Button
-				type="button"
-				onclick={saveSecondaries}
-				disabled={secondariesSaving || !canSaveSecondaries}
-				class="mt-4"
-			>
-				{secondariesSaving
-					? 'Saving…'
-					: canSaveSecondaries
-						? 'Save secondaries'
-						: `Add ${requiredSecondaryCount - draftSecondaries.length} more to save`}
-			</Button>
-		{/if}
+			{#if secondaryType === null}
+				<p class="mt-2 text-sm text-muted-foreground">
+					Point-based scoring structures cannot have secondary (tie-breaker) scoring structures
+					{#if draftSecondaries.length > 0}
+						— remove the {draftSecondaries.length} assigned secondaries (or change the counting type)
+						before saving.
+					{/if}
+				</p>
+			{:else if requiredSecondaryCount === null}
+				<p class="mt-2 text-sm text-muted-foreground">
+					Win conditions that require winning by 2 or more without an instant-win threshold cannot
+					be composite
+					{#if draftSecondaries.length > 0}
+						— remove the {draftSecondaries.length} assigned secondaries (or change the win condition)
+						before saving.
+					{/if}
+				</p>
+			{:else}
+				<p class="mt-1 text-sm text-muted-foreground">
+					The {secondaryTypeName}-based structures used to score each {unitNoun} in this structure,
+					in tie-breaker order.
+				</p>
 
-		{#if secondariesError}
-			<p class="mt-3 text-sm font-medium text-destructive">{secondariesError}</p>
-		{/if}
-	</section>
+				{#if draftSecondaries.length === 0}
+					<p class="mt-4 text-muted-foreground">No secondary scoring structures assigned yet.</p>
+				{/if}
 
-	<div class="mt-4">
-		<Popover bind:open={deleteOpen}>
-			<PopoverTrigger disabled={deleting} class={buttonVariants({ variant: 'destructive' })}>
-				{deleting ? 'Deleting...' : 'Delete scoring structure'}
-			</PopoverTrigger>
-			<PopoverContent class="w-80">
-				<PopoverHeader>
-					<PopoverTitle>Delete scoring structure?</PopoverTitle>
-					<p class="text-sm text-muted-foreground">
-						This permanently removes this scoring structure and cannot be undone.
+				{#if draftSecondaries.length !== requiredSecondaryCount}
+					<p class="mt-2 text-sm text-muted-foreground">
+						This win condition can play at most {requiredSecondaryCount} {unitNoun}s, so a
+						composite structure needs exactly {requiredSecondaryCount} secondary scoring
+						structures ({draftSecondaries.length} currently assigned).
 					</p>
-				</PopoverHeader>
-				<div class="flex justify-end gap-2">
-					<PopoverClose class={buttonVariants({ variant: 'outline', size: 'sm' })}>Cancel</PopoverClose>
-					<Button variant="destructive" size="sm" onclick={handleDelete}>Delete</Button>
-				</div>
-			</PopoverContent>
-		</Popover>
-	</div>
+				{:else if draftSecondaries.length > 0}
+					<p class="mt-2 text-sm text-muted-foreground">
+						All {requiredSecondaryCount} required secondary scoring structures assigned.
+					</p>
+				{/if}
 
-	{#if error}
-		<p class="mt-4 text-sm font-medium text-destructive">{error}</p>
-	{/if}
-{/if}
+				{#if eligibleStructures.length > 0}
+					<div class="mt-4 flex items-center gap-2">
+						<NativeSelect
+							bind:value={selectedSecondaryId}
+							aria-label="Secondary structure to assign"
+							class="flex-1"
+						>
+							<NativeSelectOption value="" disabled
+								>Select a {secondaryTypeName} structure…</NativeSelectOption
+							>
+							{#each eligibleStructures as s}
+								<NativeSelectOption value={s.id}>{s.name}</NativeSelectOption>
+							{/each}
+						</NativeSelect>
+						<Button
+							type="button"
+							onclick={addToDraft}
+							disabled={
+								!selectedSecondaryId || draftSecondaries.length >= requiredSecondaryCount
+							}
+						>
+							Add secondary
+						</Button>
+					</div>
+				{:else}
+					<p class="mt-4 text-sm text-muted-foreground">
+						No {secondaryTypeName}-based scoring structures available to assign.
+					</p>
+				{/if}
+
+				<Button
+					type="button"
+					onclick={saveSecondaries}
+					disabled={secondariesSaving || !canSaveSecondaries}
+					class="mt-4"
+				>
+					{secondariesSaving
+						? 'Saving…'
+						: canSaveSecondaries
+							? 'Save secondaries'
+							: `Add ${requiredSecondaryCount - draftSecondaries.length} more to save`}
+				</Button>
+			{/if}
+
+			{#if secondariesError}
+				<Alert variant="destructive" class="mt-3">
+					<AlertDescription>{secondariesError}</AlertDescription>
+				</Alert>
+			{/if}
+		</section>
+
+		{#if error}
+			<Alert variant="destructive" class="mt-4 max-w-md">
+				<AlertDescription>{error}</AlertDescription>
+			</Alert>
+		{/if}
+
+		<div class="mt-4">
+			<AlertDialog bind:open={deleteOpen}>
+				<AlertDialogTrigger
+					disabled={deleting}
+					class={buttonVariants({ variant: 'destructive' })}
+				>
+					{deleting ? 'Deleting...' : 'Delete scoring structure'}
+				</AlertDialogTrigger>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Delete scoring structure?</AlertDialogTitle>
+						<AlertDialogDescription>
+							This permanently removes this scoring structure and cannot be undone.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel>Cancel</AlertDialogCancel>
+						<AlertDialogAction variant="destructive" onclick={handleDelete}>
+							Delete
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+		</div>
+	{/snippet}
+</AsyncSection>

--- a/ui/src/routes/scoring-structures/new/+page.svelte
+++ b/ui/src/routes/scoring-structures/new/+page.svelte
@@ -3,11 +3,15 @@
 	import { createScoringStructure, getScoreCountingTypes } from '$lib/scoringStructure';
 	import type { ScoreCountingType } from '$lib/scoringStructure';
 	import { goto } from '$app/navigation';
+	import { PageHeader } from '$lib/components/app/index.js';
+	import { Alert, AlertDescription } from '$lib/components/ui/alert/index.js';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
 	import { Label } from '$lib/components/ui/label/index.js';
 	import { NativeSelect, NativeSelectOption } from '$lib/components/ui/native-select/index.js';
+	import { toast } from '$lib/toast';
+	import GaugeIcon from '@lucide/svelte/icons/gauge';
 
 	let countingTypes = $state<ScoreCountingType[]>([]);
 	let name = $state('');
@@ -17,6 +21,7 @@
 	let instantWinThreshold = $state<string>('0');
 	let error = $state('');
 	let submitting = $state(false);
+	let attempted = $state(false);
 
 	onMount(async () => {
 		try {
@@ -29,6 +34,7 @@
 
 	async function handleSubmit(e: Event) {
 		e.preventDefault();
+		attempted = true;
 		error = '';
 		submitting = true;
 		try {
@@ -41,6 +47,7 @@
 					instant_win_threshold: parseInt(instantWinThreshold || '0', 10)
 				}
 			});
+			toast.success('Scoring structure created');
 			await goto(`/scoring-structures/${created.id}`);
 		} catch (err) {
 			error = err instanceof Error ? err.message : 'Failed to create scoring structure';
@@ -54,22 +61,33 @@
 	<title>Intraclub | New scoring structure</title>
 </svelte:head>
 
-<div class="flex items-center gap-4">
-	<h1 class="text-2xl font-semibold tracking-tight">New scoring structure</h1>
-	<a href="/scoring-structures" class="text-sm text-muted-foreground hover:text-foreground"
-		>&larr; Back to scoring structures</a
-	>
-</div>
+<PageHeader
+	title="New scoring structure"
+	icon={GaugeIcon}
+	backHref="/scoring-structures"
+	backLabel="Back to scoring structures"
+/>
 
 <Card class="mt-6 max-w-md">
 	<CardHeader>
 		<CardTitle>Scoring structure details</CardTitle>
 	</CardHeader>
 	<CardContent>
+		{#if error}
+			<Alert variant="destructive" class="mb-4">
+				<AlertDescription>{error}</AlertDescription>
+			</Alert>
+		{/if}
 		<form onsubmit={handleSubmit} class="flex flex-col gap-4">
 			<div class="flex flex-col gap-2">
 				<Label for="name">Name</Label>
-				<Input id="name" type="text" bind:value={name} required />
+				<Input
+					id="name"
+					type="text"
+					bind:value={name}
+					required
+					aria-invalid={attempted && !name.trim()}
+				/>
 			</div>
 			<div class="flex flex-col gap-2">
 				<Label for="countingType">Score counting type</Label>
@@ -81,11 +99,25 @@
 			</div>
 			<div class="flex flex-col gap-2">
 				<Label for="winThreshold">Win threshold</Label>
-				<Input id="winThreshold" type="number" min="1" bind:value={winThreshold} required />
+				<Input
+					id="winThreshold"
+					type="number"
+					min="1"
+					bind:value={winThreshold}
+					required
+					aria-invalid={attempted && !winThreshold}
+				/>
 			</div>
 			<div class="flex flex-col gap-2">
 				<Label for="mustWinBy">Must win by</Label>
-				<Input id="mustWinBy" type="number" min="1" bind:value={mustWinBy} required />
+				<Input
+					id="mustWinBy"
+					type="number"
+					min="1"
+					bind:value={mustWinBy}
+					required
+					aria-invalid={attempted && !mustWinBy}
+				/>
 			</div>
 			<div class="flex flex-col gap-2">
 				<Label for="instantWinThreshold">Instant win threshold</Label>
@@ -103,7 +135,3 @@
 		</form>
 	</CardContent>
 </Card>
-
-{#if error}
-	<p class="mt-4 text-sm font-medium text-destructive">{error}</p>
-{/if}

--- a/ui/src/routes/seasons/+page.svelte
+++ b/ui/src/routes/seasons/+page.svelte
@@ -1,99 +1,99 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
+	import { Async } from '$lib/async.svelte';
+	import {
+		AsyncSection,
+		DataTable,
+		EmptyState,
+		PageHeader
+	} from '$lib/components/app/index.js';
+	import type { Column } from '$lib/components/app/data-table.svelte';
 	import { listSeasons } from '$lib/season';
 	import type { Season } from '$lib/season';
 	import { listFacilities } from '$lib/facility';
 	import { listDrafts } from '$lib/draft';
 	import { listPlayoffStructures } from '$lib/playoffStructure';
-	import {
-		Table,
-		TableBody,
-		TableCell,
-		TableHead,
-		TableHeader,
-		TableRow
-	} from '$lib/components/ui/table/index.js';
+	import CalendarIcon from '@lucide/svelte/icons/calendar';
 
-	let seasons = $state<Season[]>([]);
 	let facilities = $state<Record<string, string>>({});
 	let drafts = $state<Record<string, string>>({});
 	let playoffs = $state<Record<string, string>>({});
-	let loading = $state(true);
-	let error = $state('');
 
-	function playoffLabel(p: { byes: number; number_of_teams: number }): string {
-		if (p.number_of_teams === 0 && p.byes === 0) return '';
-		return `${p.number_of_teams} teams${p.byes > 0 ? ` / ${p.byes} bye${p.byes > 1 ? 's' : ''}` : ''}`;
-	}
-
-	onMount(async () => {
-		try {
+	const seasons = new Async<Season[]>();
+	onMount(() =>
+		seasons.run(async () => {
 			const [seasonList, facilityList, draftList, playoffList] = await Promise.all([
 				listSeasons(),
 				listFacilities(),
 				listDrafts(),
 				listPlayoffStructures()
 			]);
-			seasons = seasonList;
 			facilities = Object.fromEntries(facilityList.map((f) => [f.id, f.name]));
 			drafts = Object.fromEntries(draftList.map((d) => [d.id, d.name]));
-			playoffs = Object.fromEntries(
-				playoffList.map((p) => [p.id, playoffLabel(p)])
-			);
-		} catch (e) {
-			error = e instanceof Error ? e.message : 'Failed to load seasons';
-		} finally {
-			loading = false;
+			playoffs = Object.fromEntries(playoffList.map((p) => [p.id, playoffLabel(p)]));
+			return seasonList;
+		})
+	);
+
+	function playoffLabel(p: { byes: number; number_of_teams: number }): string {
+		if (p.number_of_teams === 0 && p.byes === 0) return '';
+		return `${p.number_of_teams} teams${p.byes > 0 ? ` / ${p.byes} bye${p.byes > 1 ? 's' : ''}` : ''}`;
+	}
+
+	const columns: Column<Season>[] = [
+		{ key: 'name', header: 'Name', sortable: true, cell: nameCell },
+		{
+			key: 'facility',
+			header: 'Facility',
+			hideBelow: 'sm',
+			value: (s) => facilities[s.facility] ?? s.facility
+		},
+		{ key: 'start_time', header: 'Start time', hideBelow: 'sm', value: (s) => s.start_time },
+		{
+			key: 'draft',
+			header: 'Draft',
+			hideBelow: 'md',
+			value: (s) => drafts[s.draft_id] ?? s.draft_id
+		},
+		{
+			key: 'playoff',
+			header: 'Playoff structure',
+			hideBelow: 'md',
+			value: (s) => playoffs[s.playoff_structure] ?? s.playoff_structure
 		}
-	});
+	];
 </script>
+
+{#snippet nameCell(s: Season)}
+	<a href={`/seasons/${s.id}`} class="font-medium text-primary underline-offset-4 hover:underline">
+		{s.name}
+	</a>
+{/snippet}
 
 <svelte:head>
 	<title>Intraclub | Seasons</title>
 </svelte:head>
 
-<div class="flex items-center justify-between gap-4">
-	<h1 class="text-2xl font-semibold tracking-tight">Seasons</h1>
-</div>
+<PageHeader title="Seasons" description="Weekly head-to-head play, draft to playoffs" icon={CalendarIcon} />
 
-{#if loading}
-	<p class="text-muted-foreground">Loading...</p>
-{:else if error}
-	<p class="text-sm font-medium text-destructive">{error}</p>
-{:else if seasons.length === 0}
-	<p class="text-muted-foreground">No seasons yet. Complete a draft to create one.</p>
-{:else}
-	<div class="mt-4 overflow-hidden rounded-lg border">
-		<Table>
-			<TableHeader>
-				<TableRow>
-					<TableHead>Name</TableHead>
-					<TableHead>Facility</TableHead>
-					<TableHead>Start time</TableHead>
-					<TableHead>Draft</TableHead>
-					<TableHead>Playoff structure</TableHead>
-				</TableRow>
-			</TableHeader>
-			<TableBody>
-				{#each seasons as season}
-					<TableRow>
-						<TableCell>
-							<a
-								href={`/seasons/${season.id}`}
-								class="font-medium text-primary underline-offset-4 hover:underline"
-							>
-								{season.name}
-							</a>
-						</TableCell>
-						<TableCell>{facilities[season.facility] ?? season.facility}</TableCell>
-						<TableCell>{season.start_time}</TableCell>
-						<TableCell>{drafts[season.draft_id] ?? season.draft_id}</TableCell>
-						<TableCell>
-							{playoffs[season.playoff_structure] ?? season.playoff_structure}
-						</TableCell>
-					</TableRow>
-				{/each}
-			</TableBody>
-		</Table>
-	</div>
-{/if}
+<AsyncSection state={seasons} isEmpty={(s) => s.length === 0}>
+	{#snippet loading()}
+		<DataTable rows={[]} {columns} getKey={(s) => s.id} loading />
+	{/snippet}
+	{#snippet empty()}
+		<EmptyState
+			title="No seasons yet."
+			description="Complete a draft to create one."
+		/>
+	{/snippet}
+	{#snippet children(ss)}
+		<DataTable
+			rows={ss}
+			{columns}
+			getKey={(s) => s.id}
+			caption="Seasons"
+			filter
+			filterLabel="Filter seasons"
+		/>
+	{/snippet}
+</AsyncSection>

--- a/ui/src/routes/teams/+page.svelte
+++ b/ui/src/routes/teams/+page.svelte
@@ -1,73 +1,62 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
+	import { Async } from '$lib/async.svelte';
+	import {
+		AsyncSection,
+		DataTable,
+		EmptyState,
+		PageHeader
+	} from '$lib/components/app/index.js';
+	import type { Column } from '$lib/components/app/data-table.svelte';
 	import { listTeams } from '$lib/team';
 	import type { TeamRoster } from '$lib/team';
-	import {
-		Table,
-		TableBody,
-		TableCell,
-		TableHead,
-		TableHeader,
-		TableRow
-	} from '$lib/components/ui/table/index.js';
+	import ShieldIcon from '@lucide/svelte/icons/shield';
 
-	let rosters = $state<TeamRoster[]>([]);
-	let loading = $state(true);
-	let error = $state('');
+	const rosters = new Async<TeamRoster[]>();
+	onMount(() => rosters.run(() => listTeams()));
 
-	onMount(async () => {
-		try {
-			rosters = await listTeams();
-		} catch (e) {
-			error = e instanceof Error ? e.message : 'Failed to load teams';
-		} finally {
-			loading = false;
+	const columns: Column<TeamRoster>[] = [
+		{ key: 'name', header: 'Team', sortable: true, cell: nameCell },
+		{
+			key: 'members',
+			header: 'Members',
+			align: 'right',
+			value: (r) => r.assignments.length,
+			class: 'text-muted-foreground'
 		}
-	});
+	];
 </script>
+
+{#snippet nameCell(r: TeamRoster)}
+	<a href={`/teams/${r.team.id}`} class="font-medium text-primary underline-offset-4 hover:underline">
+		{r.team.name}
+	</a>
+{/snippet}
 
 <svelte:head>
 	<title>Intraclub | Teams</title>
 </svelte:head>
 
-<div class="flex items-center gap-4">
-	<h1 class="text-2xl font-semibold tracking-tight">Teams</h1>
-</div>
+<PageHeader title="Teams" description="Rosters formed by finalized drafts" icon={ShieldIcon} />
 
-{#if loading}
-	<p class="text-muted-foreground">Loading...</p>
-{:else if error}
-	<p class="text-sm font-medium text-destructive">{error}</p>
-{:else if rosters.length === 0}
-	<p class="text-muted-foreground">
-		You aren't on any teams. Teams are created when a draft is finalized and are only visible to their members.
-	</p>
-{:else}
-	<div class="mt-4 overflow-hidden rounded-lg border">
-		<Table>
-			<TableHeader>
-				<TableRow>
-					<TableHead>Team</TableHead>
-					<TableHead>Members</TableHead>
-				</TableRow>
-			</TableHeader>
-			<TableBody>
-				{#each rosters as roster}
-					<TableRow>
-						<TableCell>
-							<a
-								href={`/teams/${roster.team.id}`}
-								class="font-medium text-primary underline-offset-4 hover:underline"
-							>
-								{roster.team.name}
-							</a>
-						</TableCell>
-						<TableCell class="text-muted-foreground">
-							{roster.assignments.length}
-						</TableCell>
-					</TableRow>
-				{/each}
-			</TableBody>
-		</Table>
-	</div>
-{/if}
+<AsyncSection state={rosters} isEmpty={(r) => r.length === 0}>
+	{#snippet loading()}
+		<DataTable rows={[]} {columns} getKey={(r) => r.team.id} loading />
+	{/snippet}
+	{#snippet empty()}
+		<EmptyState
+			title="You aren't on any teams."
+			description="Teams are created when a draft is finalized and are only visible to their members."
+		/>
+	{/snippet}
+	{#snippet children(rs)}
+		<DataTable
+			rows={rs}
+			{columns}
+			getKey={(r) => r.team.id}
+			caption="Teams"
+			filter
+			filterLabel="Filter teams"
+		/>
+	{/snippet}
+</AsyncSection>

--- a/ui/src/routes/teams/[id]/+page.svelte
+++ b/ui/src/routes/teams/[id]/+page.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { page } from '$app/state';
+	import { Async } from '$lib/async.svelte';
+	import { AsyncSection, PageHeader } from '$lib/components/app/index.js';
+	import { Alert, AlertDescription } from '$lib/components/ui/alert/index.js';
 	import { getTeam, promoteCoCaptain } from '$lib/team';
 	import type { TeamAssignment, TeamRoster, TeamRole } from '$lib/team';
 	import { getCurrentUserId } from '$lib/auth';
@@ -20,32 +23,23 @@
 		TabsList,
 		TabsTrigger
 	} from '$lib/components/ui/tabs/index.js';
+	import ShieldIcon from '@lucide/svelte/icons/shield';
 
 	const id = () => page.params.id as string;
 
-	let roster = $state<TeamRoster | null>(null);
+	const roster = new Async<TeamRoster>();
 	let users = $state<User[]>([]);
 	let activeTab = $state('members');
-	let loading = $state(true);
-	let loadError = $state('');
 	let actionError = $state('');
 	let actionMessage = $state('');
 
-	onMount(load);
-
-	async function load() {
-		loading = true;
-		loadError = '';
-		try {
+	onMount(() =>
+		roster.run(async () => {
 			const [teamRoster, userList] = await Promise.all([getTeam(id()), listUsers()]);
-			roster = teamRoster;
 			users = userList;
-		} catch (e) {
-			loadError = e instanceof Error ? e.message : 'Failed to load team';
-		} finally {
-			loading = false;
-		}
-	}
+			return teamRoster;
+		})
+	);
 
 	function userName(userId: string): string {
 		const u = users.find((x) => x.id === userId);
@@ -67,18 +61,20 @@
 	// a co-captain themselves (mirrors the backend's EditableBy).
 	const canManage = $derived.by(() => {
 		const me = getCurrentUserId();
-		if (!me || !roster) return false;
-		return roster.assignments.some((a) => a.user_id === me && a.role !== 'member');
+		if (!me || !roster.data) return false;
+		return roster.data.assignments.some((a) => a.user_id === me && a.role !== 'member');
 	});
 
 	const sortedAssignments = $derived(
-		roster ? [...roster.assignments].sort((a, b) => userName(a.user_id).localeCompare(userName(b.user_id))) : []
+		roster.data
+			? [...roster.data.assignments].sort((a, b) =>
+					userName(a.user_id).localeCompare(userName(b.user_id))
+				)
+			: []
 	);
 
 	// Members eligible to be promoted to co-captain (regular members only).
-	const promotableMembers = $derived(
-		sortedAssignments.filter((a) => a.role === 'member')
-	);
+	const promotableMembers = $derived(sortedAssignments.filter((a) => a.role === 'member'));
 
 	async function promote(userId: string) {
 		actionError = '';
@@ -86,7 +82,11 @@
 		try {
 			await promoteCoCaptain(id(), userId);
 			actionMessage = `${userName(userId)} is now a co-captain.`;
-			await load();
+			await roster.run(async () => {
+				const [teamRoster, userList] = await Promise.all([getTeam(id()), listUsers()]);
+				users = userList;
+				return teamRoster;
+			});
 		} catch (e) {
 			actionError = e instanceof Error ? e.message : 'Failed to promote member';
 		}
@@ -94,84 +94,86 @@
 </script>
 
 <svelte:head>
-	<title>Intraclub | {roster ? roster.team.name : 'Team'}</title>
+	<title>Intraclub | {roster.data ? roster.data.team.name : 'Team'}</title>
 </svelte:head>
 
-<div class="flex items-center gap-4">
-	<h1 class="text-2xl font-semibold tracking-tight">{roster?.team.name ?? 'Team'}</h1>
-	<a href="/teams" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to teams</a>
-</div>
+<PageHeader
+	title={roster.data?.team.name}
+	icon={ShieldIcon}
+	backHref="/teams"
+	backLabel="Back to teams"
+/>
 
-{#if loading}
-	<p class="mt-4 text-muted-foreground">Loading...</p>
-{:else if loadError}
-	<p class="mt-4 text-sm font-medium text-destructive">{loadError}</p>
-{:else if roster}
-	<Card class="mt-6">
-		<CardHeader>
-			<CardTitle>Team</CardTitle>
-		</CardHeader>
-		<CardContent>
-			<div class="flex flex-wrap items-center gap-4 text-sm">
-				<Badge variant="secondary">{roster.assignments.length} members</Badge>
-				<span class="text-muted-foreground">{roster.team.color.name}</span>
-			</div>
-		</CardContent>
-	</Card>
+<AsyncSection state={roster}>
+	{#snippet children(r)}
+		<Card class="mt-6">
+			<CardHeader>
+				<CardTitle>Team</CardTitle>
+			</CardHeader>
+			<CardContent>
+				<div class="flex flex-wrap items-center gap-4 text-sm">
+					<Badge variant="secondary">{r.assignments.length} members</Badge>
+					<span class="text-muted-foreground">{r.team.color.name}</span>
+				</div>
+			</CardContent>
+		</Card>
 
-	<Tabs bind:value={activeTab} class="mt-6 w-full">
-		<TabsList>
-			<TabsTrigger value="members">Members</TabsTrigger>
-			<TabsTrigger value="co-captains">Co-captains</TabsTrigger>
-		</TabsList>
-		<TabsContent value="members">
-			{#if sortedAssignments.length === 0}
-				<p class="mt-4 text-sm text-muted-foreground">No players assigned.</p>
-			{:else}
-				<ul class="mt-4 space-y-2 text-sm">
-					{#each sortedAssignments as assignment}
-						<li class="flex items-center justify-between gap-3 rounded-lg border px-3 py-2">
-							<span class="font-medium">{userName(assignment.user_id)}</span>
-							<Badge variant={assignment.role === 'captain' ? 'default' : 'secondary'}>
-								{roleLabel(assignment.role)}
-							</Badge>
-						</li>
-					{/each}
-				</ul>
-			{/if}
-		</TabsContent>
-		<TabsContent value="co-captains">
-			<p class="mt-4 text-sm text-muted-foreground">
-				Co-captains help manage the team roster. Rosters are otherwise fixed after the draft is finalized.
-			</p>
-
-			{#if actionError}
-				<p class="mt-3 text-sm font-medium text-destructive">{actionError}</p>
-			{/if}
-			{#if actionMessage}
-				<p class="mt-3 text-sm font-medium text-success">{actionMessage}</p>
-			{/if}
-
-			{#if canManage}
-				{#if promotableMembers.length === 0}
-					<p class="mt-4 text-sm text-muted-foreground">There are no members to promote.</p>
+		<Tabs bind:value={activeTab} class="mt-6 w-full">
+			<TabsList>
+				<TabsTrigger value="members">Members</TabsTrigger>
+				<TabsTrigger value="co-captains">Co-captains</TabsTrigger>
+			</TabsList>
+			<TabsContent value="members">
+				{#if sortedAssignments.length === 0}
+					<p class="mt-4 text-sm text-muted-foreground">No players assigned.</p>
 				{:else}
 					<ul class="mt-4 space-y-2 text-sm">
-						{#each promotableMembers as assignment}
+						{#each sortedAssignments as assignment}
 							<li class="flex items-center justify-between gap-3 rounded-lg border px-3 py-2">
 								<span class="font-medium">{userName(assignment.user_id)}</span>
-								<Button size="sm" onclick={() => promote(assignment.user_id)}>
-									Promote to co-captain
-								</Button>
+								<Badge variant={assignment.role === 'captain' ? 'default' : 'secondary'}>
+									{roleLabel(assignment.role)}
+								</Badge>
 							</li>
 						{/each}
 					</ul>
 				{/if}
-			{:else}
+			</TabsContent>
+			<TabsContent value="co-captains">
 				<p class="mt-4 text-sm text-muted-foreground">
-					Only this team's captain or co-captains can assign roles.
+					Co-captains help manage the team roster. Rosters are otherwise fixed after the draft is finalized.
 				</p>
-			{/if}
-		</TabsContent>
-	</Tabs>
-{/if}
+
+				{#if actionError}
+					<Alert variant="destructive" class="mt-3">
+						<AlertDescription>{actionError}</AlertDescription>
+					</Alert>
+				{/if}
+				{#if actionMessage}
+					<p class="mt-3 text-sm font-medium text-success">{actionMessage}</p>
+				{/if}
+
+				{#if canManage}
+					{#if promotableMembers.length === 0}
+						<p class="mt-4 text-sm text-muted-foreground">There are no members to promote.</p>
+					{:else}
+						<ul class="mt-4 space-y-2 text-sm">
+							{#each promotableMembers as assignment}
+								<li class="flex items-center justify-between gap-3 rounded-lg border px-3 py-2">
+									<span class="font-medium">{userName(assignment.user_id)}</span>
+									<Button size="sm" onclick={() => promote(assignment.user_id)}>
+										Promote to co-captain
+									</Button>
+								</li>
+							{/each}
+						</ul>
+					{/if}
+				{:else}
+					<p class="mt-4 text-sm text-muted-foreground">
+						Only this team's captain or co-captains can assign roles.
+					</p>
+				{/if}
+			</TabsContent>
+		</Tabs>
+	{/snippet}
+</AsyncSection>

--- a/ui/src/routes/users/+page.svelte
+++ b/ui/src/routes/users/+page.svelte
@@ -1,72 +1,65 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { listUsers } from '$lib/user';
+	import { Async } from '$lib/async.svelte';
+	import {
+		AsyncSection,
+		DataTable,
+		EmptyState,
+		PageHeader
+	} from '$lib/components/app/index.js';
+	import type { Column } from '$lib/components/app/data-table.svelte';
+	import { listUsers, fullName } from '$lib/user';
 	import type { User } from '$lib/user';
 	import { Button } from '$lib/components/ui/button/index.js';
-	import {
-		Table,
-		TableBody,
-		TableCell,
-		TableHead,
-		TableHeader,
-		TableRow
-	} from '$lib/components/ui/table/index.js';
+	import UsersIcon from '@lucide/svelte/icons/users';
 
-	let users = $state<User[]>([]);
-	let loading = $state(true);
-	let error = $state('');
+	const users = new Async<User[]>();
+	onMount(() => users.run(() => listUsers()));
 
-	onMount(async () => {
-		try {
-			users = await listUsers();
-		} catch (e) {
-			error = e instanceof Error ? e.message : 'Failed to load users';
-		} finally {
-			loading = false;
-		}
-	});
+	const columns: Column<User>[] = [
+		{ key: 'name', header: 'Name', sortable: true, cell: nameCell },
+		{ key: 'email', header: 'Email', hideBelow: 'sm', value: (u) => u.email },
+		{
+			key: 'phone',
+			header: 'Phone',
+			hideBelow: 'md',
+			value: (u) => u.phone_number || '—'
+		},
+		{ key: 'verified', header: 'Verified', value: (u) => (u.verified ? 'Yes' : 'No') }
+	];
 </script>
+
+{#snippet nameCell(u: User)}
+	<a href={`/users/${u.id}`} class="font-medium text-primary underline-offset-4 hover:underline">
+		{fullName(u)}
+	</a>
+{/snippet}
 
 <svelte:head>
 	<title>Intraclub | Users</title>
 </svelte:head>
 
-<div class="flex items-center justify-between gap-4">
-	<h1 class="text-2xl font-semibold tracking-tight">Users</h1>
-	<Button href="/users/import">Import users</Button>
-</div>
+<PageHeader title="Users" description="Everyone registered to play" icon={UsersIcon}>
+	{#snippet actions()}
+		<Button href="/users/import">Import users</Button>
+	{/snippet}
+</PageHeader>
 
-{#if loading}
-	<p class="text-muted-foreground">Loading...</p>
-{:else if error}
-	<p class="text-sm font-medium text-destructive">{error}</p>
-{:else if users.length === 0}
-	<p class="text-muted-foreground">No users yet.</p>
-{:else}
-	<div class="mt-4 overflow-hidden rounded-lg border">
-		<Table>
-			<TableHeader>
-				<TableRow>
-					<TableHead>Name</TableHead>
-					<TableHead>Email</TableHead>
-					<TableHead>Phone</TableHead>
-					<TableHead>Verified</TableHead>
-				</TableRow>
-			</TableHeader>
-			<TableBody>
-				{#each users as user}
-					<TableRow>
-						<TableCell>
-							<a href={`/users/${user.id}`} class="font-medium text-primary underline-offset-4 hover:underline">
-								{user.first_name} {user.last_name}
-							</a>
-						</TableCell>
-						<TableCell>{user.email}</TableCell>
-						<TableCell>{user.phone_number || '—'}</TableCell>
-						<TableCell>{user.verified ? 'Yes' : 'No'}</TableCell>
-					</TableRow>
-				{/each}
-			</TableBody>
-		</Table>
-	</div>
-{/if}
+<AsyncSection state={users} isEmpty={(u) => u.length === 0}>
+	{#snippet loading()}
+		<DataTable rows={[]} {columns} getKey={(u) => u.id} loading />
+	{/snippet}
+	{#snippet empty()}
+		<EmptyState title="No users yet." description="Import or invite players to get them registered." />
+	{/snippet}
+	{#snippet children(us)}
+		<DataTable
+			rows={us}
+			{columns}
+			getKey={(u) => u.id}
+			caption="Users"
+			filter
+			filterLabel="Filter users"
+		/>
+	{/snippet}
+</AsyncSection>

--- a/ui/src/routes/users/[id]/+page.svelte
+++ b/ui/src/routes/users/[id]/+page.svelte
@@ -1,67 +1,56 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { page } from '$app/state';
-	import { getUser } from '$lib/user';
+	import { Async } from '$lib/async.svelte';
+	import { AsyncSection, PageHeader } from '$lib/components/app/index.js';
+	import { getUser, fullName } from '$lib/user';
 	import type { User } from '$lib/user';
 	import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card/index.js';
+	import UsersIcon from '@lucide/svelte/icons/users';
 
 	const id = () => page.params.id as string;
 
-	let user = $state<User | null>(null);
-	let loadError = $state('');
-
-	onMount(load);
-
-	async function load() {
-		loadError = '';
-		try {
-			user = await getUser(id());
-		} catch (e) {
-			loadError = e instanceof Error ? e.message : 'Failed to load user';
-		}
-	}
+	const user = new Async<User>();
+	onMount(() => user.run(() => getUser(id())));
 </script>
 
 <svelte:head>
-	<title>Intraclub | {user ? `${user.first_name} ${user.last_name}` : 'User'}</title>
+	<title>Intraclub | {user.data ? fullName(user.data) : 'User'}</title>
 </svelte:head>
 
-{#if loadError}
-	<h1 class="text-2xl font-semibold tracking-tight">User</h1>
-	<p class="text-sm font-medium text-destructive">{loadError}</p>
-	<a href="/users" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to users</a>
-{:else if !user}
-	<h1 class="text-2xl font-semibold tracking-tight">User</h1>
-	<p class="text-muted-foreground">Loading...</p>
-{:else}
-	<div class="flex items-center gap-4">
-		<h1 class="text-2xl font-semibold tracking-tight">{user.first_name} {user.last_name}</h1>
-		<a href="/users" class="text-sm text-muted-foreground hover:text-foreground">&larr; Back to users</a>
-	</div>
+<PageHeader
+	title={user.data ? fullName(user.data) : undefined}
+	icon={UsersIcon}
+	backHref="/users"
+	backLabel="Back to users"
+/>
 
-	<Card class="mt-6 max-w-md">
-		<CardHeader>
-			<CardTitle>User details</CardTitle>
-		</CardHeader>
-		<CardContent>
-			<dl class="grid gap-4 text-sm">
-				<div class="flex justify-between gap-4">
-					<dt class="text-muted-foreground">Name</dt>
-					<dd>{user.first_name} {user.last_name}</dd>
-				</div>
-				<div class="flex justify-between gap-4">
-					<dt class="text-muted-foreground">Email</dt>
-					<dd>{user.email}</dd>
-				</div>
-				<div class="flex justify-between gap-4">
-					<dt class="text-muted-foreground">Phone</dt>
-					<dd>{user.phone_number || '—'}</dd>
-				</div>
-				<div class="flex justify-between gap-4">
-					<dt class="text-muted-foreground">Verified</dt>
-					<dd>{user.verified ? 'Yes' : 'No'}</dd>
-				</div>
-			</dl>
-		</CardContent>
-	</Card>
-{/if}
+<AsyncSection state={user}>
+	{#snippet children(u)}
+		<Card class="mt-6 max-w-md">
+			<CardHeader>
+				<CardTitle>User details</CardTitle>
+			</CardHeader>
+			<CardContent>
+				<dl class="grid gap-4 text-sm">
+					<div class="flex justify-between gap-4">
+						<dt class="text-muted-foreground">Name</dt>
+						<dd>{fullName(u)}</dd>
+					</div>
+					<div class="flex justify-between gap-4">
+						<dt class="text-muted-foreground">Email</dt>
+						<dd>{u.email}</dd>
+					</div>
+					<div class="flex justify-between gap-4">
+						<dt class="text-muted-foreground">Phone</dt>
+						<dd>{u.phone_number || '—'}</dd>
+					</div>
+					<div class="flex justify-between gap-4">
+						<dt class="text-muted-foreground">Verified</dt>
+						<dd>{u.verified ? 'Yes' : 'No'}</dd>
+					</div>
+				</dl>
+			</CardContent>
+		</Card>
+	{/snippet}
+</AsyncSection>


### PR DESCRIPTION
Closes #199 — part of #188, builds on the shared primitives from #193.

## What changed

All 31 pages in the list/detail/new triads now use the shared primitives —
no page hand-rolls the loading/error/empty chain anymore:

- **List pages** (facilities, formats, organizations, playoff-structures,
  ratings, rulesets, scoring-structures, users, seasons, drafts, teams,
  photos): `PageHeader` (icon + description), `Async`/`AsyncSection` with
  skeleton rows shaped like the table, `EmptyState`, `DataTable` (filter,
  sort, horizontal scroll at 375px).
- **Detail pages** (facilities, formats, organizations, photos,
  playoff-structures, ratings, rulesets, scoring-structures, users, teams):
  `PageHeader` with a single h1 + normalized back link, `AsyncSection`,
  errors as `Alert` with `role="alert"` (raw backend message preserved),
  delete confirmations as `AlertDialog` with a focus trap, and
  `toast.success(...)` on save/delete — `ratings/[id]` no longer saves
  silently.
- **New forms** (all 9): `aria-invalid` set on empty required fields only
  after a submit attempt (`attempted` flag — never derived from `required`
  alone), and the backend error moved inside the Card as an `Alert`.
  No client-side validation added.
- **Primitives**: `PageHeader` gains an optional Lucide icon and an icon
  back-arrow (replaces the literal `&larr;` entity); the layout container is
  `px-4 md:px-6`.

## Test hooks preserved

`.rating-name`, `.secondary-name`, `input[id^="edit-title-"]`, `img.detail`,
`thumb-img`, and the `<li>` sub-lists on formats/rulesets/scoring-structures
detail pages are untouched. All accessible names (button labels, link text,
headings, form labels) are byte-identical; no text button became icon-only.
List-page `EmptyState`s carry no CTA (header action is adjacent), avoiding
strict-mode duplicate-link failures.

## Notes

- bits-ui v2's `AlertDialogAction` does not auto-close the dialog, so the
  delete dialogs bind `open` and close it in `handleDelete` (mirroring the
  old Popover's `deleteOpen = false`) — otherwise a failed delete leaves the
  overlay up and blocks the page.
- Per the ticket's out-of-scope list, `seasons/[id]`, `drafts/[id]`,
  `drafts/[id]/draft`, `drafts/[id]/grades`, `auth/callback`, and the
  season/draft sub-pages were **not** touched, so `Loading...` and bare
  `<p class="text-destructive">` remain only in those files (the grep
  acceptance criterion cannot pass literally without violating the
  out-of-scope list).

## Verification

- `make e2e` green on every batch commit (12 intermediate runs) plus 3 final
  full-suite runs: 40/40 passed.
- `npm run check` (svelte-check): 0 errors, 0 warnings.
- Known pre-existing parallel flakes (hydration races on out-of-scope pages:
  scoring-structure-secondary reorder, organization create, facility
  delete-blocked, draft-grades, blurbs) each pass solo and were observed in
  the baseline run before any change.