### PR TITLE
UI (bug): add closed field to Week client type and currentWeek helper

### DIFF
--- a/ui/src/lib/week.test.ts
+++ b/ui/src/lib/week.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { currentWeek, type Week } from './week';
+
+function week(id: string, date: string, closed: boolean): Week {
+	return { id, draft_id: 'd', date, note: '', closed };
+}
+
+describe('currentWeek', () => {
+	it('returns null when every week is closed', () => {
+		expect(
+			currentWeek([
+				week('a', '2026-01-05T08:00:00Z', true),
+				week('b', '2026-01-12T08:00:00Z', true)
+			])
+		).toBeNull();
+	});
+
+	it('returns the earliest week when none are closed', () => {
+		expect(
+			currentWeek([
+				week('a', '2026-01-05T08:00:00Z', false),
+				week('b', '2026-01-12T08:00:00Z', false)
+			])?.id
+		).toBe('a');
+	});
+
+	it('returns the first unclosed week in a mixed list', () => {
+		expect(
+			currentWeek([
+				week('a', '2026-01-05T08:00:00Z', true),
+				week('b', '2026-01-12T08:00:00Z', false),
+				week('c', '2026-01-19T08:00:00Z', false)
+			])?.id
+		).toBe('b');
+	});
+
+	it('returns null for an empty list', () => {
+		expect(currentWeek([])).toBeNull();
+	});
+
+	it('sorts by date rather than relying on input order', () => {
+		expect(
+			currentWeek([
+				week('c', '2026-01-19T08:00:00Z', false),
+				week('a', '2026-01-05T08:00:00Z', true),
+				week('b', '2026-01-12T08:00:00Z', false)
+			])?.id
+		).toBe('b');
+	});
+});

--- a/ui/src/lib/week.ts
+++ b/ui/src/lib/week.ts
@@ -12,6 +12,27 @@ export interface Week {
 	draft_id: string;
 	date: string;
 	note: string;
+	/**
+	 * Closed is set by the season commissioner once every team match in the
+	 * week is complete. A closed week is final; standings are computed from
+	 * closed (and completed) weeks' team matches.
+	 */
+	closed: boolean;
+}
+
+/**
+ * The current week: the first week (by date) that has not been closed.
+ * Null if all weeks are closed.
+ *
+ * `GET /api/week?season_id=` returns weeks sorted by date, but the list is
+ * sorted defensively here so the helper keeps working if that guarantee ever
+ * changes.
+ */
+export function currentWeek(weeks: Week[]): Week | null {
+	const byDate = [...weeks].sort(
+		(a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()
+	);
+	return byDate.find((w) => !w.closed) ?? null;
 }
 
 async function unwrap(res: Response): Promise<any> {

--- a/ui/vitest.config.ts
+++ b/ui/vitest.config.ts
@@ -1,6 +1,11 @@
+import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+	// The sveltekit plugin provides the `$lib` / `$app` aliases and compiles
+	// `.svelte.ts` modules, so unit tests can import from the real API client
+	// modules (e.g. src/lib/week.ts) rather than only from `$lib`-free files.
+	plugins: [sveltekit()],
 	test: {
 		// Only pick up unit tests under src/ — the Playwright suites live in
 		// e2e/*.spec.ts and run via `npm run test:e2e`.


### PR DESCRIPTION
Closes #195

## What
- Adds `closed: boolean` to the `Week` interface in `ui/src/lib/week.ts`, matching the backend `model/week.go` field. The flag is present in every `GET /api/week?season_id=` response but was invisible to TypeScript.
- Adds a `currentWeek(weeks)` helper: the first unclosed week by date, or `null` when all are closed. Sorts defensively so it does not silently break if the API's date ordering guarantee changes.
- Adds unit tests (`ui/src/lib/week.test.ts`) covering all-closed / none-closed / mixed / empty / out-of-order input, following the `session.test.ts` precedent.
- Adds the sveltekit plugin to the vitest config so unit tests can import real API-client modules (`$lib`/`$app` aliases, `.svelte.ts` compilation).

## Verification
- Real response check: ran the backend with `--dev-token`, created a season + two weeks via the API, and confirmed `GET /api/week?season_id=` returns `closed: false` on each week.
- Audit: no remaining date-only inference of week open/closed state in the UI (the only week-date use is display formatting; the pre-existing `detail?.closed` badge reads the separate match-sheet flag).
- `npm run test` (13 tests) and `npm run check` (0 errors) green.
- `make e2e` green: all 40 Playwright tests pass, including the week close flow.