### PR TITLE
UI: real landing page — public hero (signed out)

### DIFF
--- a/ui/e2e/smoke.spec.ts
+++ b/ui/e2e/smoke.spec.ts
@@ -11,4 +11,10 @@ test('homepage renders a landing page with nav and login form', async ({ page })
 	// Not logged in, so the login form is displayed on the root route.
 	await expect(page.getByRole('heading', { name: 'IntraClub' })).toBeVisible();
 	await expect(page.getByLabel('Email')).toBeVisible();
+
+	// The signed-out hero explains the app lifecycle with a how-it-works strip.
+	await expect(page.getByRole('heading', { name: 'How it works' })).toBeVisible();
+	await expect(page.getByRole('heading', { name: 'Draft', exact: true })).toBeVisible();
+	await expect(page.getByRole('heading', { name: 'Season', exact: true })).toBeVisible();
+	await expect(page.getByRole('heading', { name: 'Score', exact: true })).toBeVisible();
 });

--- a/ui/src/lib/components/LoginForm.svelte
+++ b/ui/src/lib/components/LoginForm.svelte
@@ -2,38 +2,46 @@
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
 	import { Label } from '$lib/components/ui/label/index.js';
+	import Loader2Icon from '@lucide/svelte/icons/loader-2';
 
 	let email = $state('');
 	let message = $state('');
 	let error = $state('');
 	let devLink = $state('');
+	let submitting = $state(false);
 
 	async function handleSubmit(e: Event) {
 		e.preventDefault();
+		if (submitting) return;
+		submitting = true;
 		message = '';
 		error = '';
 		devLink = '';
 
-		const res = await fetch('/api/one_time_password', {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify({ email })
-		});
+		try {
+			const res = await fetch('/api/one_time_password', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ email })
+			});
 
-		if (!res.ok) {
+			if (!res.ok) {
+				const body = await res.json();
+				error = body.error ?? 'Failed to send login link';
+				return;
+			}
+
 			const body = await res.json();
-			error = body.error ?? 'Failed to send login link';
-			return;
-		}
-
-		const body = await res.json();
-		if (body?.token) {
-			// DEV MODE ONLY: the API returned the magic-link token in the response
-			// instead of emailing it. Render it as a clickable link.
-			devLink = `/auth/callback?token=${encodeURIComponent(body.token)}`;
-			message = 'DEV MODE ONLY — no email was sent. Use the magic link below to log in.';
-		} else {
-			message = 'Check your email for the login link.';
+			if (body?.token) {
+				// DEV MODE ONLY: the API returned the magic-link token in the response
+				// instead of emailing it. Render it as a clickable link.
+				devLink = `/auth/callback?token=${encodeURIComponent(body.token)}`;
+				message = 'DEV MODE ONLY — no email was sent. Use the magic link below to log in.';
+			} else {
+				message = 'Check your email for the login link.';
+			}
+		} finally {
+			submitting = false;
 		}
 	}
 </script>
@@ -43,7 +51,14 @@
 		<Label for="email">Email</Label>
 		<Input id="email" type="email" bind:value={email} required />
 	</div>
-	<Button type="submit" class="w-fit">Send login link</Button>
+	<Button type="submit" disabled={submitting} class="w-fit">
+		{#if submitting}
+			<Loader2Icon class="size-4 animate-spin" aria-hidden />
+			Sending…
+		{:else}
+			Send login link
+		{/if}
+	</Button>
 </form>
 
 {#if message}

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -1,6 +1,16 @@
 <script lang="ts">
 	import { isLoggedIn, sessionExpired, SESSION_EXPIRED_MESSAGE } from '$lib/auth';
 	import LoginForm from '$lib/components/LoginForm.svelte';
+	import {
+		Card,
+		CardContent,
+		CardDescription,
+		CardHeader,
+		CardTitle
+	} from '$lib/components/ui/card/index.js';
+	import DraftingCompassIcon from '@lucide/svelte/icons/drafting-compass';
+	import CalendarDaysIcon from '@lucide/svelte/icons/calendar-days';
+	import TrophyIcon from '@lucide/svelte/icons/trophy';
 
 	let loggedIn = $state(false);
 
@@ -23,12 +33,78 @@
 	<h1 class="text-2xl font-semibold tracking-tight">Welcome to IntraClub</h1>
 	<p class="mt-2 text-muted-foreground">Head to <a href="/facilities" class="text-primary underline-offset-4 hover:underline">Facilities</a>, <a href="/formats" class="text-primary underline-offset-4 hover:underline">Formats</a>, <a href="/ratings" class="text-primary underline-offset-4 hover:underline">Ratings</a>, <a href="/rulesets" class="text-primary underline-offset-4 hover:underline">Rulesets</a>, <a href="/scoring-structures" class="text-primary underline-offset-4 hover:underline">Scoring Structures</a>, or <a href="/playoff-structures" class="text-primary underline-offset-4 hover:underline">Playoff Structures</a> to get started.</p>
 {:else}
-	<h1 class="text-2xl font-semibold tracking-tight">IntraClub</h1>
+	<section class="mx-auto max-w-2xl pt-4 text-center">
+		<h1 class="text-4xl font-bold tracking-tight sm:text-5xl">IntraClub</h1>
+		<p class="mt-4 text-lg text-muted-foreground">
+			Run your intra-club season from draft to trophy — snake-order drafts,
+			weekly matches, per-line scoring, and playoff standings, all under one
+			roof.
+		</p>
+	</section>
+
 	{#if $sessionExpired}
-		<p class="mt-2 text-sm font-semibold text-destructive" role="status">{SESSION_EXPIRED_MESSAGE}</p>
+		<p class="mt-6 text-center text-sm font-semibold text-destructive" role="status">
+			{SESSION_EXPIRED_MESSAGE}
+		</p>
 	{/if}
-	<p class="mt-2 text-muted-foreground">Welcome! Log in to manage your club.</p>
-	<div class="mt-4">
-		<LoginForm />
+
+	<div class="mx-auto mt-8 max-w-sm">
+		<Card>
+			<CardHeader>
+				<CardTitle level={2} class="text-center">Welcome to your club</CardTitle>
+				<CardDescription class="text-center">
+					Enter your email and we'll send you a login link.
+				</CardDescription>
+			</CardHeader>
+			<CardContent>
+				<LoginForm />
+			</CardContent>
+		</Card>
 	</div>
+
+	<section class="mt-16">
+		<h2 class="text-center text-2xl font-semibold tracking-tight">How it works</h2>
+		<div class="mt-8 grid gap-6 sm:grid-cols-3">
+			<Card>
+				<CardHeader>
+					<DraftingCompassIcon class="size-6 text-primary" aria-hidden />
+					<CardTitle>Draft</CardTitle>
+				</CardHeader>
+				<CardContent>
+					<p class="text-muted-foreground">
+						Grade players before the draft, then pick in snake order to build
+						balanced teams.
+					</p>
+				</CardContent>
+			</Card>
+			<Card>
+				<CardHeader>
+					<CalendarDaysIcon class="size-6 text-primary" aria-hidden />
+					<CardTitle>Season</CardTitle>
+				</CardHeader>
+				<CardContent>
+					<p class="text-muted-foreground">
+						Players share weekly availability; captains set lineups against
+						your club's format.
+					</p>
+				</CardContent>
+			</Card>
+			<Card>
+				<CardHeader>
+					<TrophyIcon class="size-6 text-primary" aria-hidden />
+					<CardTitle>Score</CardTitle>
+				</CardHeader>
+				<CardContent>
+					<p class="text-muted-foreground">
+						Per-line scoring, composite structures and tie-breakers decide
+						matches, standings and the playoffs.
+					</p>
+				</CardContent>
+			</Card>
+		</div>
+		<p class="mt-8 text-center text-sm text-muted-foreground">
+			Club rules live in an amendable ruleset — commissioners propose changes
+			and captains vote.
+		</p>
+	</section>
 {/if}


### PR DESCRIPTION
Closes #197

## What changed

**`ui/src/routes/+page.svelte`** — the signed-out branch is now a branded hero:
- Centered `<h1>IntraClub</h1>` with one sentence of positioning copy
- The existing `LoginForm`, unchanged in behaviour, presented in a `Card`
- A **Draft → Season → Score** how-it-works strip (three cards, `<h2>How it works` + `<h3>`s), plus a governance footnote
- The session-expired `role="status"` message is preserved

**`ui/src/lib/components/LoginForm.svelte`** — while-here polish: `submitting` state disables the button, swaps the label to `Sending…` with a spinner, and guards double submits. The button's accessible name `Send login link` is unchanged (all 28 e2e specs that click it by name stay green).

**`ui/e2e/smoke.spec.ts`** — now also asserts the how-it-works strip headings.

## E2E landmine compliance

- Exactly one heading containing "IntraClub" (`<h1>` only) — smoke's strict-mode `getByRole('heading', { name: 'IntraClub' })` passes
- No link inside `<main>` named "Log in" other than the dev magic link — 20+ specs scoped `getByRole('main').getByRole('link', { name: 'Log in' })` pass
- `LoginForm` rendered once, so `getByLabel('Email')` resolves uniquely
- No links in the hero at all, so no collisions with nav's Drafts/Teams/Users/Photos/Seasons

## Verification

- `npm run check` (svelte-check): 0 errors / 0 warnings
- `npm run test` (vitest): 13 passed
- `make e2e`: **40/40 passed, run twice** (required by the ticket for the hydration race)
- Manual: light + dark mode, 375px viewport — hero content has zero horizontal overflow (the page-level nav overflow is pre-existing and tracked separately in #200)
