### PR TITLE
UI: transfer-list component for Format -> Ratings (Closes #224)

### DIFF
--- a/ui/e2e/format-ratings.spec.ts
+++ b/ui/e2e/format-ratings.spec.ts
@@ -40,39 +40,55 @@ test('assign ratings to a format: add, list, remove', async ({ page }) => {
 	await page.getByRole('button', { name: 'Create format' }).click();
 	await expect(page).toHaveURL(/\/formats\/[0-9a-f]+$/);
 
-	// No ratings assigned yet.
-	await expect(page.getByText('No ratings assigned yet.')).toBeVisible();
+	// The Ratings tab hosts the transfer list.
+	await page.getByRole('tab', { name: 'Ratings' }).click();
 
-	const ratingNames = page.locator('.rating-name');
+	// Fresh format: no ratings assigned yet; both ratings are available in the
+	// source list. The target is empty, so saving is blocked.
+	await expect(page.getByText('0 ratings')).toBeVisible();
+	await expect(page.getByText('A format must keep at least one rating.')).toBeVisible();
+	await expect(page.getByRole('button', { name: 'Save ratings' })).toBeDisabled();
 
-	// Assign the first rating.
-	await page.getByLabel('Rating to assign').selectOption({ label: ratingName1 });
-	await page.getByRole('button', { name: 'Add rating' }).click();
-	await expect(ratingNames.getByText(ratingName1)).toBeVisible();
+	// Assign the first rating: select it in the source, move it, save.
+	await page.getByRole('button', { name: ratingName1, exact: true }).click();
+	await page.getByRole('button', { name: 'Move selected to pool' }).click();
+	await expect(page.getByText('1 rating')).toBeVisible();
+	await page.getByRole('button', { name: 'Save ratings' }).click();
+	await expect(page.getByText('1 rating')).toBeVisible();
 
 	// Assign the second rating.
-	await page.getByLabel('Rating to assign').selectOption({ label: ratingName2 });
-	await page.getByRole('button', { name: 'Add rating' }).click();
-	await expect(ratingNames.getByText(ratingName1)).toBeVisible();
-	await expect(ratingNames.getByText(ratingName2)).toBeVisible();
+	await page.getByRole('button', { name: ratingName2, exact: true }).click();
+	await page.getByRole('button', { name: 'Move selected to pool' }).click();
+	await page.getByRole('button', { name: 'Save ratings' }).click();
+	await expect(page.getByText('2 ratings')).toBeVisible();
 
-	// Remove the first rating; it disappears and becomes assignable again.
-	const firstItem = page.locator('li', { hasText: ratingName1 });
-	await firstItem.getByRole('button', { name: 'Remove' }).click();
-	await expect(ratingNames.getByText(ratingName1)).toHaveCount(0);
-	await expect(ratingNames.getByText(ratingName2)).toBeVisible();
-	await expect(page.getByLabel('Rating to assign')).toContainText(ratingName1);
+	// Remove the first rating: select it in the target, move it back out, save.
+	const firstItem = page.getByRole('button', { name: ratingName1, exact: true });
+	await firstItem.getByRole('checkbox').click();
+	await expect(firstItem.getByRole('checkbox')).toHaveAttribute('aria-checked', 'true');
+	await page.getByRole('button', { name: 'Move selected out of pool' }).click();
+	await expect(page.getByText('1 rating')).toBeVisible();
+	await page.getByRole('button', { name: 'Save ratings' }).click();
+	await expect(page.getByText('1 rating')).toBeVisible();
 
-	// A format must keep at least one rating, so with only rating2 remaining the
-	// Remove button is disabled.
-	const secondItem = page.locator('li', { hasText: ratingName2 });
-	await expect(secondItem.getByRole('button', { name: 'Remove' })).toBeDisabled();
+	// The removed rating is available again and the remaining one is assigned.
+	await expect(page.getByRole('button', { name: ratingName1, exact: true })).toBeVisible();
+	await expect(page.getByRole('button', { name: ratingName2, exact: true })).toBeVisible();
+
+	// A format must keep at least one rating: move the last one out and the
+	// save button becomes disabled again.
+	const secondItem = page.getByRole('button', { name: ratingName2, exact: true });
+	await secondItem.getByRole('checkbox').click();
+	await page.getByRole('button', { name: 'Move selected out of pool' }).click();
+	await expect(page.getByText('0 ratings')).toBeVisible();
 	await expect(page.getByText('A format must keep at least one rating.')).toBeVisible();
+	await expect(page.getByRole('button', { name: 'Save ratings' })).toBeDisabled();
 
 	// Clean up. Deleting a format now cascades to its format_rating / format_line
 	// join rows, so the ratings are no longer "in-use" and can be deleted to
 	// keep the shared dev db clean. Both deletes below confirm via an in-app
-	// popover (no window.confirm).
+	// popover (no window.confirm). The delete button lives on the Details tab.
+	await page.getByRole('tab', { name: 'Details' }).click();
 	await page.getByRole('button', { name: 'Delete format' }).click();
 	await page.getByRole('button', { name: 'Delete', exact: true }).click();
 	await expect(page).toHaveURL('/formats');

--- a/ui/src/routes/formats/[id]/+page.svelte
+++ b/ui/src/routes/formats/[id]/+page.svelte
@@ -16,15 +16,18 @@
 		AlertDialogTitle,
 		AlertDialogTrigger
 	} from '$lib/components/ui/alert-dialog/index.js';
-	import { Badge } from '$lib/components/ui/badge/index.js';
 	import { Button, buttonVariants } from '$lib/components/ui/button/index.js';
 	import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
 	import { Label } from '$lib/components/ui/label/index.js';
 	import {
-		NativeSelect,
-		NativeSelectOption
-	} from '$lib/components/ui/native-select/index.js';
+		Tabs,
+		TabsContent,
+		TabsList,
+		TabsTrigger
+	} from '$lib/components/ui/tabs/index.js';
+	import * as TransferList from '$lib/components/ui/transfer-list/index.js';
+	import { getCurrentUserId } from '$lib/auth';
 	import { toast } from '$lib/toast';
 	import {
 		getFormat,
@@ -46,40 +49,52 @@
 	let saving = $state(false);
 	let deleting = $state(false);
 	let deleteOpen = $state(false);
+	let isOwner = $state(false);
 
 	// Possible ratings assigned to this format.
 	let possibleRatings = $state<Rating[]>([]);
 	let allRatings = $state<Rating[]>([]);
-	let selectedRatingId = $state('');
 	let ratingsError = $state('');
 	let ratingsSaving = $state(false);
+
+	// Rating assignments (owner only). The transfer list core holds the
+	// in-memory source (unassigned ratings) / target (assigned ratings) lists
+	// and selection; we persist diffs on save.
+	let transferCore = $state<TransferList.Core<Rating> | null>(null);
+
+	// Which section is shown in the sidebar at a time.
+	let activeTab = $state('details');
 
 	onMount(() => format.run(load));
 
 	async function load(): Promise<Format> {
 		const f = await getFormat(id());
 		name = f.name;
-		await loadRatings();
-		return f;
-	}
+		isOwner = getCurrentUserId() === f.user_id;
 
-	async function loadRatings() {
 		try {
 			possibleRatings = await getFormatPossibleRatings(id());
 		} catch (e) {
 			ratingsError = e instanceof Error ? e.message : 'Failed to load possible ratings';
 		}
-		// Refresh the full catalog so the add dropdown reflects current assignments.
-		try {
-			allRatings = await listRatings();
-		} catch {
-			// ignore; the add dropdown just stays empty
-		}
-	}
 
-	const unassignedRatings = $derived(
-		allRatings.filter((r) => !possibleRatings.some((p) => p.id === r.id))
-	);
+		// The owner can assign any rating in the catalog; build the transfer
+		// list source from the ratings not already assigned.
+		if (isOwner) {
+			try {
+				allRatings = await listRatings();
+			} catch {
+				// member-edit controls stay usable; the source just lists members
+			}
+			const assignedIds = new Set(possibleRatings.map((r) => r.id));
+			transferCore = new TransferList.Core<Rating>({
+				initialSource: allRatings.filter((r) => !assignedIds.has(r.id)),
+				initialTarget: possibleRatings,
+				filterPredicate: (r, search) => r.name.toLowerCase().includes(search.toLowerCase())
+			});
+		}
+		return f;
+	}
 
 	async function handleSave(e: Event) {
 		e.preventDefault();
@@ -88,6 +103,7 @@
 		try {
 			const updated = await updateFormat(id(), { name: name.trim() });
 			format.data = updated;
+			name = updated.name;
 			toast.success('Format saved');
 		} catch (err) {
 			error = err instanceof Error ? err.message : 'Failed to update format';
@@ -111,29 +127,29 @@
 		}
 	}
 
-	async function saveRatings(ratingIds: string[]) {
+	// Persists the transfer-list state: the target order (highest-skill to
+	// lowest-skill) is sent as-is and becomes the FormatRating.RatingIndex
+	// ordering on the backend.
+	async function handleSaveRatings() {
 		ratingsError = '';
+		if (!transferCore) return;
+		const currentIds = possibleRatings.map((r) => r.id);
+		const targetIds = transferCore.target.map((r) => r.id);
+		if (targetIds.length === 0) {
+			ratingsError = 'A format must keep at least one rating.';
+			return;
+		}
+		if (currentIds.length === targetIds.length && currentIds.every((c, i) => c === targetIds[i])) {
+			return;
+		}
 		ratingsSaving = true;
 		try {
-			possibleRatings = await setFormatPossibleRatings(id(), ratingIds);
-			selectedRatingId = '';
+			possibleRatings = await setFormatPossibleRatings(id(), targetIds);
 		} catch (err) {
 			ratingsError = err instanceof Error ? err.message : 'Failed to update possible ratings';
 		} finally {
 			ratingsSaving = false;
 		}
-	}
-
-	function handleAddRating(e: Event) {
-		e.preventDefault();
-		if (!selectedRatingId) return;
-		const next = [...possibleRatings.map((r) => r.id), selectedRatingId];
-		saveRatings(next);
-	}
-
-	function handleRemoveRating(ratingId: string) {
-		const next = possibleRatings.filter((r) => r.id !== ratingId).map((r) => r.id);
-		saveRatings(next);
 	}
 </script>
 
@@ -150,113 +166,187 @@
 
 <AsyncSection state={format}>
 	{#snippet children(f)}
-		<Card class="mt-6 max-w-md">
-			<CardHeader>
-				<CardTitle>Format details</CardTitle>
-			</CardHeader>
-			<CardContent>
-				<form onsubmit={handleSave} class="flex flex-col gap-4">
-					<div class="flex flex-col gap-2">
-						<Label for="name">Name</Label>
-						<Input id="name" type="text" bind:value={name} required />
-					</div>
-					<Button type="submit" disabled={saving} class="w-fit">
-						{saving ? 'Saving...' : 'Save changes'}
-					</Button>
-				</form>
-			</CardContent>
-		</Card>
-
-		<section class="mt-8 max-w-md">
-			<h2 class="text-xl font-semibold tracking-tight">Possible ratings</h2>
-			<p class="mt-1 text-sm text-muted-foreground">
-				The skill ratings that players can be assigned to in this format, ordered
-				highest-skill to lowest-skill.
-			</p>
-
-			{#if possibleRatings.length === 0}
-				<p class="mt-4 text-muted-foreground">No ratings assigned yet.</p>
-			{:else}
-				<ul class="mt-4 flex flex-col gap-2">
-					{#each possibleRatings as rating}
-						<li class="flex items-center justify-between gap-2 rounded-lg border p-2 pl-3">
-							<Badge variant="secondary" class="rating-name">{rating.name}</Badge>
-							<Button
-								type="button"
-								variant="outline"
-								size="sm"
-								onclick={() => handleRemoveRating(rating.id)}
-								disabled={ratingsSaving || possibleRatings.length === 1}
-								title={possibleRatings.length === 1
-									? 'A format must keep at least one rating'
-									: undefined}
-							>
-								Remove
-							</Button>
-						</li>
-					{/each}
-				</ul>
-				{#if possibleRatings.length === 1}
-					<p class="mt-2 text-sm text-muted-foreground">A format must keep at least one rating.</p>
-				{/if}
-			{/if}
-
-			{#if unassignedRatings.length > 0}
-				<form onsubmit={handleAddRating} class="mt-4 flex items-center gap-2">
-					<NativeSelect
-						bind:value={selectedRatingId}
-						aria-label="Rating to assign"
-						class="flex-1"
-					>
-						<NativeSelectOption value="" disabled>Select a rating…</NativeSelectOption>
-						{#each unassignedRatings as rating}
-							<NativeSelectOption value={rating.id}>{rating.name}</NativeSelectOption>
-						{/each}
-					</NativeSelect>
-					<Button type="submit" disabled={ratingsSaving || !selectedRatingId}>
-						Add rating
-					</Button>
-				</form>
-			{:else if allRatings.length > 0}
-				<p class="mt-4 text-sm text-muted-foreground">All ratings are already assigned.</p>
-			{/if}
-
-			{#if ratingsError}
-				<Alert variant="destructive" class="mt-3">
-					<AlertDescription>{ratingsError}</AlertDescription>
-				</Alert>
-			{/if}
-		</section>
-
 		{#if error}
-			<Alert variant="destructive" class="mt-4 max-w-md">
+			<Alert variant="destructive" class="mt-4">
 				<AlertDescription>{error}</AlertDescription>
 			</Alert>
 		{/if}
 
-		<div class="mt-8">
-			<AlertDialog bind:open={deleteOpen}>
-				<AlertDialogTrigger
-					disabled={deleting}
-					class={buttonVariants({ variant: 'destructive' })}
+		<Tabs bind:value={activeTab} orientation="vertical" class="mt-6 flex flex-col gap-6 md:flex-row">
+			<TabsList class="h-fit w-full items-stretch md:w-56 md:shrink-0">
+				<TabsTrigger
+					value="details"
+					class="group justify-start gap-2.5 px-3 py-2 text-base"
 				>
-					{deleting ? 'Deleting...' : 'Delete format'}
-				</AlertDialogTrigger>
-				<AlertDialogContent>
-					<AlertDialogHeader>
-						<AlertDialogTitle>Delete format?</AlertDialogTitle>
-						<AlertDialogDescription>
-							This permanently removes this format and cannot be undone.
-						</AlertDialogDescription>
-					</AlertDialogHeader>
-					<AlertDialogFooter>
-						<AlertDialogCancel>Cancel</AlertDialogCancel>
-						<AlertDialogAction variant="destructive" onclick={handleDelete}>
-							Delete
-						</AlertDialogAction>
-					</AlertDialogFooter>
-				</AlertDialogContent>
-			</AlertDialog>
-		</div>
+					<span
+						class="size-1.5 shrink-0 rounded-full bg-primary opacity-0 transition-opacity group-data-[state=active]:opacity-100"
+						aria-hidden="true"
+					></span>
+					Details
+				</TabsTrigger>
+				<TabsTrigger
+					value="ratings"
+					class="group justify-start gap-2.5 px-3 py-2 text-base"
+				>
+					<span
+						class="size-1.5 shrink-0 rounded-full bg-primary opacity-0 transition-opacity group-data-[state=active]:opacity-100"
+						aria-hidden="true"
+					></span>
+					Ratings
+				</TabsTrigger>
+			</TabsList>
+
+			<TabsContent value="details" class="flex-1">
+				{#if isOwner}
+					<Card class="max-w-md">
+						<CardHeader>
+							<CardTitle>Format details</CardTitle>
+						</CardHeader>
+						<CardContent>
+							<form onsubmit={handleSave} class="flex flex-col gap-4">
+								<div class="flex flex-col gap-2">
+									<Label for="name">Name</Label>
+									<Input id="name" type="text" bind:value={name} required />
+								</div>
+								<Button type="submit" disabled={saving} class="w-fit">
+									{saving ? 'Saving...' : 'Save changes'}
+								</Button>
+							</form>
+						</CardContent>
+					</Card>
+
+					<div class="mt-4">
+						<AlertDialog bind:open={deleteOpen}>
+							<AlertDialogTrigger
+								disabled={deleting}
+								class={buttonVariants({ variant: 'destructive' })}
+							>
+								{deleting ? 'Deleting...' : 'Delete format'}
+							</AlertDialogTrigger>
+							<AlertDialogContent>
+								<AlertDialogHeader>
+									<AlertDialogTitle>Delete format?</AlertDialogTitle>
+									<AlertDialogDescription>
+										This permanently removes this format and cannot be undone.
+									</AlertDialogDescription>
+								</AlertDialogHeader>
+								<AlertDialogFooter>
+									<AlertDialogCancel>Cancel</AlertDialogCancel>
+									<AlertDialogAction variant="destructive" onclick={handleDelete}>
+										Delete
+									</AlertDialogAction>
+								</AlertDialogFooter>
+							</AlertDialogContent>
+						</AlertDialog>
+					</div>
+				{:else}
+					<Card class="max-w-md">
+						<CardHeader>
+							<CardTitle>Format</CardTitle>
+						</CardHeader>
+						<CardContent>
+							<p class="text-sm text-muted-foreground">
+								Only the owner can edit this format's details.
+							</p>
+						</CardContent>
+					</Card>
+				{/if}
+			</TabsContent>
+
+			<TabsContent value="ratings" class="flex-1">
+				{#if ratingsError}
+					<Alert variant="destructive">
+						<AlertDescription>{ratingsError}</AlertDescription>
+					</Alert>
+				{/if}
+
+				{#if isOwner}
+					{#if transferCore}
+						<Card class="max-w-2xl">
+							<CardHeader>
+								<CardTitle>Possible ratings</CardTitle>
+							</CardHeader>
+							<CardContent>
+								<p class="text-sm text-muted-foreground">
+									Move ratings into the roster to make them assignable in this format.
+									The order shown (highest-skill to lowest-skill) is preserved when you
+									save. Changes apply when you save.
+								</p>
+								<div class="mt-4">
+									<TransferList.Root direction="horizontal">
+										<TransferList.Container>
+											<TransferList.Title title="Available ratings" />
+											<TransferList.Toolbar
+												variant="source"
+												core={transferCore}
+												inputPlaceholder="Search ratings..."
+											/>
+											<TransferList.Body>
+												{#each transferCore.filteredSource as row (row.id)}
+													<TransferList.Item side="source" {row} core={transferCore}>
+														{row.name}
+													</TransferList.Item>
+												{/each}
+											</TransferList.Body>
+										</TransferList.Container>
+										<TransferList.Container>
+											<TransferList.Title title="Assigned ratings" />
+											<TransferList.Toolbar
+												variant="target"
+												core={transferCore}
+												inputPlaceholder="Search ratings..."
+											/>
+											<TransferList.Body>
+												{#each transferCore.filteredTarget as row (row.id)}
+													<TransferList.Item side="target" {row} core={transferCore}>
+														{row.name}
+													</TransferList.Item>
+												{/each}
+											</TransferList.Body>
+										</TransferList.Container>
+									</TransferList.Root>
+									<div class="mt-4 flex items-center gap-3">
+										<Button
+											type="button"
+											onclick={handleSaveRatings}
+											disabled={ratingsSaving || transferCore.target.length === 0}
+										>
+											{ratingsSaving ? 'Saving...' : 'Save ratings'}
+										</Button>
+										<span class="text-sm text-muted-foreground">
+											{transferCore.target.length} rating{transferCore.target.length === 1 ? '' : 's'}
+										</span>
+									</div>
+									{#if transferCore.target.length === 0}
+										<p class="mt-2 text-sm text-muted-foreground">
+											A format must keep at least one rating.
+										</p>
+									{/if}
+								</div>
+							</CardContent>
+						</Card>
+					{:else}
+						<p class="text-sm text-muted-foreground">Loading ratings...</p>
+					{/if}
+				{:else}
+					<Card class="max-w-md">
+						<CardHeader>
+							<CardTitle>Possible ratings</CardTitle>
+						</CardHeader>
+						<CardContent>
+							{#if possibleRatings.length === 0}
+								<p class="text-sm text-muted-foreground">No ratings assigned yet.</p>
+							{:else}
+								<ul class="flex flex-col gap-2">
+									{#each possibleRatings as rating}
+										<li class="text-sm">{rating.name}</li>
+									{/each}
+								</ul>
+							{/if}
+						</CardContent>
+					</Card>
+				{/if}
+			</TabsContent>
+		</Tabs>
 	{/snippet}
 </AsyncSection>


### PR DESCRIPTION
## What

Adopts the Organizations detail-page pattern for Formats: the `Formats/[id]` page is now a tabbed **Details / Ratings** view, and the ratings editor swaps the dropdown-style add for the shared **Transfer List** component.

- **Details tab**: edit the format name / delete the format (owner only; read-only card otherwise)
- **Ratings tab**: transfer list with "Available ratings" (source) and "Assigned ratings" (target), searchable, with a "Save ratings" button that persists diffs via `PUT /api/format/:id/possible_ratings`
- Target order (highest-skill to lowest-skill) is preserved on save, matching the existing `FormatRating.RatingIndex` semantics
- A format must keep at least one rating: the save button is disabled and a hint shown when the target is empty
- Updated `format-ratings` e2e spec to drive the transfer list (select -> move -> save), including the empty-target guard

## Verification

- `npm run check`: 0 errors, 0 warnings
- `make e2e`: 60/60 passing (full parallel suite incl. visual baselines)

Closes #224