### PR TITLE
UI: mobile navigation + responsive tables (Closes #200)

### DIFF
--- a/ui/e2e/mobile-nav.spec.ts
+++ b/ui/e2e/mobile-nav.spec.ts
@@ -1,0 +1,108 @@
+import { expect, test, type Page } from '@playwright/test';
+import { waitForHydration } from './helpers';
+
+// Dedicated mobile spec for #200 (mobile navigation + responsive tables) at a
+// 375px viewport. The full mobile-viewport project / visual-regression
+// baselines live in #201; this stays small so the two don't duplicate work.
+test.use({ viewport: { width: 375, height: 667 } });
+
+const API = 'http://127.0.0.1:8080/api';
+
+async function login(page: Page) {
+	await page.goto('/login');
+	await page.waitForLoadState('networkidle');
+	await page.getByLabel('Email').fill('jdarthur@gatech.edu');
+	await page.getByRole('button', { name: 'Send login link' }).click();
+	const link = page.getByRole('main').getByRole('link', { name: 'Log in' });
+	await expect(link).toBeVisible();
+	await link.click();
+	await expect(page).toHaveURL('/');
+}
+
+// The document must fit inside the viewport: no horizontal body scroll.
+async function expectNoHorizontalScroll(page: Page) {
+	const overflow = await page.evaluate(() => {
+		const doc = document.documentElement;
+		return doc.scrollWidth - doc.clientWidth;
+	});
+	expect(overflow, `document overflows horizontally by ${overflow}px`).toBeLessThanOrEqual(0);
+}
+
+test('mobile: sheet menu opens, closes, and navigates', async ({ page }) => {
+	await page.goto('/');
+	await waitForHydration(page);
+
+	// Exactly one <nav> and exactly one Email-labelled input in the DOM, and no
+	// horizontal body scroll at 375px.
+	await expect(page.getByRole('navigation')).toHaveCount(1);
+	await expect(page.getByLabel('Email')).toHaveCount(1);
+	await expectNoHorizontalScroll(page);
+
+	// Desktop nav is hidden at this viewport; the mobile trigger is exposed.
+	await expect(page.getByRole('button', { name: 'Settings' })).toBeHidden();
+	await expect(page.getByRole('button', { name: 'Open menu' })).toBeVisible();
+
+	// Open: the sheet (a dialog) appears with the nav links. Still exactly one
+	// <nav> — the sheet links are not wrapped in a second one.
+	await page.getByRole('button', { name: 'Open menu' }).click();
+	const dialog = page.getByRole('dialog');
+	await expect(dialog).toBeVisible();
+	await expect(page.getByRole('link', { name: 'Seasons' })).toBeVisible();
+	await expect(page.getByRole('link', { name: 'Drafts' })).toBeVisible();
+	await expect(page.getByRole('link', { name: 'Organizations' })).toBeVisible();
+	await expect(page.getByRole('navigation')).toHaveCount(1);
+
+	// Keyboard: Escape closes the sheet (focus is trapped inside while open).
+	await page.keyboard.press('Escape');
+	await expect(page.getByRole('link', { name: 'Seasons' })).toHaveCount(0);
+
+	// Re-open and navigate: clicking a link closes the sheet and routes.
+	await page.getByRole('button', { name: 'Open menu' }).click();
+	await page.getByRole('link', { name: 'Drafts' }).click();
+	await page.waitForURL('/drafts');
+	await waitForHydration(page);
+	await expect(page.getByRole('link', { name: 'Drafts' })).toHaveCount(0);
+	await expectNoHorizontalScroll(page);
+});
+
+test('mobile: list pages have no horizontal scroll', async ({ page }) => {
+	await login(page);
+	for (const path of ['/drafts', '/seasons', '/teams', '/users', '/photos', '/organizations']) {
+		await page.goto(path);
+		await waitForHydration(page);
+		await expectNoHorizontalScroll(page);
+	}
+});
+
+test('mobile: vertical tab page stacks and stays usable', async ({ page }) => {
+	await login(page);
+	const token = await page.evaluate(() => localStorage.getItem('intraclub_jwt') ?? '');
+	expect(token).toBeTruthy();
+
+	// Create an organization via the API so the detail page (vertical tabs)
+	// has something to render.
+	const unique = Date.now();
+	const create = await page.request.post(`${API}/organization`, {
+		headers: { 'Content-Type': 'application/json', 'X-INTRACLUB-TOKEN': token },
+		data: { name: `Mobile Org ${unique}` }
+	});
+	expect(create.ok()).toBeTruthy();
+	const org = (await create.json()).resource as { id: string };
+
+	await page.goto(`/organizations/${org.id}`);
+	await waitForHydration(page);
+	await expectNoHorizontalScroll(page);
+
+	// The tab rail renders (stacked at this width) and switching tabs works.
+	const membersTab = page.getByRole('tab', { name: 'Members' });
+	await expect(membersTab).toBeVisible();
+	await membersTab.click();
+	await expect(page.getByText('0 members')).toBeVisible();
+	await expectNoHorizontalScroll(page);
+
+	// Clean up the organization so the list doesn't accumulate rows.
+	const cleanup = await page.request.delete(`${API}/organization/${org.id}`, {
+		headers: { 'X-INTRACLUB-TOKEN': token }
+	});
+	expect(cleanup.ok()).toBeTruthy();
+});

--- a/ui/e2e/seasons.spec.ts
+++ b/ui/e2e/seasons.spec.ts
@@ -121,10 +121,9 @@ test('seasons list renders created seasons and links to the detail page', async 
 	expect(seasonRes.ok()).toBeTruthy();
 	const season = (await seasonRes.json()).resource as { id: string };
 
-	// The Settings nav exposes Seasons.
+	// The nav exposes Seasons as a top-level link (promoted out of Settings).
 	await page.goto('/');
 	await waitForHydration(page);
-	await page.getByRole('button', { name: 'Settings' }).click();
 	await expect(page.getByRole('link', { name: 'Seasons' })).toBeVisible();
 
 	// The /seasons list shows the new season and links to its detail page.

--- a/ui/src/lib/components/NavBar.svelte
+++ b/ui/src/lib/components/NavBar.svelte
@@ -17,14 +17,15 @@
 		DropdownMenuTrigger
 	} from '$lib/components/ui/dropdown-menu/index.js';
 	import { mode, setMode, userPrefersMode } from 'mode-watcher';
+	import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '$lib/components/ui/sheet/index.js';
 	import ChevronDownIcon from '@lucide/svelte/icons/chevron-down';
+	import MenuIcon from '@lucide/svelte/icons/menu';
 	import SunIcon from '@lucide/svelte/icons/sun';
 	import MoonIcon from '@lucide/svelte/icons/moon';
 	import MonitorIcon from '@lucide/svelte/icons/monitor';
 	import logo from '$lib/assets/favicon.svg';
 
 	const settingsLinks = [
-		{ href: '/seasons', label: 'Seasons' },
 		{ href: '/organizations', label: 'Organizations' },
 		{ href: '/facilities', label: 'Facilities' },
 		{ href: '/formats', label: 'Formats' },
@@ -34,11 +35,31 @@
 		{ href: '/playoff-structures', label: 'Playoff Structures' }
 	];
 
+	// Top-level destinations, shown as links in the desktop nav and in the
+	// mobile sheet. Seasons lives here (not in Settings) because it is the
+	// app's primary object.
+	const topLevelLinks = [
+		{ href: '/seasons', label: 'Seasons' },
+		{ href: '/drafts', label: 'Drafts' },
+		{ href: '/teams', label: 'Teams' },
+		{ href: '/photos', label: 'Photos' },
+		{ href: '/users', label: 'Users' }
+	];
+
 	// Shared look for every nav item (Settings trigger + top-level links): same
 	// height, size and weight so nothing reads smaller or lighter than the rest.
 	const navItemClass =
 		'flex h-9 items-center rounded-md px-3 text-base font-medium text-primary-foreground transition-colors hover:bg-foreground/10';
 	const navItemActiveClass = 'bg-foreground/15';
+
+	// Mobile sheet links sit on the popover surface instead of the primary bar.
+	const mobileNavItemClass =
+		'flex h-9 items-center rounded-md px-3 text-base font-medium transition-colors hover:bg-muted';
+	const mobileNavItemActiveClass = 'bg-muted text-foreground';
+
+	// Sheet state: bind:open keeps the trigger and content in sync so links can
+	// close the sheet (bits-ui unmounts the content while closed).
+	let mobileOpen = $state(false);
 
 	function isActive(href: string) {
 		const p = page.url.pathname;
@@ -58,61 +79,107 @@
 	);
 
 	function logout() {
+		mobileOpen = false;
 		clearToken();
 		goto('/');
+	}
+
+	function closeMobile() {
+		mobileOpen = false;
 	}
 </script>
 
 <header
 	class="sticky top-0 z-40 w-full border-b border-primary-foreground/20 bg-primary text-primary-foreground"
 >
-	<div class="mx-auto flex h-14 max-w-6xl items-center gap-6 px-6">
+	<div class="mx-auto flex h-14 max-w-6xl items-center gap-3 px-4 md:gap-6 md:px-6">
 		<a href="/" class="flex items-center gap-2 text-base font-semibold tracking-tight">
 			<img src={logo} alt="" class="size-6" />
 			IntraClub
 		</a>
+		<!-- Exactly one <nav>: it always carries the mobile sheet trigger and the
+		     desktop links. The sheet's links live inside SheetContent (unmounted
+		     while closed), so at most one set of nav links is in the a11y tree. -->
 		<nav class="flex items-center gap-1">
-			<Popover>
-				<PopoverTrigger
-					class={`${navItemClass} ${settingsActive ? navItemActiveClass : ''} aria-expanded:bg-foreground/15 aria-expanded:text-primary-foreground`}
-					aria-current={settingsActive ? 'true' : undefined}
-					>Settings</PopoverTrigger
+			<Sheet bind:open={mobileOpen}>
+				<SheetTrigger
+					class="flex size-9 items-center justify-center rounded-md text-primary-foreground transition-colors hover:bg-foreground/10 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring md:hidden"
+					aria-label="Open menu"
 				>
-				<PopoverContent class="flex flex-col gap-0.5 p-1.5" align="start">
-					{#each settingsLinks as link}
-						<a
-							href={link.href}
-							class="rounded-md px-2.5 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground {isActive(link.href) ? 'bg-muted font-semibold text-foreground' : ''}"
-							aria-current={isActive(link.href) ? 'page' : undefined}
-							>{link.label}</a
+					<MenuIcon class="size-5" aria-hidden />
+				</SheetTrigger>
+				<SheetContent side="left" class="w-80">
+					<SheetHeader class="border-b px-4 pb-3">
+						<SheetTitle>Menu</SheetTitle>
+					</SheetHeader>
+					<div class="flex flex-col gap-0.5 overflow-y-auto p-3">
+						<p
+							class="px-3 pb-1 pt-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+							>Settings</p
 						>
-					{/each}
-				</PopoverContent>
-			</Popover>
-			<a
-				href="/drafts"
-				class={`${navItemClass} ${isActive('/drafts') ? navItemActiveClass : ''}`}
-				aria-current={isActive('/drafts') ? 'page' : undefined}
-				>Drafts</a
-			>
-			<a
-				href="/teams"
-				class={`${navItemClass} ${isActive('/teams') ? navItemActiveClass : ''}`}
-				aria-current={isActive('/teams') ? 'page' : undefined}
-				>Teams</a
-			>
-			<a
-				href="/photos"
-				class={`${navItemClass} ${isActive('/photos') ? navItemActiveClass : ''}`}
-				aria-current={isActive('/photos') ? 'page' : undefined}
-				>Photos</a
-			>
-			<a
-				href="/users"
-				class={`${navItemClass} ${isActive('/users') ? navItemActiveClass : ''}`}
-				aria-current={isActive('/users') ? 'page' : undefined}
-				>Users</a
-			>
+						{#each settingsLinks as link}
+							<a
+								href={link.href}
+								onclick={closeMobile}
+								class={`${mobileNavItemClass} ${isActive(link.href) ? mobileNavItemActiveClass : ''}`}
+								aria-current={isActive(link.href) ? 'page' : undefined}
+								>{link.label}</a
+							>
+						{/each}
+						<div class="my-2 border-t"></div>
+						{#each topLevelLinks as link}
+							<a
+								href={link.href}
+								onclick={closeMobile}
+								class={`${mobileNavItemClass} ${isActive(link.href) ? mobileNavItemActiveClass : ''}`}
+								aria-current={isActive(link.href) ? 'page' : undefined}
+								>{link.label}</a
+							>
+						{/each}
+					</div>
+					<div class="mt-auto border-t p-3">
+						{#if showAccount}
+							<Button variant="ghost" class="w-full justify-start text-base" onclick={logout}>
+								Log out
+							</Button>
+						{:else}
+							<a
+								href="/login"
+								onclick={closeMobile}
+								class="flex h-9 items-center rounded-md px-3 text-base font-medium transition-colors hover:bg-muted"
+								>Log in</a
+							>
+						{/if}
+					</div>
+				</SheetContent>
+			</Sheet>
+			<div class="hidden items-center gap-1 md:flex">
+				<Popover>
+					<PopoverTrigger
+						class={`${navItemClass} ${settingsActive ? navItemActiveClass : ''} aria-expanded:bg-foreground/15 aria-expanded:text-primary-foreground`}
+						aria-current={settingsActive ? 'true' : undefined}
+						>Settings</PopoverTrigger
+					>
+					<PopoverContent class="flex flex-col gap-0.5 p-1.5" align="start">
+						{#each settingsLinks as link}
+							<a
+								href={link.href}
+								class="rounded-md px-2.5 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground {isActive(link.href) ? 'bg-muted font-semibold text-foreground' : ''}"
+								aria-current={isActive(link.href) ? 'page' : undefined}
+								>{link.label}</a
+							>
+						{/each}
+					</PopoverContent>
+				</Popover>
+				{#each topLevelLinks as link}
+					<a
+						href={link.href}
+						class={`${navItemClass} ${isActive(link.href) ? navItemActiveClass : ''}`}
+						aria-current={isActive(link.href) ? 'page' : undefined}
+						>{link.label}</a
+					>
+				{/each}
+			</div>
 		</nav>
 		<div class="ml-auto flex items-center gap-2">
 			<!-- Theme picker: Light / Dark / System. Defaults to the OS preference
@@ -160,7 +227,7 @@
 								class="flex size-6 shrink-0 items-center justify-center rounded-full bg-foreground/15 text-xs font-semibold"
 								>{identity.initials}</span
 							>
-							<span class="max-w-40 truncate">{identity.displayName}</span>
+							<span class="max-sm:hidden max-w-40 truncate">{identity.displayName}</span>
 						{:else}
 							<span class="text-sm text-primary-foreground/80">Account</span>
 						{/if}

--- a/ui/src/routes/drafts/[id]/+page.svelte
+++ b/ui/src/routes/drafts/[id]/+page.svelte
@@ -404,9 +404,9 @@
 	<title>Intraclub | {draft ? draft.name : 'Draft'}</title>
 </svelte:head>
 
-<div class="flex items-center gap-4">
+<div class="flex flex-wrap items-center gap-x-4 gap-y-2">
 	<h1 class="text-2xl font-semibold tracking-tight">{draft?.name ?? 'Draft'}</h1>
-	<div class="ml-auto flex items-center gap-3">
+	<div class="ml-auto flex flex-wrap items-center gap-x-3 gap-y-2">
 		<a href={`/drafts/${id()}/draft`} class="text-sm text-muted-foreground hover:text-foreground">
 			Live draft board →
 		</a>
@@ -483,8 +483,8 @@
 		<p class="mt-4 text-sm font-medium text-destructive">{actionError}</p>
 	{/if}
 
-	<Tabs bind:value={activeTab} orientation="vertical" class="mt-6 flex gap-6">
-		<TabsList class="h-fit w-56 shrink-0 items-stretch">
+	<Tabs bind:value={activeTab} orientation="vertical" class="mt-6 flex flex-col gap-6 md:flex-row">
+		<TabsList class="h-fit w-full items-stretch md:w-56 md:shrink-0">
 			<TabsTrigger
 				value="captains"
 				class="group justify-start gap-2.5 px-3 py-2 text-base"

--- a/ui/src/routes/drafts/[id]/grades/+page.svelte
+++ b/ui/src/routes/drafts/[id]/grades/+page.svelte
@@ -205,7 +205,7 @@
 	<title>Intraclub | {draft ? `${draft.name} — Grades` : 'Pre-draft grades'}</title>
 </svelte:head>
 
-<div class="flex items-center gap-4">
+<div class="flex flex-wrap items-center gap-x-4 gap-y-2">
 	<h1 class="text-2xl font-semibold tracking-tight">{draft?.name ?? 'Pre-draft grades'}</h1>
 	<a href={`/drafts/${id()}`} class="text-sm text-muted-foreground hover:text-foreground">
 		&larr; Draft setup

--- a/ui/src/routes/drafts/[id]/results/+page.svelte
+++ b/ui/src/routes/drafts/[id]/results/+page.svelte
@@ -81,9 +81,9 @@
 	<title>Intraclub | {draft ? `${draft.name} — Results` : 'Draft results'}</title>
 </svelte:head>
 
-<div class="flex items-center gap-4">
+<div class="flex flex-wrap items-center gap-x-4 gap-y-2">
 	<h1 class="text-2xl font-semibold tracking-tight">{draft?.name ?? 'Draft results'}</h1>
-	<div class="ml-auto flex items-center gap-3">
+	<div class="ml-auto flex flex-wrap items-center gap-x-3 gap-y-2">
 		<a href={`/drafts/${id()}`} class="text-sm text-muted-foreground hover:text-foreground">
 			&larr; Draft setup
 		</a>

--- a/ui/src/routes/organizations/[id]/+page.svelte
+++ b/ui/src/routes/organizations/[id]/+page.svelte
@@ -176,8 +176,8 @@
 			</Alert>
 		{/if}
 
-		<Tabs bind:value={activeTab} orientation="vertical" class="mt-6 flex gap-6">
-			<TabsList class="h-fit w-56 shrink-0 items-stretch">
+		<Tabs bind:value={activeTab} orientation="vertical" class="mt-6 flex flex-col gap-6 md:flex-row">
+			<TabsList class="h-fit w-full items-stretch md:w-56 md:shrink-0">
 				<TabsTrigger
 					value="details"
 					class="group justify-start gap-2.5 px-3 py-2 text-base"

--- a/ui/src/routes/seasons/[id]/+page.svelte
+++ b/ui/src/routes/seasons/[id]/+page.svelte
@@ -729,9 +729,9 @@
 	<title>Intraclub | {season ? season.name : 'Season'}</title>
 </svelte:head>
 
-<div class="flex items-center gap-4">
+<div class="flex flex-wrap items-center gap-x-4 gap-y-2">
 	<h1 class="text-2xl font-semibold tracking-tight">{season?.name ?? 'Season'}</h1>
-	<div class="ml-auto flex items-center gap-3">
+	<div class="ml-auto flex flex-wrap items-center gap-x-3 gap-y-2">
 		{#if season}
 							<a
 								href={`/seasons/${season.id}/proposals`}


### PR DESCRIPTION
## What

Implements #200 — makes the app usable at 375px:

- **Mobile nav:** a `Sheet`-based menu below `md`. One `<nav>` stays in the DOM; the mobile links live inside `SheetContent` (unmounted while closed) and the desktop links sit in a `hidden md:flex` wrapper. Trigger button is `md:hidden` with `aria-label="Open menu"`. The sheet traps focus (bits-ui Dialog), closes on Escape/overlay, and every link closes it on navigation.
- **Seasons promoted to a top-level nav link** (out of the Settings popover) — it's the app's primary object.
- **Layout gutter** `px-4 md:px-6` (already landed in #197/#198) — verified in place.
- **Wide tables** scroll/stack via the `DataTable` from #193 (`overflow-x-auto` + `hideBelow` stacking).
- **Vertical tab rails** (`organizations/[id]`, `drafts/[id]`) collapse to a stacked full-width list below `md` (`flex-col md:flex-row`, `w-full md:w-56`).
- **Detail-page headers** (`drafts/[id]`, grades, results, `seasons/[id]`) now wrap instead of overflowing at 375px.
- **Tests:** `seasons.spec.ts` updated to assert the top-level Seasons link; new dedicated `ui/e2e/mobile-nav.spec.ts` at a 375px viewport covers sheet open/close/Escape/navigation, exactly one `<nav>` + one `Email` input on `/`, no horizontal scroll on the in-scope routes, and the stacked vertical-tab page. Kept small per the ticket — the full mobile project / visual baselines stay in #201.

## Verification

- `npm run check` — 0 errors / 0 warnings
- `npm run test` — 13 passed
- `make e2e` — 43 passed, run **twice** (nav change + parallel suite)
- Targeted `smoke`, `seasons`, `mobile-nav` specs green

Closes #200