### PR TITLE
UI: refactor season co-commissioners picker to TransferList (Closes #230)

### DIFF
--- a/ui/e2e/schedule.spec.ts
+++ b/ui/e2e/schedule.spec.ts
@@ -162,7 +162,7 @@ test('commissioner builds a season schedule and participants can view it', async
 	// Fill the matchup: Team 1 (home) vs Team 2 (away).
 	await page.getByLabel('Home').selectOption({ label: 'Team 1' });
 	await page.getByLabel('Away').selectOption({ label: 'Team 2' });
-	await page.getByRole('button', { name: 'Save' }).click();
+	await page.getByRole('button', { name: 'Save', exact: true }).click();
 
 	// The assigned matchup is visible on the season page.
 	await expect(page.getByText('Team 1 vs Team 2')).toBeVisible();

--- a/ui/e2e/scoring-structure-secondary.spec.ts
+++ b/ui/e2e/scoring-structure-secondary.spec.ts
@@ -1,6 +1,12 @@
 import { expect, test, type Page } from '@playwright/test';
 import { waitForHydration } from './helpers';
 
+// This spec drives a long UI flow (creating four structures, transfer-list
+// edits, saves, reloads, then deleting each structure) that routinely exceeds
+// Playwright's 30s default test timeout when the fullyParallel suite runs on a
+// loaded machine, so give it a longer budget.
+test.describe.configure({ timeout: 60_000 });
+
 // The Go backend runs with --dev-token from the repo root (see
 // playwright.config.ts), so POST /api/one_time_password returns the magic-link
 // token in the response body. Login with the user seeded by SeedDevData.

--- a/ui/e2e/season-commissioners.spec.ts
+++ b/ui/e2e/season-commissioners.spec.ts
@@ -152,33 +152,37 @@ test('sysadmin adds and removes co-commissioners on a season via the UI', async 
 	await waitForHydration(page);
 
 	// The sysadmin sees the Co-commissioners card, listing the existing
-	// commissioner (the sysadmin who created the season).
-	await expect(page.getByText('Co-commissioners', { exact: true })).toBeVisible();
-	await expect(page.getByRole('list').filter({ hasText: 'JD Arthur' })).toBeVisible();
+	// commissioner (the sysadmin who created the season) on the target side.
+	await expect(page.getByRole('heading', { name: 'Co-commissioners' })).toBeVisible();
+	await expect(page.getByRole('button', { name: 'JD Arthur' })).toBeVisible();
 
 	// The new co-commissioner is not yet a commissioner.
 	expect(await commissionerUserIds(page, seasonId)).not.toContain(coUserId);
 
-	// Add the co-commissioner through the UI.
-	await page.getByLabel('User').selectOption({ label: `${coName} SC` });
-	await page.getByRole('button', { name: 'Add co-commissioner' }).click();
-	await expect(page.getByRole('listitem').filter({ hasText: coName })).toBeVisible();
+	// Add the co-commissioner through the transfer list.
+	await page.getByRole('button', { name: `${coName} SC`, exact: true }).click();
+	await page.getByRole('button', { name: 'Move selected to pool' }).click();
+	await page.getByRole('button', { name: 'Save co-commissioners' }).click();
+	// The save button stays disabled until the join rows are persisted and the
+	// list is re-seeded with the new co-commissioner on the target side.
+	await expect(page.getByRole('button', { name: 'Save co-commissioners' })).toBeEnabled();
+	await expect(page.getByRole('button', { name: `${coName} SC`, exact: true })).toBeVisible();
 
 	// The API reflects the new co-commissioner.
 	expect(await commissionerUserIds(page, seasonId)).toContain(coUserId);
 
-	// The added user no longer appears in the add dropdown.
-	await expect(page.getByLabel('User')).not.toHaveValue(coUserId);
-
-	// Remove the co-commissioner through the UI (leaving the original one).
-	await page.getByRole('listitem').filter({ hasText: coName }).getByRole('button', { name: 'Remove' }).click();
-	await expect(page.getByRole('listitem').filter({ hasText: coName })).toHaveCount(0);
-	await expect(page.getByRole('list').filter({ hasText: 'JD Arthur' })).toBeVisible();
+	// Remove the co-commissioner through the transfer list (leaving the
+	// original one).
+	await page.getByRole('button', { name: `${coName} SC`, exact: true }).click();
+	await page.getByRole('button', { name: 'Move selected out of pool' }).click();
+	await page.getByRole('button', { name: 'Save co-commissioners' }).click();
+	await expect(page.getByRole('button', { name: 'Save co-commissioners' })).toBeEnabled();
+	// The original commissioner is still assigned on the target side.
+	await expect(page.getByRole('button', { name: 'JD Arthur' })).toBeVisible();
 	expect(await commissionerUserIds(page, seasonId)).not.toContain(coUserId);
 
-	// The user is selectable again after removal.
-	await page.getByLabel('User').selectOption({ label: `${coName} SC` });
-	await expect(page.getByRole('button', { name: 'Add co-commissioner' })).toBeEnabled();
+	// The user is selectable again after removal (back in the source pool).
+	await expect(page.getByRole('button', { name: `${coName} SC`, exact: true })).toBeVisible();
 
 	// Clean up the co-commissioner rows so the table doesn't accumulate across runs.
 	const rows = (await (await page.request.get(`${API}/season_commissioner`)).json())

--- a/ui/src/routes/seasons/[id]/+page.svelte
+++ b/ui/src/routes/seasons/[id]/+page.svelte
@@ -75,6 +75,7 @@
 	} from '$lib/components/ui/native-select/index.js';
 	import { Checkbox } from '$lib/components/ui/checkbox/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
+	import * as TransferList from '$lib/components/ui/transfer-list/index.js';
 	import Standings from '$lib/components/Standings.svelte';
 
 	const id = () => page.params.id as string;
@@ -123,9 +124,13 @@
 
 	// co-commissioners state (sysadmin-only writes)
 	let seasonCommissioners = $state<SeasonCommissioner[]>([]);
-	let commissionerUserId = $state('');
 	let commissionerError = $state('');
 	let savingCommissioner = $state(false);
+
+	// Co-commissioner assignment (sysadmin-only). The transfer-list core holds
+	// the in-memory source (eligible users) / target (current co-commissioners)
+	// lists and selection; we persist diffs on save.
+	let commissionerTransferCore = $state<TransferList.Core<User> | null>(null);
 
 	let loading = $state(true);
 	let loadError = $state('');
@@ -199,6 +204,7 @@
 			lateAdditions = lateAdditionList.filter((l) => l.season_id === seasonData.id);
 			seasonCommissioners = commissionerList.filter((c) => c.season_id === seasonData.id);
 			isSysAdmin = (await getRoles()).includes('System Administrator');
+			seedCommissionerTransfer();
 			selectedScoringStructure =
 				scoringStructureList.find((s) => s.name === 'Tennis standard set')?.id ??
 				scoringStructureList[0]?.id ??
@@ -668,11 +674,11 @@
 	// --- co-commissioners (sysadmin only) --------------------------------
 
 	// Users already serving as commissioners of this season (from the schedule
-	// detail), used to filter the add dropdown and to render the current list.
+	// detail), used to filter the transfer-list source pool.
 	const currentCommissionerIds = $derived(scheduleDetail?.commissioners ?? []);
 
 	// Co-commissioners are typically users who help administer the season
-	// rather than players in it, so the add dropdown excludes anyone already in
+	// rather than players in it, so the source pool excludes anyone already in
 	// the season (drafted roster / late addition) as well as current
 	// commissioners — mirroring the late-addition dropdown.
 	const commissionerOptions = $derived(
@@ -681,44 +687,50 @@
 			.sort((a, b) => fullName(a).localeCompare(fullName(b)))
 	);
 
-	const commissionerNames = $derived(
-		[...seasonCommissioners].sort((a, b) => userName(a.user_id).localeCompare(userName(b.user_id)))
-	);
-
-	// addSeasonCommissioner creates a SeasonCommissioner for the selected user
-	// and refreshes both the join rows and the schedule detail (so the new
-	// co-commissioner immediately counts as a commissioner of the season).
-	async function handleAddSeasonCommissioner() {
-		const seasonId = season?.id;
-		if (!seasonId || !commissionerUserId) return;
-		savingCommissioner = true;
-		commissionerError = '';
-		try {
-			await addSeasonCommissioner(seasonId, commissionerUserId);
-			commissionerUserId = '';
-			seasonCommissioners = (await listSeasonCommissioners()).filter((c) => c.season_id === seasonId);
-			scheduleDetail = await getScheduleForSeason(seasonId);
-		} catch (e) {
-			commissionerError = e instanceof Error ? e.message : 'Failed to add co-commissioner';
-		} finally {
-			savingCommissioner = false;
-		}
+	// seedCommissionerTransfer builds a fresh transfer-list core from the
+	// current users / join rows: source = eligible users (see
+	// commissionerOptions), target = the season's current co-commissioners.
+	function seedCommissionerTransfer() {
+		commissionerTransferCore = new TransferList.Core<User>({
+			initialSource: commissionerOptions,
+			initialTarget: seasonCommissioners
+				.map((sc) => users.find((u) => u.id === sc.user_id))
+				.filter((u): u is User => u !== undefined),
+			filterPredicate: (u, search) =>
+				fullName(u).toLowerCase().includes(search.toLowerCase())
+		});
 	}
 
-	// removeSeasonCommissioner deletes the SeasonCommissioner record and
-	// refreshes both the join rows and the schedule detail.
-	async function handleRemoveSeasonCommissioner(scId: string) {
+	// handleSaveCommissioners persists the transfer-list state: adds users that
+	// moved into the target, removes users that moved back to the source, then
+	// refreshes both the join rows and the schedule detail (so the new
+	// co-commissioners immediately count as commissioners of the season).
+	async function handleSaveCommissioners() {
 		const seasonId = season?.id;
-		savingCommissioner = true;
+		if (!seasonId || !commissionerTransferCore) return;
 		commissionerError = '';
+		const currentIds = new Set(seasonCommissioners.map((sc) => sc.user_id));
+		const targetIds = new Set(commissionerTransferCore.target.map((u) => u.id));
+		const toAdd = commissionerTransferCore.target
+			.filter((u) => !currentIds.has(u.id))
+			.map((u) => u.id);
+		const toRemove = seasonCommissioners.filter((sc) => !targetIds.has(sc.user_id));
+		if (toAdd.length === 0 && toRemove.length === 0) return;
+		savingCommissioner = true;
 		try {
-			await removeSeasonCommissioner(scId);
-			if (seasonId) {
-				seasonCommissioners = (await listSeasonCommissioners()).filter((c) => c.season_id === seasonId);
-				scheduleDetail = await getScheduleForSeason(seasonId);
+			for (const userId of toAdd) {
+				await addSeasonCommissioner(seasonId, userId);
 			}
+			for (const sc of toRemove) {
+				await removeSeasonCommissioner(sc.id);
+			}
+			seasonCommissioners = (await listSeasonCommissioners()).filter(
+				(c) => c.season_id === seasonId
+			);
+			scheduleDetail = await getScheduleForSeason(seasonId);
+			seedCommissionerTransfer();
 		} catch (e) {
-			commissionerError = e instanceof Error ? e.message : 'Failed to remove co-commissioner';
+			commissionerError = e instanceof Error ? e.message : 'Failed to save co-commissioners';
 		} finally {
 			savingCommissioner = false;
 		}
@@ -1365,63 +1377,60 @@
 			</CardHeader>
 			<CardContent>
 				<p class="mb-4 text-sm text-muted-foreground">
-					Additional users who can help administer this season.
+					Additional users who can help administer this season. Move users into
+					the list to make them co-commissioners. Changes apply when you save.
 				</p>
 
 				{#if commissionerError}
 					<p class="mb-4 text-sm font-medium text-destructive">{commissionerError}</p>
 				{/if}
 
-				<form
-					class="flex flex-wrap items-end gap-3"
-					onsubmit={(e) => {
-						e.preventDefault();
-						handleAddSeasonCommissioner();
-					}}
-				>
-					<div class="flex flex-col gap-1">
-						<Label for="co-commissioner-user" class="text-xs">User</Label>
-						<NativeSelect
-							id="co-commissioner-user"
-							value={commissionerUserId}
-							oninput={(e) =>
-								(commissionerUserId = (
-									e.currentTarget as HTMLSelectElement
-								).value)}
+				{#if commissionerTransferCore}
+					<TransferList.Root direction="horizontal">
+						<TransferList.Container>
+							<TransferList.Title title="Eligible users" />
+							<TransferList.Toolbar
+								variant="source"
+								core={commissionerTransferCore}
+								inputPlaceholder="Search users..."
+							/>
+							<TransferList.Body>
+								{#each commissionerTransferCore.filteredSource as row (row.id)}
+									<TransferList.Item side="source" {row} core={commissionerTransferCore}>
+										{fullName(row)}
+									</TransferList.Item>
+								{/each}
+							</TransferList.Body>
+						</TransferList.Container>
+						<TransferList.Container>
+							<TransferList.Title title="Co-commissioners" />
+							<TransferList.Toolbar
+								variant="target"
+								core={commissionerTransferCore}
+								inputPlaceholder="Search co-commissioners..."
+							/>
+							<TransferList.Body>
+								{#each commissionerTransferCore.filteredTarget as row (row.id)}
+									<TransferList.Item side="target" {row} core={commissionerTransferCore}>
+										{fullName(row)}
+									</TransferList.Item>
+								{/each}
+							</TransferList.Body>
+						</TransferList.Container>
+					</TransferList.Root>
+					<div class="mt-4 flex items-center gap-3">
+						<Button
+							type="button"
+							onclick={handleSaveCommissioners}
+							disabled={savingCommissioner}
 						>
-							<NativeSelectOption value="" disabled>Select a user…</NativeSelectOption>
-							{#each commissionerOptions as u (u.id)}
-								<NativeSelectOption value={u.id}>{fullName(u)}</NativeSelectOption>
-							{/each}
-						</NativeSelect>
+							{savingCommissioner ? 'Saving…' : 'Save co-commissioners'}
+						</Button>
+						<span class="text-sm text-muted-foreground">
+							{commissionerTransferCore.target.length} co-commissioner
+							{commissionerTransferCore.target.length === 1 ? '' : 's'}
+						</span>
 					</div>
-					<Button
-						type="submit"
-						disabled={savingCommissioner || !commissionerUserId}
-					>
-						{savingCommissioner ? 'Saving…' : 'Add co-commissioner'}
-					</Button>
-				</form>
-
-				{#if commissionerNames.length === 0}
-					<p class="mt-4 text-sm text-muted-foreground">No co-commissioners yet.</p>
-				{:else}
-					<ul class="mt-4 space-y-2 text-sm">
-						{#each commissionerNames as sc (sc.id)}
-							<li class="flex items-center justify-between gap-3">
-								<span class="font-medium">{userName(sc.user_id)}</span>
-								<Button
-									type="button"
-									variant="ghost"
-									size="sm"
-									disabled={savingCommissioner}
-									onclick={() => handleRemoveSeasonCommissioner(sc.id)}
-								>
-									Remove
-								</Button>
-							</li>
-						{/each}
-					</ul>
 				{/if}
 			</CardContent>
 		</Card>


### PR DESCRIPTION
## What
Refactors the sysadmin-only **Co-commissioners** section of the season detail page (`ui/src/routes/seasons/[id]/+page.svelte`) from a `NativeSelect` dropdown + "Add" button + Remove list to the shared `TransferList` component, following the established pattern in `formats/[id]`, `organizations/[id]`, and `drafts/[id]`.

- **Source** = users not already in the season and not current commissioners (mirrors the existing `commissionerOptions` filter).
- **Target** = assigned co-commissioners (from `season_commissioner` join rows).
- Changes persist on a **Save co-commissioners** button by diffing the target against the current join rows (adds + removes), then refreshing both the join rows and the schedule detail so new co-commissioners immediately count as commissioners of the season.
- The sysadmin-only gate is unchanged.

## Tests
- `npm run check` — 0 errors / 0 warnings.
- Updated `ui/e2e/season-commissioners.spec.ts` to drive the transfer list (select → move → save → verify via API → move back → save). My season-commissioners test passed in every full-suite run.
- `ui/e2e/schedule.spec.ts`: the weekly-matchup **Save** click now matches `{ name: 'Save', exact: true }` — the new "Save co-commissioners" button (visible to sysadmins) collided with the old substring match.
- Drive-by flake mitigation: `scoring-structure-secondary.spec.ts` now gets a 60s test timeout — its long UI flow (create 4 structures, transfer edits, saves, reloads, deletes) repeatedly exceeded Playwright's 30s default under the `fullyParallel` suite.

## Notes / pre-existing flakiness (not introduced here)
While verifying, the suite intermittently fails on long, write-heavy specs (`scoring-structure-secondary`, `matches`, `format-ratings`) that share the single SQLite DB with ~8 parallel workers — observed as `Test timeout of 30000ms exceeded` or assertion failures right after an API write whose effect never appeared (SQLite `busy_timeout`/`_txlock=immediate` contention). These pages/tests are untouched by this PR and the failures reproduce independently of it.

Also: running `make e2e` locally requires port 5173 to be free — a Vite dev server for another project on `[::1]:5173` blocks Playwright's UI webServer readiness check (`127.0.0.1:5173`). I verified the suite using a temporary alternate-port config (removed afterward).

Closes #230
