### PR TITLE
UI: dark mode toggle (Closes #191)

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "0.0.1",
 			"dependencies": {
 				"@tailwindcss/vite": "^4.3.3",
+				"mode-watcher": "^1.1.0",
 				"tailwindcss": "^4.3.3"
 			},
 			"devDependencies": {
@@ -21,7 +22,6 @@
 				"@types/node": "^25.9.1",
 				"bits-ui": "^2.18.1",
 				"clsx": "^2.1.1",
-				"mode-watcher": "^1.1.0",
 				"svelte": "^5.55.2",
 				"svelte-check": "^4.4.6",
 				"svelte-sonner": "^1.2.1",
@@ -466,7 +466,6 @@
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.10.tgz",
 			"integrity": "sha512-4WfKk68eTih+MiJD4fSbxN7E8kVBmTMPWHUPYjvl2N0rMs53YLTT8/YjKU5Dtnz5LqDjl7LEw4U7lXR2W3J5WA==",
-			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
 				"acorn": "^8.9.0"
@@ -850,7 +849,6 @@
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
 			"integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
@@ -867,7 +865,6 @@
 			"version": "2.0.7",
 			"resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
 			"integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@vitest/expect": {
@@ -987,7 +984,6 @@
 			"version": "8.16.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
 			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-			"dev": true,
 			"license": "MIT",
 			"bin": {
 				"acorn": "bin/acorn"
@@ -1000,7 +996,6 @@
 			"version": "5.3.1",
 			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.1.tgz",
 			"integrity": "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==",
-			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">= 0.4"
@@ -1020,7 +1015,6 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
 			"integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
-			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">= 0.4"
@@ -1081,7 +1075,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
 			"integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -1137,7 +1130,6 @@
 			"version": "5.8.1",
 			"resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
 			"integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/enhanced-resolve": {
@@ -1164,14 +1156,12 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
 			"integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/esrap": {
 			"version": "2.2.9",
 			"resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.9.tgz",
 			"integrity": "sha512-4KijP+NxCWthMCUC3qHbE6n4vCjqgJS1uAYKhuT/GWfFTf1Qyive2TgOjep+gzbSzRfnNyaN/UU9YmdOt8Eg0A==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.4.15"
@@ -1246,14 +1236,12 @@
 			"version": "0.2.7",
 			"resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
 			"integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/is-reference": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
 			"integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/estree": "^1.0.6"
@@ -1531,7 +1519,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
 			"integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/lz-string": {
@@ -1557,7 +1544,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/mode-watcher/-/mode-watcher-1.1.0.tgz",
 			"integrity": "sha512-mUT9RRGPDYenk59qJauN1rhsIMKBmWA3xMF+uRwE8MW/tjhaDSCCARqkSuDTq8vr4/2KcAxIGVjACxTjdk5C3g==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"runed": "^0.25.0",
@@ -1571,7 +1557,6 @@
 			"version": "0.25.0",
 			"resolved": "https://registry.npmjs.org/runed/-/runed-0.25.0.tgz",
 			"integrity": "sha512-7+ma4AG9FT2sWQEA0Egf6mb7PBT2vHyuHail1ie8ropfSjvZGtEAx8YTmUjv/APCsdRRxEVvArNjALk9zFSOrg==",
-			"dev": true,
 			"funding": [
 				"https://github.com/sponsors/huntabyte",
 				"https://github.com/sponsors/tglide"
@@ -1587,7 +1572,6 @@
 			"version": "0.7.1",
 			"resolved": "https://registry.npmjs.org/svelte-toolbelt/-/svelte-toolbelt-0.7.1.tgz",
 			"integrity": "sha512-HcBOcR17Vx9bjaOceUvxkY3nGmbBmCBBbuWLLEWO6jtmWH8f/QoWmbyUfQZrpDINH39en1b8mptfPQT9VKQ1xQ==",
-			"dev": true,
 			"funding": [
 				"https://github.com/sponsors/huntabyte"
 			],
@@ -1608,7 +1592,6 @@
 			"version": "0.23.4",
 			"resolved": "https://registry.npmjs.org/runed/-/runed-0.23.4.tgz",
 			"integrity": "sha512-9q8oUiBYeXIDLWNK5DfCWlkL0EW3oGbk845VdKlPeia28l751VpfesaB/+7pI6rnbx1I6rqoZ2fZxptOJLxILA==",
-			"dev": true,
 			"funding": [
 				"https://github.com/sponsors/huntabyte",
 				"https://github.com/sponsors/tglide"
@@ -1910,7 +1893,6 @@
 			"version": "1.0.14",
 			"resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
 			"integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"inline-style-parser": "0.2.7"
@@ -1920,7 +1902,6 @@
 			"version": "5.55.9",
 			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.9.tgz",
 			"integrity": "sha512-fTjjT8cHLDwigcu2j3pv7Jq04LklXevPB8uBgyHNiTXv+RMNvVnrjS4UEYrLMkhuq1vpCodHjiW+z/95SDs/fg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/remapping": "^2.3.4",
@@ -2378,7 +2359,6 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.4.tgz",
 			"integrity": "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==",
-			"dev": true,
 			"license": "MIT"
 		}
 	}

--- a/ui/package.json
+++ b/ui/package.json
@@ -24,7 +24,6 @@
 		"@types/node": "^25.9.1",
 		"bits-ui": "^2.18.1",
 		"clsx": "^2.1.1",
-		"mode-watcher": "^1.1.0",
 		"svelte": "^5.55.2",
 		"svelte-check": "^4.4.6",
 		"svelte-sonner": "^1.2.1",
@@ -37,6 +36,7 @@
 	},
 	"dependencies": {
 		"@tailwindcss/vite": "^4.3.3",
+		"mode-watcher": "^1.1.0",
 		"tailwindcss": "^4.3.3"
 	}
 }

--- a/ui/src/lib/components/NavBar.svelte
+++ b/ui/src/lib/components/NavBar.svelte
@@ -9,7 +9,18 @@
 		PopoverContent,
 		PopoverTrigger
 	} from '$lib/components/ui/popover/index.js';
+	import {
+		DropdownMenu,
+		DropdownMenuContent,
+		DropdownMenuRadioGroup,
+		DropdownMenuRadioItem,
+		DropdownMenuTrigger
+	} from '$lib/components/ui/dropdown-menu/index.js';
+	import { mode, setMode, userPrefersMode } from 'mode-watcher';
 	import ChevronDownIcon from '@lucide/svelte/icons/chevron-down';
+	import SunIcon from '@lucide/svelte/icons/sun';
+	import MoonIcon from '@lucide/svelte/icons/moon';
+	import MonitorIcon from '@lucide/svelte/icons/monitor';
 	import logo from '$lib/assets/favicon.svg';
 
 	const settingsLinks = [
@@ -103,7 +114,41 @@
 				>Users</a
 			>
 		</nav>
-		<div class="ml-auto flex items-center">
+		<div class="ml-auto flex items-center gap-2">
+			<!-- Theme picker: Light / Dark / System. Defaults to the OS preference
+			     (mode-watcher's `system`) and persists an explicit choice in
+			     localStorage, so the `.dark` class on <html> survives reloads. -->
+			<DropdownMenu>
+				<DropdownMenuTrigger
+					class="flex size-9 items-center justify-center rounded-md text-primary-foreground transition-colors hover:bg-foreground/10 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring aria-expanded:bg-foreground/15"
+					aria-label="Toggle theme"
+				>
+					{#if mode.current === 'dark'}
+						<MoonIcon class="size-5" aria-hidden />
+					{:else}
+						<SunIcon class="size-5" aria-hidden />
+					{/if}
+				</DropdownMenuTrigger>
+				<DropdownMenuContent align="end">
+					<DropdownMenuRadioGroup
+						value={userPrefersMode.current}
+						onValueChange={(v) => setMode(v as 'light' | 'dark' | 'system')}
+					>
+						<DropdownMenuRadioItem value="light">
+							<SunIcon class="size-4" aria-hidden />
+							Light
+						</DropdownMenuRadioItem>
+						<DropdownMenuRadioItem value="dark">
+							<MoonIcon class="size-4" aria-hidden />
+							Dark
+						</DropdownMenuRadioItem>
+						<DropdownMenuRadioItem value="system">
+							<MonitorIcon class="size-4" aria-hidden />
+							System
+						</DropdownMenuRadioItem>
+					</DropdownMenuRadioGroup>
+				</DropdownMenuContent>
+			</DropdownMenu>
 			{#if showAccount}
 				<Popover>
 					<PopoverTrigger

--- a/ui/src/routes/+layout.svelte
+++ b/ui/src/routes/+layout.svelte
@@ -6,6 +6,7 @@
 	import { identity } from '$lib/identity.svelte';
 	import NavBar from '$lib/components/NavBar.svelte';
 	import { Toaster } from '$lib/components/ui/sonner/index.js';
+	import { ModeWatcher } from 'mode-watcher';
 
 	let { children } = $props();
 
@@ -36,3 +37,4 @@
 	{@render children()}
 </main>
 <Toaster />
+<ModeWatcher />

--- a/ui/src/routes/photos/+page.svelte
+++ b/ui/src/routes/photos/+page.svelte
@@ -29,7 +29,11 @@
 
 {#snippet thumbCell(p: Photo)}
 	<a href={`/photos/${p.id}`}>
-		<img class="thumb-img" src={dataUrlFor(p)} alt={p.alt_text || 'Photo thumbnail'} />
+		<img
+			class="block size-12 rounded object-cover"
+			src={dataUrlFor(p)}
+			alt={p.alt_text || 'Photo thumbnail'}
+		/>
 	</a>
 {/snippet}
 
@@ -70,13 +74,3 @@
 		/>
 	{/snippet}
 </AsyncSection>
-
-<style>
-	.thumb-img {
-		display: block;
-		width: 48px;
-		height: 48px;
-		object-fit: cover;
-		border-radius: 4px;
-	}
-</style>

--- a/ui/src/routes/photos/[id]/+page.svelte
+++ b/ui/src/routes/photos/[id]/+page.svelte
@@ -119,20 +119,24 @@
 
 <AsyncSection state={photo}>
 	{#snippet children(p)}
-		<img class="detail" src={dataUrlFor(p)} alt={p.alt_text || 'Photo'} />
+		<img
+			class="detail mt-2 block max-h-60 max-w-[360px] rounded-md border border-border"
+			src={dataUrlFor(p)}
+			alt={p.alt_text || 'Photo'}
+		/>
 
-		<dl class="meta">
+		<dl class="my-4 flex gap-6">
 			<div>
-				<dt>Alt text</dt>
-				<dd>{p.alt_text || '(none)'}</dd>
+				<dt class="text-sm text-muted-foreground">Alt text</dt>
+				<dd class="m-0">{p.alt_text || '(none)'}</dd>
 			</div>
 			<div>
-				<dt>File type</dt>
-				<dd>{photoTypeLabels[p.file_type] ?? 'unknown'}</dd>
+				<dt class="text-sm text-muted-foreground">File type</dt>
+				<dd class="m-0">{photoTypeLabels[p.file_type] ?? 'unknown'}</dd>
 			</div>
 			<div>
-				<dt>Owner</dt>
-				<dd>{p.owner}</dd>
+				<dt class="text-sm text-muted-foreground">Owner</dt>
+				<dd class="m-0">{p.owner}</dd>
 			</div>
 		</dl>
 
@@ -199,25 +203,3 @@
 		</div>
 	{/snippet}
 </AsyncSection>
-
-<style>
-	.detail {
-		max-width: 360px;
-		max-height: 240px;
-		border: 1px solid #ccc;
-		border-radius: 6px;
-		margin-top: 0.5rem;
-	}
-	.meta {
-		display: flex;
-		gap: 1.5rem;
-		margin: 1rem 0;
-	}
-	.meta dt {
-		font-size: 0.85rem;
-		color: #666;
-	}
-	.meta dd {
-		margin: 0;
-	}
-</style>

--- a/ui/src/routes/rulesets/[id]/+page.svelte
+++ b/ui/src/routes/rulesets/[id]/+page.svelte
@@ -236,18 +236,18 @@
 
 <AsyncSection state={ruleset}>
 	{#snippet children(r)}
-		<dl class="meta">
+		<dl class="my-4 flex gap-6">
 			<div>
-				<dt>Revision</dt>
-				<dd>{r.revision}</dd>
+				<dt class="text-sm text-muted-foreground">Revision</dt>
+				<dd class="m-0">{r.revision}</dd>
 			</div>
 			<div>
-				<dt>Date</dt>
-				<dd>{new Date(r.date).toLocaleString()}</dd>
+				<dt class="text-sm text-muted-foreground">Date</dt>
+				<dd class="m-0">{new Date(r.date).toLocaleString()}</dd>
 			</div>
 			<div>
-				<dt>Superseded by</dt>
-				<dd>
+				<dt class="text-sm text-muted-foreground">Superseded by</dt>
+				<dd class="m-0">
 					{#if r.superseded_by}
 						<a href={`/rulesets/${r.superseded_by}`}>{r.superseded_by}</a>
 					{:else}
@@ -287,7 +287,7 @@
 				{:else}
 					<ol class="flex flex-col gap-3">
 						{#each sections as section, i (section.section_id)}
-							<li class="section-card">
+							<li class="rounded-lg border border-border p-3">
 								<div class="flex items-center justify-between gap-2">
 									<span class="font-medium">
 										{i + 1}. {section.title || '(untitled)'}
@@ -358,7 +358,9 @@
 									</form>
 								{:else}
 									{#if section.markdown}
-										<p class="section-contents">{section.markdown}</p>
+										<p class="mt-2 whitespace-pre-wrap text-sm text-muted-foreground">
+											{section.markdown}
+										</p>
 									{/if}
 								{/if}
 							</li>
@@ -432,29 +434,3 @@
 		</div>
 	{/snippet}
 </AsyncSection>
-
-<style>
-	.meta {
-		display: flex;
-		gap: 1.5rem;
-		margin: 1rem 0;
-	}
-	.meta dt {
-		font-size: 0.85rem;
-		color: #666;
-	}
-	.meta dd {
-		margin: 0;
-	}
-	.section-card {
-		border: 1px solid var(--border);
-		border-radius: var(--radius);
-		padding: 0.75rem;
-	}
-	.section-contents {
-		margin-top: 0.5rem;
-		white-space: pre-wrap;
-		font-size: 0.875rem;
-		color: #555;
-	}
-</style>


### PR DESCRIPTION
## What

The dark palette in `ui/src/routes/styles.css` (33 tokens + every `dark:` variant in the vendored components) was fully styled but unreachable — nothing ever added the `.dark` class. This wires it up end-to-end.

## Changes

- **`<ModeWatcher />` in `+layout.svelte`** — defaults to the OS preference (`system`) and persists an explicit choice in localStorage under `mode-watcher-mode`, surviving reloads.
- **Theme picker in the nav bar** (Light / Dark / System) via the already-vendored `dropdown-menu`, next to the account popover. Accessible name `Toggle theme` (distinct from the `Settings` button asserted in `smoke.spec.ts`), keyboard-reachable with a visible focus ring (`focus-visible:outline-2 outline-ring`, verified `solid 2px oklch(0.72 0.15 155)`).
- **Dark-mode sweep** — replaced the last three raw `<style>` blocks with hardcoded colors (`#ccc` / `#666` / `#555`) with semantic tokens:
  - `photos/+page.svelte` thumbnail (`thumb-img` → Tailwind classes, style block removed)
  - `photos/[id]/+page.svelte` detail image + meta (border `#ccc` → `border-border`, `#666` → `text-muted-foreground`)
  - `rulesets/[id]/+page.svelte` meta + section cards/contents
  - The 5 raw-`<table>` spots already use only theme tokens (`border-b` → `border-border` via the base layer, `text-muted-foreground`, `bg-muted/50`), so they flip correctly with `.dark` — no change needed.
- Moved `mode-watcher` from `devDependencies` to `dependencies` (runtime import).

## Verification

- `npm run check`: 0 errors / 0 warnings
- Manual dark-mode sweep (headless Chromium, `colorScheme: dark`): `.dark` applied by default; Light/Dark persist across reloads; System re-honours `prefers-color-scheme`; keyboard focus ring confirmed; list, detail, form, and tabbed pages (facilities, ratings, organizations, photos, drafts, seasons, teams, users) all render dark (~90%+ dark pixels per screenshot).
- `make e2e`: 40/40 passed × 3 full runs. One run hit an unrelated parallel-run flake in `scoring-structure-secondary` (reorder race — passes 3/3 in isolation and 2/2 other full runs).

Closes #191